### PR TITLE
Include modifiedByMeTime in list_files response

### DIFF
--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -67,7 +67,7 @@ def list_files(query: str) -> list[dict]:
                 service.files()
                 .list(
                     q=query,
-                    fields="nextPageToken, files(id, name, mimeType, modifiedTime)",
+                    fields="nextPageToken, files(id, name, mimeType, modifiedTime, modifiedByMeTime)",
                     pageSize=100,
                     pageToken=page_token,
                 )


### PR DESCRIPTION
## Summary

- Adds `modifiedByMeTime` to the fields requested by `list_files()` in `gdoc/api/drive.py`

## Motivation

The Drive API's `modifiedByMeTime` field lets callers distinguish documents the authenticated user personally edited from documents modified by collaborators. Without this field, `list_files()` results filtered by `modifiedTime` include all documents modified by anyone with access.

`modifiedByMeTime` is not queryable in Drive API search (server returns 400), so it must be filtered client-side after retrieval. This one-line change makes that possible by including the field in the API response.

## Example usage

```python
from gdoc.api.drive import list_files

files = list_files("modifiedTime > '2026-03-14T00:00:00' and mimeType='application/vnd.google-apps.document'")
my_edits = [f for f in files if (f.get("modifiedByMeTime") or "").startswith("2026-03-14")]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File listings now include modification timestamps, showing when files were last updated by you. This provides improved visibility into your recent work and helps you track file changes more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->