### PR TITLE
feat: include quoted text in comments output

### DIFF
--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -910,7 +910,7 @@ def cmd_comments(args) -> int:
     # Full fetch for display (separate from pre-flight, per CONTEXT.md Decision #8)
     from gdoc.api.comments import list_comments
     include_resolved = getattr(args, "all", False)
-    comments = list_comments(doc_id, include_resolved=include_resolved)
+    comments = list_comments(doc_id, include_resolved=include_resolved, include_anchor=True)
 
     from gdoc.format import get_output_mode, format_json
 
@@ -925,7 +925,8 @@ def cmd_comments(args) -> int:
             author = c.get("author", {})
             author_str = author.get("emailAddress") or author.get("displayName", "unknown")
             content = c.get("content", "")
-            print(f"{cid}\t{status}\t{author_str}\t{content}")
+            quoted = c.get("quotedFileContent", {}).get("value", "")
+            print(f"{cid}\t{status}\t{author_str}\t{content}\t{quoted}")
     elif not comments:
         print("No comments.")
     else:
@@ -943,6 +944,9 @@ def cmd_comments(args) -> int:
             print(f"#{cid} [{status}] {author_str} {date_str}")
             content = c.get("content", "")
             print(f'  "{content}"')
+            quoted = c.get("quotedFileContent", {}).get("value", "")
+            if quoted:
+                print(f'  on "{quoted}"')
             for r in c.get("replies", []):
                 reply_content = r.get("content", "")
                 if not reply_content:

--- a/tests/test_comments_cmd.py
+++ b/tests/test_comments_cmd.py
@@ -237,7 +237,7 @@ class TestCmdComments:
         mock_list.return_value = []
         args = _make_args("comments", quiet=True)
         cmd_comments(args)
-        mock_list.assert_called_once_with("abc123", include_resolved=False)
+        mock_list.assert_called_once_with("abc123", include_resolved=False, include_anchor=True)
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
@@ -249,7 +249,7 @@ class TestCmdComments:
         mock_list.return_value = []
         args = _make_args("comments", quiet=True, **{"all": True})
         cmd_comments(args)
-        mock_list.assert_called_once_with("abc123", include_resolved=True)
+        mock_list.assert_called_once_with("abc123", include_resolved=True, include_anchor=True)
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
@@ -600,7 +600,7 @@ class TestCommentCommandsPlainOutput:
         args = _make_args("comments", quiet=True, plain=True)
         cmd_comments(args)
         out = capsys.readouterr().out
-        assert "c1\topen\talice@co.com\tFix typo" in out
+        assert "c1\topen\talice@co.com\tFix typo\t" in out
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)


### PR DESCRIPTION
## Summary

- Pass `include_anchor=True` to `list_comments()` in `cmd_comments()`, so the `comments` subcommand now includes `quotedFileContent` — the highlighted text each comment references
- Terse/verbose formats show `on "..."` below each comment; plain/TSV adds it as a 5th column; JSON includes the full `quotedFileContent` object
- The API layer already supported this via the `include_anchor` parameter — this just wires it up in the CLI handler

## Context

The `comment-info` command (single comment) already returns `quotedFileContent`, but the bulk `comments` command did not, making it impossible to see what text a comment refers to without fetching each comment individually. This was reported in #2.

## Changes

- `gdoc/cli.py`: 3 small additions (pass `include_anchor=True`, render quoted text in terse/verbose and plain formats)
- `tests/test_comments_cmd.py`: 3 assertion updates to match the new `include_anchor=True` parameter

## Test plan

- [x] All 722 existing tests pass (`uv run pytest tests/ -v`)
- [x] Lint clean (`uv run ruff check gdoc/ tests/`)
- [x] Live-tested against a real Google Doc with 86 comments — 74/86 now show `quotedFileContent` (remaining 12 are whole-document comments with no anchor)
- [x] Verified all output formats: terse, verbose, JSON, plain

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments now display quoted content information, showing the specific text referenced by each comment in both standard and detailed output formats.

* **Tests**
  * Test expectations updated to verify enhanced comment output functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->