### PR TITLE
Fix version metadata drift

### DIFF
--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.6.2"
+version = "0.6.3"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 """Tests for gdoc.cli: argument parsing, exit codes, and error formatting."""
 
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+from gdoc import __version__
 
 REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 
@@ -101,6 +104,17 @@ class TestHelpText:
         result = run_gdoc("auth", "--help")
         assert result.returncode == 0
         assert "--no-browser" in result.stdout
+
+    def test_version_matches_project_version(self):
+        result = run_gdoc("--version")
+        assert result.returncode == 0
+
+        pyproject = Path(REPO_ROOT, "pyproject.toml").read_text()
+        match = re.search(r'^version = "([^"]+)"$', pyproject, re.MULTILINE)
+
+        assert match is not None
+        assert __version__ == match.group(1)
+        assert result.stdout.strip() == f"gdoc {match.group(1)}"
 
 
 class TestPlainFlag:

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
- Fix `__init__.py` version that was stuck at 0.5.0 while pyproject.toml was at 0.6.2
- Add test to prevent future version drift between `__init__.py`, `pyproject.toml`, and CLI output
- Bump version to 0.6.3

## Test plan
- [x] `test_version_matches_project_version` passes — verifies all three sources agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.6.3

* **Tests**
  * Added new version verification test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->