### PR TITLE
Fix version metadata drift

### DIFF
--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.2"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 """Tests for gdoc.cli: argument parsing, exit codes, and error formatting."""
 
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+from gdoc import __version__
 
 REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 
@@ -101,6 +104,17 @@ class TestHelpText:
         result = run_gdoc("auth", "--help")
         assert result.returncode == 0
         assert "--no-browser" in result.stdout
+
+    def test_version_matches_project_version(self):
+        result = run_gdoc("--version")
+        assert result.returncode == 0
+
+        pyproject = Path(REPO_ROOT, "pyproject.toml").read_text()
+        match = re.search(r'^version = "([^"]+)"$', pyproject, re.MULTILINE)
+
+        assert match is not None
+        assert __version__ == match.group(1)
+        assert result.stdout.strip() == f"gdoc {match.group(1)}"
 
 
 class TestPlainFlag:

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
- update `gdoc.__version__` to match the packaged project version
- add a CLI regression test that checks `gdoc --version` against `pyproject.toml`
- refresh `uv.lock` so the editable package version is consistent too

## Verification
- `uv run --extra dev pytest tests/test_cli.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.2.

* **Tests**
  * Added test coverage for version command validation, ensuring the CLI version output correctly reflects the package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->