### PR TITLE
feat: add multi-account support via --account flag

### DIFF
--- a/gdoc/auth.py
+++ b/gdoc/auth.py
@@ -3,13 +3,14 @@
 import json
 import os
 import sys
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 
-from gdoc.util import AuthError, CONFIG_DIR, CREDS_PATH, TOKEN_PATH
+from gdoc.util import AuthError, CONFIG_DIR, CREDS_PATH, TOKEN_PATH, get_token_path
 
 SCOPES = [
     "https://www.googleapis.com/auth/drive",
@@ -19,7 +20,13 @@ SCOPES = [
 
 def get_credentials() -> Credentials:
     """Load or refresh credentials. Returns valid Credentials or raises AuthError."""
-    creds = _load_token()
+    from gdoc.util import get_active_account
+    account = get_active_account()
+    if not account:
+        print("account: default (use --account to switch)", file=sys.stderr)
+
+    token_path = get_token_path()
+    creds = _load_token(token_path)
 
     if creds and creds.valid:
         return creds
@@ -27,12 +34,15 @@ def get_credentials() -> Credentials:
     if creds and creds.expired and creds.refresh_token:
         try:
             creds.refresh(Request())
-            _save_token(creds)
+            _save_token(creds, token_path)
             return creds
         except Exception:
             pass
 
-    raise AuthError("Not authenticated. Run `gdoc auth` to authenticate.")
+    from gdoc.util import get_active_account
+    account = get_active_account()
+    hint = f" (account: {account})" if account else ""
+    raise AuthError(f"Not authenticated{hint}. Run `gdoc auth{' --account ' + account if account else ''}` to authenticate.")
 
 
 def authenticate(no_browser: bool = False) -> Credentials:
@@ -66,35 +76,80 @@ def authenticate(no_browser: bool = False) -> Credentials:
     else:
         creds = flow.run_local_server(port=0)
 
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    _save_token(creds)
+    token_path = get_token_path()
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    _save_token(creds, token_path)
     print(
-        f"OK authenticated successfully. Credentials stored in {TOKEN_PATH}",
+        f"OK authenticated successfully. Credentials stored in {token_path}",
         file=sys.stderr,
     )
     return creds
 
 
-def _load_token() -> Credentials | None:
+def _load_token(token_path: Path | None = None) -> Credentials | None:
     """Load token.json with defensive error handling."""
-    if not TOKEN_PATH.exists():
+    if token_path is None:
+        token_path = get_token_path()
+    if not token_path.exists():
         return None
 
     try:
-        return Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+        return Credentials.from_authorized_user_file(str(token_path), SCOPES)
     except (json.JSONDecodeError, ValueError, KeyError):
         print(
             "ERR: stored credentials are corrupt. "
             "Run `gdoc auth` to re-authenticate.",
             file=sys.stderr,
         )
-        TOKEN_PATH.unlink(missing_ok=True)
+        token_path.unlink(missing_ok=True)
         return None
 
 
-def _save_token(creds: Credentials) -> None:
+def _save_token(creds: Credentials, token_path: Path | None = None) -> None:
     """Save credentials to token.json with restricted permissions."""
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    fd = os.open(TOKEN_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    if token_path is None:
+        token_path = get_token_path()
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
         f.write(creds.to_json())
+
+
+def list_accounts() -> list[str]:
+    """List all authenticated accounts.
+
+    Returns account names, with 'default' for the base token.
+    """
+    accounts = []
+    if TOKEN_PATH.exists():
+        accounts.append("default")
+    accounts_dir = CONFIG_DIR / "accounts"
+    if accounts_dir.is_dir():
+        for entry in sorted(accounts_dir.iterdir()):
+            if entry.is_dir() and (entry / "token.json").exists():
+                accounts.append(entry.name)
+    return accounts
+
+
+def remove_account(account: str) -> None:
+    """Remove credentials for a named account."""
+    from gdoc.util import _validate_account_name
+
+    if account == "default":
+        if not TOKEN_PATH.exists():
+            raise AuthError("No default account credentials found.")
+        TOKEN_PATH.unlink()
+        print("OK removed default account credentials.", file=sys.stderr)
+        return
+
+    _validate_account_name(account)
+    account_dir = CONFIG_DIR / "accounts" / account
+    token = account_dir / "token.json"
+    if not token.exists():
+        raise AuthError(f"No credentials found for account: {account}")
+    token.unlink()
+    try:
+        account_dir.rmdir()  # only succeeds if empty
+    except OSError:
+        pass
+    print(f"OK removed credentials for account: {account}", file=sys.stderr)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1284,8 +1284,28 @@ def cmd_images(args) -> int:
 
 def cmd_auth(args) -> int:
     """Handler for `gdoc auth`."""
-    from gdoc.auth import authenticate
+    if getattr(args, "list", False):
+        from gdoc.auth import list_accounts
+        accounts = list_accounts()
+        if not accounts:
+            print("No accounts found. Run `gdoc auth` to authenticate.", file=sys.stderr)
+            return 0
+        for acct in accounts:
+            print(acct)
+        return 0
 
+    remove = getattr(args, "remove", None)
+    if remove:
+        from gdoc.util import confirm_destructive
+        confirm_destructive(
+            f"remove credentials for account {remove!r}",
+            force=getattr(args, "force", False),
+        )
+        from gdoc.auth import remove_account
+        remove_account(remove)
+        return 0
+
+    from gdoc.auth import authenticate
     authenticate(no_browser=getattr(args, "no_browser", False))
     return 0
 
@@ -1581,6 +1601,11 @@ def build_parser() -> GdocArgumentParser:
         "--plain", action="store_true", default=argparse.SUPPRESS,
         help="Stable TSV output",
     )
+    output_parent.add_argument(
+        "--account",
+        default=os.environ.get("GDOC_ACCOUNT"),
+        help="Google account name for multi-account support (e.g. work, personal, or an email)",
+    )
 
     # Also add to the top-level parser for `gdoc --json <cmd>` form
     top_output_group = parser.add_mutually_exclusive_group()
@@ -1610,6 +1635,21 @@ def build_parser() -> GdocArgumentParser:
         "--no-browser",
         action="store_true",
         help="Don't open browser, print URL for manual auth",
+    )
+    auth_p.add_argument(
+        "--list",
+        action="store_true",
+        help="List all authenticated accounts",
+    )
+    auth_p.add_argument(
+        "--remove",
+        metavar="ACCOUNT",
+        help="Remove credentials for a named account",
+    )
+    auth_p.add_argument(
+        "--force", "-y",
+        action="store_true",
+        help="Skip confirmation for --remove",
     )
     auth_p.set_defaults(func=cmd_auth)
 
@@ -1904,12 +1944,18 @@ def main() -> int:
             print(f"ERR: command not allowed: {args.command}", file=sys.stderr)
             return 3
 
-    # Check for updates (skip for the update command itself and internal hooks)
-    if args.command not in ("update", "_sync-hook", "_pull-hook"):
-        from gdoc.update import check_for_update
-        check_for_update()
-
     try:
+        # Multi-account support
+        account = getattr(args, "account", None)
+        if account:
+            from gdoc.util import set_active_account
+            set_active_account(account)
+
+        # Check for updates (skip for the update command itself and internal hooks)
+        if args.command not in ("update", "_sync-hook", "_pull-hook"):
+            from gdoc.update import check_for_update
+            check_for_update()
+
         return args.func(args)
     except AuthError as e:
         print(f"ERR: {e}", file=sys.stderr)

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -31,6 +31,44 @@ TOKEN_PATH = CONFIG_DIR / "token.json"
 CREDS_PATH = CONFIG_DIR / "credentials.json"
 STATE_DIR = CONFIG_DIR / "state"
 
+# Multi-account support: when set, token is stored under a per-account dir
+_active_account: str | None = None
+_VALID_ACCOUNT = re.compile(r'^[\w.\-@]+$')
+
+
+def _validate_account_name(account: str) -> None:
+    """Validate account name to prevent path traversal."""
+    if not _VALID_ACCOUNT.match(account):
+        raise GdocError(
+            f"Invalid account name: {account!r}. "
+            "Use alphanumeric characters, dots, hyphens, underscores, or @.",
+            exit_code=3,
+        )
+
+
+def set_active_account(account: str | None) -> None:
+    """Set the active account for token resolution."""
+    global _active_account
+    if account:
+        _validate_account_name(account)
+    _active_account = account
+
+
+def get_active_account() -> str | None:
+    """Return the active account, if set."""
+    return _active_account
+
+
+def get_token_path() -> Path:
+    """Return the token path for the active account.
+
+    Default account uses CONFIG_DIR/token.json (backward-compatible).
+    Named accounts use CONFIG_DIR/accounts/<account>/token.json.
+    """
+    if _active_account:
+        return CONFIG_DIR / "accounts" / _active_account / "token.json"
+    return TOKEN_PATH
+
 _PATTERNS = [
     re.compile(r"/d/([a-zA-Z0-9_-]+)"),
     re.compile(r"[?&]id=([a-zA-Z0-9_-]+)"),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -125,7 +125,8 @@ class TestGetCredentials:
 
         assert result is mock_creds
         mock_creds.refresh.assert_called_once()
-        mock_save.assert_called_once_with(mock_creds)
+        mock_save.assert_called_once()
+        assert mock_save.call_args[0][0] is mock_creds
 
     def test_raises_when_not_authenticated(self):
         with patch("gdoc.auth._load_token", return_value=None):
@@ -150,15 +151,13 @@ class TestGetCredentials:
 class TestLoadToken:
     def test_missing_file(self, tmp_path):
         fake_token = tmp_path / "token.json"
-        with patch("gdoc.auth.TOKEN_PATH", fake_token):
-            assert _load_token() is None
+        assert _load_token(fake_token) is None
 
     def test_corrupt_json(self, tmp_path):
         fake_token = tmp_path / "token.json"
         fake_token.write_text("not valid json{{{")
 
-        with patch("gdoc.auth.TOKEN_PATH", fake_token):
-            result = _load_token()
+        result = _load_token(fake_token)
 
         assert result is None
         assert not fake_token.exists()
@@ -167,14 +166,11 @@ class TestLoadToken:
         fake_token = tmp_path / "token.json"
         fake_token.write_text('{"client_id": "x"}')
 
-        with (
-            patch("gdoc.auth.TOKEN_PATH", fake_token),
-            patch(
-                "gdoc.auth.Credentials.from_authorized_user_file",
-                side_effect=ValueError("missing fields"),
-            ),
+        with patch(
+            "gdoc.auth.Credentials.from_authorized_user_file",
+            side_effect=ValueError("missing fields"),
         ):
-            result = _load_token()
+            result = _load_token(fake_token)
 
         assert result is None
 
@@ -185,11 +181,7 @@ class TestSaveToken:
         mock_creds = MagicMock()
         mock_creds.to_json.return_value = '{"token": "test"}'
 
-        with (
-            patch("gdoc.auth.TOKEN_PATH", fake_token),
-            patch("gdoc.auth.CONFIG_DIR", tmp_path),
-        ):
-            _save_token(mock_creds)
+        _save_token(mock_creds, fake_token)
 
         assert fake_token.exists()
         assert oct(os.stat(fake_token).st_mode & 0o777) == "0o600"
@@ -209,12 +201,8 @@ class TestSaveToken:
             assert oct(stat.st_mode & 0o777) == "0o600"
             return fd
 
-        with (
-            patch("gdoc.auth.TOKEN_PATH", fake_token),
-            patch("gdoc.auth.CONFIG_DIR", tmp_path),
-            patch("gdoc.auth.os.open", side_effect=spy_open),
-        ):
-            _save_token(mock_creds)
+        with patch("gdoc.auth.os.open", side_effect=spy_open):
+            _save_token(mock_creds, fake_token)
 
 
 class TestCmdAuthIntegration:


### PR DESCRIPTION
## Summary

- Adds `--account <name>` flag to all subcommands for switching between Google accounts
- Each account stores its token separately at `~/.config/gdoc/accounts/<name>/token.json`, keeping the default account untouched
- Supports `GDOC_ACCOUNT` env var as an alternative to the flag
- When no `--account` is specified, prints a stderr reminder that the default account is in use
- `gdoc auth --list` to show all authenticated accounts
- `gdoc auth --remove <account>` to remove credentials (with confirmation prompt)
- Account names validated against a strict pattern to prevent path traversal

## Usage

```bash
# Authenticate a second account
gdoc auth --account work

# Use it for any command
gdoc info --account work <doc-id>
gdoc pull --account work <doc-id> output.md

# Or set via env var
export GDOC_ACCOUNT=work
gdoc info <doc-id>

# List all authenticated accounts
gdoc auth --list

# Remove an account (prompts for confirmation)
gdoc auth --remove work
gdoc auth --remove work --force  # skip confirmation
```

## Implementation

Three source files changed, plus test updates:

1. **`util.py`** — adds `_validate_account_name()` (regex guard against path traversal), `set_active_account()`, `get_active_account()`, `get_token_path()` for per-account token resolution
2. **`auth.py`** — threads the active account through credential loading/saving, adds `list_accounts()` and `remove_account()` (deletes only the token file, rmdir if empty), with account-aware error messages
3. **`cli.py`** — adds `--account` to the `output_parent` parser (inherited by all subcommands), adds `--list`, `--remove`, and `--force` to auth subcommand, sets active account before dispatch inside the try/except block
4. **`tests/test_auth.py`** — updates `_load_token` and `_save_token` tests to pass `token_path` explicitly (matching new signatures), fixes `_save_token` assertion in refresh test

## Test plan

- [x] Default account (no `--account`) works as before
- [x] `gdoc auth --account <name>` authenticates and stores token at `~/.config/gdoc/accounts/<name>/token.json`
- [x] `gdoc info --account <name> <doc-id>` reads using the named account
- [x] `gdoc pull --account <name> <doc-id> <file>` downloads using the named account
- [x] Unauthenticated account gives clear error with hint to run `gdoc auth --account <name>`
- [x] `GDOC_ACCOUNT` env var works as alternative to the flag
- [x] `gdoc auth --list` shows default + named accounts
- [x] `gdoc auth --remove <nonexistent>` gives clear error
- [x] Path traversal attempts (`--account ../../etc`) are rejected with clean error message
- [x] Existing tests updated to match new function signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-account support: manage and switch between multiple authenticated accounts
  * List all authenticated accounts with `gdoc auth --list`
  * Remove accounts with `gdoc auth --remove <account>` (with `--force`/`-y` to confirm)
  * Set active account using `--account` flag or `GDOC_ACCOUNT` environment variable
  * Token storage is now per-account with full backward compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->