### PR TITLE
feat: add --tab support to edit command

### DIFF
--- a/gdoc/mdparse.py
+++ b/gdoc/mdparse.py
@@ -206,6 +206,7 @@ def parse_markdown(text: str) -> ParsedMarkdown:
                 i += 1
 
             # Record table with a placeholder newline
+            para_start = offset
             all_tables.append(TableData(
                 rows=table_rows,
                 num_rows=len(table_rows),
@@ -214,6 +215,12 @@ def parse_markdown(text: str) -> ParsedMarkdown:
             ))
             plain_parts.append("\n")
             offset += 1
+
+            all_styles.append(StyleRange(
+                start=para_start, end=offset,
+                style={"namedStyleType": "NORMAL_TEXT"},
+                type="paragraph_style",
+            ))
             continue
 
         # Heading


### PR DESCRIPTION
## Summary

- Adds a `--tab` flag to `gdoc edit` so it can find and replace text in any tab, not just the default tab
- Without this, `gdoc edit` silently fails to match text that lives in non-default tabs, making it impossible to modify multi-tab documents
- Fixes paragraph style inheritance: inserted text no longer inherits heading styles from the insertion point, and heading styles at the insertion point are preserved on the replacement text
- Table header rows are now bolded

## Changes

**`gdoc/cli.py`**
- Add `--tab` argument to the `edit` subcommand parser
- When `--tab` is provided, fetch the document with `includeTabsContent=True`, resolve the tab by title or ID, and search within that tab's body
- Pass `tab_id` through to `replace_formatted()`

**`gdoc/api/docs.py`**
- Add `resolve_tab()` helper that matches tabs by title (case-insensitive) or ID
- Add optional `body` parameter to `find_text_in_document()` and `_find_table_cell_indices()` so they can search within a specific tab's body rather than the default
- Add `tab_id` parameter to `_insert_table()` — injects `tabId` into all location objects for table creation and cell text insertion; bold header row cells after insertion
- Add `tab_id` parameter to `replace_formatted()` — injects `tabId` into delete range, passes through to `to_docs_requests()` and `_insert_table()`
- Add `_cleanup_heading_remnant()` — after replacement, detects empty heading paragraphs left over from deletion, transfers the heading style to the last paragraph of the inserted text, and deletes the empty paragraph

**`gdoc/mdparse.py`**
- Add `tab_id` parameter to `to_docs_requests()`; add `_location()` and `_range()` helpers that inject `tabId`
- Emit explicit per-paragraph NORMAL_TEXT styles during parsing (for normal text, bullet items, numbered items, and table placeholders) instead of a blanket range reset — prevents style bleed into adjacent paragraphs at range boundaries

## Usage

\`\`\`bash
# Edit text in a specific tab by title
gdoc edit DOC_ID --tab \"Call summaries\" --old-file old.md --new-file new.md

# Edit text in a specific tab by ID
gdoc edit DOC_ID --tab \"t.sw203e8c5nf8\" --old \"old text\" --new \"new text\"
\`\`\`

## Test plan

- [x] Tested with a multi-tab Google Doc — successfully finds and replaces text in a non-default tab
- [x] Verified all tabs are preserved after edit (no flattening)
- [x] Verified formatting: headings, bold, italic, bullet lists, numbered lists render correctly
- [x] Verified table insertion works in non-default tabs with bold header row
- [x] Verified heading style at insertion point is preserved on replacement text
- [x] Verified table placeholder paragraphs don't inherit heading styles
- [x] Verified editing without \`--tab\` still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab-scoped editing: target edits to a specific tab by title or ID.
  * New CLI option --tab to perform edits within a chosen tab.

* **Improvements**
  * Per-tab support for text replacement, table insertion, and formatted content with correct revision handling.
  * Tab-aware selection and read-back to determine insertion locations.
  * Improved cleanup of heading remnants and normalized paragraph styling to avoid inherited styles.
  * Full-document behavior preserved when no tab is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->