### PR TITLE
fix: edit command inserts extra newlines

### DIFF
--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -664,6 +664,16 @@ def replace_formatted(
 
     parsed = parse_markdown(new_markdown)
 
+    # Strip trailing \n — the existing paragraph in the document
+    # already has one.  Without this, every replacement inserts an
+    # extra paragraph break.
+    if parsed.plain_text.endswith("\n"):
+        old_len = len(parsed.plain_text)
+        parsed.plain_text = parsed.plain_text[:-1]
+        for s in parsed.styles:
+            if s.end == old_len:
+                s.end = old_len - 1
+
     # Sort matches by startIndex descending (last-to-first)
     sorted_matches = sorted(
         matches, key=lambda m: m["startIndex"], reverse=True,

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -341,11 +341,11 @@ class TestReplaceFormattedCleanupPositions:
             .get.return_value.execute.return_value = {"body": {"content": []}}
 
         matches = [{"startIndex": 10, "endIndex": 13}]  # 3-char match
-        replace_formatted("doc1", matches, "foobar", "rev1")  # 7-char plain_text
+        replace_formatted("doc1", matches, "foobar", "rev1")  # 6-char plain_text
 
         mock_cleanup.assert_called_once()
-        # cleanup pos = 10 + 7 = 17 (parse_markdown adds trailing \n)
-        assert mock_cleanup.call_args[0][1] == 17
+        # cleanup pos = 10 + 6 = 16 (trailing \n stripped in replace context)
+        assert mock_cleanup.call_args[0][1] == 16
 
     @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])
     @patch("gdoc.api.docs.get_docs_service")
@@ -360,7 +360,7 @@ class TestReplaceFormattedCleanupPositions:
             .get.return_value.execute.return_value = {"body": {"content": []}}
 
         # 3 matches of 3-char text, replaced with "foobar" (plain_text
-        # is "foobar\n" = 7 chars, delta = 7 - 3 = 4)
+        # is "foobar" = 6 chars after trailing \n strip, delta = 6 - 3 = 3)
         matches = [
             {"startIndex": 10, "endIndex": 13},
             {"startIndex": 50, "endIndex": 53},
@@ -369,11 +369,11 @@ class TestReplaceFormattedCleanupPositions:
         replace_formatted("doc1", matches, "foobar", "rev1")
 
         positions = [c[0][1] for c in mock_cleanup.call_args_list]
-        # sorted_matches descending: [100, 50, 10]; delta=4
-        # j=0 (100): 100 + 7 + (3-1-0)*4 = 100 + 7 + 8 = 115
-        # j=1 (50):  50  + 7 + (3-1-1)*4 = 50  + 7 + 4 = 61
-        # j=2 (10):  10  + 7 + (3-1-2)*4 = 10  + 7 + 0 = 17
-        assert positions == [115, 61, 17]
+        # sorted_matches descending: [100, 50, 10]; delta=3
+        # j=0 (100): 100 + 6 + (3-1-0)*3 = 100 + 6 + 6 = 112
+        # j=1 (50):  50  + 6 + (3-1-1)*3 = 50  + 6 + 3 = 59
+        # j=2 (10):  10  + 6 + (3-1-2)*3 = 10  + 6 + 0 = 16
+        assert positions == [112, 59, 16]
 
     @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])
     @patch("gdoc.api.docs.get_docs_service")
@@ -386,7 +386,7 @@ class TestReplaceFormattedCleanupPositions:
         mock_svc.return_value.documents.return_value \
             .get.return_value.execute.return_value = {"body": {"content": []}}
 
-        # 3-char match, "bar" -> plain_text "bar\n" (4 chars), delta=1
+        # 3-char match, "bar" -> plain_text "bar" (3 chars), delta=0
         matches = [
             {"startIndex": 10, "endIndex": 13},
             {"startIndex": 50, "endIndex": 53},
@@ -394,9 +394,9 @@ class TestReplaceFormattedCleanupPositions:
         replace_formatted("doc1", matches, "bar", "rev1")
 
         positions = [c[0][1] for c in mock_cleanup.call_args_list]
-        # j=0 (50): 50 + 4 + (2-1-0)*1 = 55
-        # j=1 (10): 10 + 4 + (2-1-1)*1 = 14
-        assert positions == [55, 14]
+        # j=0 (50): 50 + 3 + (2-1-0)*0 = 53
+        # j=1 (10): 10 + 3 + (2-1-1)*0 = 13
+        assert positions == [53, 13]
 
 
 class TestFindTextBody:


### PR DESCRIPTION
## Summary

- `parse_markdown()` appends `\n` after every line, including the last. When `replace_formatted()` deletes matched text and inserts the parsed replacement, the existing paragraph in the document already has its own `\n`. The extra trailing `\n` from the parser creates a spurious blank line after every `gdoc edit`.
- Fix: strip the trailing `\n` from `parsed.plain_text` inside `replace_formatted()` before building the batchUpdate requests. The parser itself is left unchanged since its behavior is correct in general; only the replacement context doesn't need the trailing newline.
- Updated 3 cleanup-position tests to reflect the corrected character counts.

## Test plan

- [x] All 776 existing tests pass
- [x] Verified end-to-end on a real Google Doc with 12 edit scenarios:
  - Simple word swap, shorter/longer replacements, start/end of paragraph
  - Bold, italic, bold+italic, inline code, link formatting
  - `--all` flag with 4 simultaneous replacements
  - Line count stayed constant (3 lines) across all 12 edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of trailing newlines in markdown content to prevent introducing unwanted extra paragraph breaks during text replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->