### PR TITLE
feat: add --no-images flag to gdoc cat

### DIFF
--- a/gdoc/mdimport.py
+++ b/gdoc/mdimport.py
@@ -103,3 +103,10 @@ def extract_images(
 
     cleaned = _IMAGE_RE.sub(_replace, content)
     return cleaned, images
+
+
+def strip_images(content: str) -> str:
+    """Remove image references and collapse excess blank lines."""
+    result = _IMAGE_RE.sub("", content)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result

--- a/tests/test_cat_tabs.py
+++ b/tests/test_cat_tabs.py
@@ -20,6 +20,7 @@ def _make_args(**overrides):
         "all": False,
         "tab": None,
         "all_tabs": False,
+        "no_images": False,
         "json": False,
         "verbose": False,
         "quiet": False,

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- Adds `--no-images` flag to `gdoc cat` that strips `![...](...)` image references from output
- Saves tokens in AI agent workflows where embedded image URLs are useless
- Stripping happens before `--max-bytes` truncation and before `--comments` annotation

## Test plan

> **Note:** These changes have not been manually tested—they were developed and verified entirely through Claude Code (automated unit/integration tests + lint).

- [x] `uv run pytest tests/test_mdimport.py tests/test_cat.py tests/test_cat_tabs.py -v` — 70 tests pass
- [x] `uv run ruff check gdoc/ tests/` — no new lint errors
- [ ] Manual smoke test: `gdoc cat --no-images <doc-with-images>`
- [ ] Verify `gdoc cat` without `--no-images` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-images` flag to the `gdoc cat` command, enabling users to remove image references from all output formats including single-tab views, multi-tab exports, markdown output, and general content display.

* **Tests**
  * Added comprehensive test coverage for the new flag, validating image removal, interaction with content truncation and comment functionality, and consistent behavior across all output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->