### PR TITLE
Add supportsAllDrives=True to Drive API calls

### DIFF
--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -70,6 +70,8 @@ def list_files(query: str) -> list[dict]:
                     fields="nextPageToken, files(id, name, mimeType, modifiedTime)",
                     pageSize=100,
                     pageToken=page_token,
+                    supportsAllDrives=True,
+                    includeItemsFromAllDrives=True,
                 )
                 .execute()
             )
@@ -115,6 +117,7 @@ def get_file_info(doc_id: str) -> dict:
                 fields="id, name, mimeType, modifiedTime, createdTime, "
                 "owners(emailAddress, displayName), "
                 "lastModifyingUser(emailAddress, displayName), size, version",
+                supportsAllDrives=True,
             )
             .execute()
         )
@@ -160,6 +163,7 @@ def update_doc_content(doc_id: str, content: str) -> int:
                 },
                 media_body=media,
                 fields="version",
+                supportsAllDrives=True,
             )
             .execute()
         )
@@ -180,6 +184,7 @@ def get_file_version(doc_id: str) -> dict:
             .get(
                 fileId=doc_id,
                 fields="modifiedTime, version, lastModifyingUser(displayName, emailAddress)",
+                supportsAllDrives=True,
             )
             .execute()
         )
@@ -283,7 +288,7 @@ def delete_file(file_id: str) -> None:
     """Delete a file from Drive."""
     try:
         service = get_drive_service()
-        service.files().delete(fileId=file_id).execute()
+        service.files().delete(fileId=file_id, supportsAllDrives=True).execute()
     except HttpError as e:
         _translate_http_error(e, file_id)
 
@@ -339,6 +344,7 @@ def copy_doc(doc_id: str, title: str) -> dict:
                 fileId=doc_id,
                 body={"name": title},
                 fields="id, name, version, webViewLink",
+                supportsAllDrives=True,
             )
             .execute()
         )
@@ -372,6 +378,7 @@ def create_permission(doc_id: str, email: str, role: str) -> dict:
                     "emailAddress": email,
                 },
                 sendNotificationEmail=True,
+                supportsAllDrives=True,
             )
             .execute()
         )


### PR DESCRIPTION
## Summary

- `files().get()` returns HTTP 404 for documents in shared drives (Google Workspace) or documents shared via link that aren't in the user's "My Drive". Adding `supportsAllDrives=True` fixes this.
- Also adds `includeItemsFromAllDrives=True` to `list_files()` so `gdoc ls` and `gdoc find` can discover shared drive documents.
- Applied consistently to all Drive API calls: `get`, `list`, `update`, `copy`, `delete`, and `permissions.create`.

## Reproduction

1. Have someone share a Google Doc with you (commenter or viewer access) where the doc lives in a shared drive or organisation workspace
2. Run `gdoc pull <doc-id> out.md`
3. Get `ERR: Document not found: <doc-id>` despite being able to open the doc in your browser

## Fix

The Google Drive API v3 requires `supportsAllDrives=True` on most endpoints to access files in shared drives. Without it, the API returns 404 instead of the file metadata.

Note: `files().export_media()` and the Comments API work without this parameter—only `files().get()` and similar endpoints need it.

## Test plan

- Verified fix against a real shared drive document (was 404, now works)
- `gdoc pull`, `gdoc info`, `gdoc comments` all work on shared drive docs
- Existing behaviour for personal Drive docs is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cross-drive operations, enabling file management, permissions, versioning, and other operations across all Google Drives including shared and team drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->