### PR TITLE
feat: add `gdoc toc` command for deep-linked table of contents

### DIFF
--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -520,6 +520,49 @@ def download_image(content_uri: str, dest_path: str) -> None:
         f.write(data)
 
 
+_HEADING_LEVELS = {
+    "HEADING_1": 1, "HEADING_2": 2, "HEADING_3": 3,
+    "HEADING_4": 4, "HEADING_5": 5, "HEADING_6": 6,
+}
+
+
+def get_document_headings(doc_id: str, body: dict | None = None) -> list[dict]:
+    """Extract headings with deep-link IDs from a document body.
+
+    If *body* is provided (e.g. from a specific tab), it is used
+    directly; otherwise the document is fetched via documents().get().
+
+    Returns a list of dicts:
+        {"level": int, "heading_id": str, "text": str}
+    """
+    if body is None:
+        doc = get_document(doc_id)
+        body = doc.get("body", {})
+
+    headings: list[dict] = []
+    for element in body.get("content", []):
+        paragraph = element.get("paragraph")
+        if paragraph is None:
+            continue
+        style = paragraph.get("paragraphStyle", {})
+        named_style = style.get("namedStyleType", "")
+        heading_id = style.get("headingId")
+        if named_style not in _HEADING_LEVELS or not heading_id:
+            continue
+        text = "".join(
+            run.get("textRun", {}).get("content", "")
+            for run in paragraph.get("elements", [])
+        ).strip()
+        if not text:
+            continue
+        headings.append({
+            "level": _HEADING_LEVELS[named_style],
+            "heading_id": heading_id,
+            "text": text,
+        })
+    return headings
+
+
 def get_document_with_tabs(doc_id: str) -> dict:
     """Fetch document with includeTabsContent=True.
 

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -252,6 +252,10 @@ def cmd_toc(args) -> int:
         headings = [h for h in headings if h["level"] <= max_depth]
 
     base_url = f"https://docs.google.com/document/d/{doc_id}/edit"
+    tab_suffix = f"&tab=t.{tab_id}" if tab_id else ""
+
+    def _link(heading_id: str) -> str:
+        return f"{base_url}#heading={heading_id}{tab_suffix}"
 
     from gdoc.format import format_json, get_output_mode
 
@@ -259,32 +263,23 @@ def cmd_toc(args) -> int:
     if mode == "json":
         items = []
         for h in headings:
-            link = f"{base_url}#heading={h['heading_id']}"
-            if tab_id:
-                link += f"&tab=t.{tab_id}"
             items.append({
                 "level": h["level"],
                 "heading_id": h["heading_id"],
                 "text": h["text"],
-                "link": link,
+                "link": _link(h["heading_id"]),
             })
         print(format_json(headings=items))
     elif mode == "plain":
         for h in headings:
-            link = f"{base_url}#heading={h['heading_id']}"
-            if tab_id:
-                link += f"&tab=t.{tab_id}"
-            print(f"{h['level']}\t{h['heading_id']}\t{h['text']}\t{link}")
+            print(f"{h['level']}\t{h['heading_id']}\t{h['text']}\t{_link(h['heading_id'])}")
     else:
         for h in headings:
             indent = "  " * (h["level"] - 1)
             if no_links:
                 print(f"{indent}- {h['text']}")
             else:
-                link = f"{base_url}#heading={h['heading_id']}"
-                if tab_id:
-                    link += f"&tab=t.{tab_id}"
-                print(f"{indent}- [{h['text']}]({link})")
+                print(f"{indent}- [{h['text']}]({_link(h['heading_id'])})")
         if mode == "verbose":
             print(f"\n({len(headings)} headings)")
 

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -222,6 +222,79 @@ def cmd_tabs(args) -> int:
     return 0
 
 
+def cmd_toc(args) -> int:
+    """Handler for `gdoc toc`."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    tab = getattr(args, "tab", None)
+    max_depth = getattr(args, "max_depth", 0)
+    no_links = getattr(args, "no_links", False)
+
+    from gdoc.notify import pre_flight
+
+    change_info = pre_flight(doc_id, quiet=quiet)
+
+    from gdoc.api.docs import get_document_headings
+
+    body = None
+    tab_id = None
+    if tab:
+        from gdoc.api.docs import get_document_tabs, resolve_tab
+
+        tabs = get_document_tabs(doc_id)
+        tab_match = resolve_tab(tabs, tab)
+        body = tab_match["body"]
+        tab_id = tab_match["id"]
+
+    headings = get_document_headings(doc_id, body=body)
+
+    if max_depth > 0:
+        headings = [h for h in headings if h["level"] <= max_depth]
+
+    base_url = f"https://docs.google.com/document/d/{doc_id}/edit"
+
+    from gdoc.format import format_json, get_output_mode
+
+    mode = get_output_mode(args)
+    if mode == "json":
+        items = []
+        for h in headings:
+            link = f"{base_url}#heading={h['heading_id']}"
+            if tab_id:
+                link += f"&tab=t.{tab_id}"
+            items.append({
+                "level": h["level"],
+                "heading_id": h["heading_id"],
+                "text": h["text"],
+                "link": link,
+            })
+        print(format_json(headings=items))
+    elif mode == "plain":
+        for h in headings:
+            link = f"{base_url}#heading={h['heading_id']}"
+            if tab_id:
+                link += f"&tab=t.{tab_id}"
+            print(f"{h['level']}\t{h['heading_id']}\t{h['text']}\t{link}")
+    else:
+        for h in headings:
+            indent = "  " * (h["level"] - 1)
+            if no_links:
+                print(f"{indent}- {h['text']}")
+            else:
+                link = f"{base_url}#heading={h['heading_id']}"
+                if tab_id:
+                    link += f"&tab=t.{tab_id}"
+                print(f"{indent}- [{h['text']}]({link})")
+        if mode == "verbose":
+            print(f"\n({len(headings)} headings)")
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(doc_id, change_info, command="toc", quiet=quiet)
+
+    return 0
+
+
 def cmd_add_tab(args) -> int:
     """Handler for `gdoc add-tab`."""
     doc_id = _resolve_doc_id(args.doc)
@@ -1782,6 +1855,26 @@ def build_parser() -> GdocArgumentParser:
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     tabs_p.set_defaults(func=cmd_tabs)
+
+    # toc
+    toc_p = sub.add_parser(
+        "toc", parents=[output_parent],
+        help="Extract table of contents with deep links",
+    )
+    toc_p.add_argument("doc", help="Document ID or URL")
+    toc_p.add_argument("--tab", help="Read a specific tab by title or ID")
+    toc_p.add_argument(
+        "--max-depth", type=int, default=0,
+        help="Only show headings up to level N (0 = all)",
+    )
+    toc_p.add_argument(
+        "--no-links", action="store_true",
+        help="Plain text outline without links",
+    )
+    toc_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks",
+    )
+    toc_p.set_defaults(func=cmd_toc)
 
     # add-tab
     add_tab_p = sub.add_parser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.6.3"
+version = "0.7.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -1,0 +1,300 @@
+"""Tests for `gdoc toc` — table of contents with deep links."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest  # noqa: F401
+
+from gdoc.cli import cmd_toc
+from gdoc.util import GdocError
+
+DOC_ID = "abc123"
+BASE_URL = f"https://docs.google.com/document/d/{DOC_ID}/edit"
+
+
+def _make_args(**overrides):
+    defaults = {
+        "command": "toc",
+        "doc": DOC_ID,
+        "tab": None,
+        "max_depth": 0,
+        "no_links": False,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _headings(*specs):
+    """Build heading dicts from (level, heading_id, text) tuples."""
+    return [
+        {"level": lvl, "heading_id": hid, "text": txt}
+        for lvl, hid, txt in specs
+    ]
+
+
+class TestTocBasic:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_terse_output(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = _headings(
+            (1, "h.abc", "Introduction"),
+            (2, "h.def", "Background"),
+        )
+        rc = cmd_toc(_make_args())
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert f"- [Introduction]({BASE_URL}#heading=h.abc)" in out
+        assert f"  - [Background]({BASE_URL}#heading=h.def)" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_headings(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = []
+        rc = cmd_toc(_make_args())
+        assert rc == 0
+        assert capsys.readouterr().out == ""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_links_flag(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = _headings((1, "h.abc", "Title"))
+        rc = cmd_toc(_make_args(no_links=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "- Title\n" in out
+        assert "http" not in out
+
+
+class TestTocMaxDepth:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_filters_deep_headings(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = _headings(
+            (1, "h.1", "H1"),
+            (2, "h.2", "H2"),
+            (3, "h.3", "H3"),
+        )
+        rc = cmd_toc(_make_args(max_depth=2))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "H1" in out
+        assert "H2" in out
+        assert "H3" not in out
+
+
+class TestTocOutputModes:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_json_output(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = _headings((1, "h.abc", "Title"))
+        rc = cmd_toc(_make_args(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert len(data["headings"]) == 1
+        h = data["headings"][0]
+        assert h["level"] == 1
+        assert h["heading_id"] == "h.abc"
+        assert h["text"] == "Title"
+        assert h["link"] == f"{BASE_URL}#heading=h.abc"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_plain_output(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = _headings((2, "h.xyz", "Section"))
+        rc = cmd_toc(_make_args(plain=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "2\th.xyz\tSection\t" in out
+        assert f"{BASE_URL}#heading=h.xyz" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_verbose_shows_count(self, _svc, mock_headings, _pf, _update, capsys):
+        mock_headings.return_value = _headings(
+            (1, "h.1", "A"), (2, "h.2", "B"),
+        )
+        rc = cmd_toc(_make_args(verbose=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "(2 headings)" in out
+
+
+class TestTocTab:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.resolve_tab")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_passes_body(
+        self, _svc, mock_tabs, mock_resolve, mock_headings, _pf, _update, capsys,
+    ):
+        tab_body = {"content": []}
+        mock_tabs.return_value = [{"id": "t1", "title": "Notes", "body": tab_body}]
+        mock_resolve.return_value = {"id": "t1", "title": "Notes", "body": tab_body}
+        mock_headings.return_value = _headings((1, "h.1", "Note Title"))
+        rc = cmd_toc(_make_args(tab="Notes"))
+        assert rc == 0
+        mock_headings.assert_called_once_with(DOC_ID, body=tab_body)
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.resolve_tab")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_appends_tab_id_to_links(
+        self, _svc, mock_tabs, mock_resolve, mock_headings, _pf, _update, capsys,
+    ):
+        mock_tabs.return_value = [{"id": "t1", "title": "Notes", "body": {}}]
+        mock_resolve.return_value = {"id": "t1", "title": "Notes", "body": {}}
+        mock_headings.return_value = _headings((1, "h.abc", "Title"))
+        rc = cmd_toc(_make_args(tab="Notes"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "&tab=t.t1" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.resolve_tab")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_json_includes_tab_in_links(
+        self, _svc, mock_tabs, mock_resolve, mock_headings, _pf, _update, capsys,
+    ):
+        mock_tabs.return_value = [{"id": "t1", "title": "Notes", "body": {}}]
+        mock_resolve.return_value = {"id": "t1", "title": "Notes", "body": {}}
+        mock_headings.return_value = _headings((1, "h.abc", "Title"))
+        rc = cmd_toc(_make_args(tab="Notes", json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "&tab=t.t1" in data["headings"][0]["link"]
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.resolve_tab")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_not_found(self, _svc, mock_tabs, mock_resolve, _pf, _update):
+        mock_tabs.return_value = [{"id": "t1", "title": "Tab 1", "body": {}}]
+        mock_resolve.side_effect = GdocError("tab not found: nope", exit_code=3)
+        with pytest.raises(GdocError, match="tab not found"):
+            cmd_toc(_make_args(tab="nope"))
+
+
+class TestTocAwareness:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight")
+    @patch("gdoc.api.docs.get_document_headings", return_value=[])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_preflight_and_state(self, _svc, _headings, mock_pf, mock_update):
+        from gdoc.notify import ChangeInfo
+
+        change_info = ChangeInfo(current_version=5)
+        mock_pf.return_value = change_info
+        rc = cmd_toc(_make_args())
+        assert rc == 0
+        mock_pf.assert_called_once_with(DOC_ID, quiet=False)
+        mock_update.assert_called_once_with(
+            DOC_ID, change_info, command="toc", quiet=False,
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings", return_value=[])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_quiet_skips_preflight(self, _svc, _headings, mock_pf, _update):
+        cmd_toc(_make_args(quiet=True))
+        mock_pf.assert_called_once_with(DOC_ID, quiet=True)
+
+
+class TestGetDocumentHeadings:
+    """Unit tests for the API-layer heading extraction."""
+
+    def test_extracts_headings(self):
+        from gdoc.api.docs import get_document_headings
+
+        body = {"content": [
+            {"paragraph": {
+                "paragraphStyle": {"namedStyleType": "HEADING_1", "headingId": "h.1"},
+                "elements": [{"textRun": {"content": "Title\n"}}],
+            }},
+            {"paragraph": {
+                "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                "elements": [{"textRun": {"content": "Body text\n"}}],
+            }},
+            {"paragraph": {
+                "paragraphStyle": {"namedStyleType": "HEADING_2", "headingId": "h.2"},
+                "elements": [{"textRun": {"content": "Sub\n"}}],
+            }},
+        ]}
+        result = get_document_headings("doc1", body=body)
+        assert len(result) == 2
+        assert result[0] == {"level": 1, "heading_id": "h.1", "text": "Title"}
+        assert result[1] == {"level": 2, "heading_id": "h.2", "text": "Sub"}
+
+    def test_skips_headings_without_id(self):
+        from gdoc.api.docs import get_document_headings
+
+        body = {"content": [
+            {"paragraph": {
+                "paragraphStyle": {"namedStyleType": "HEADING_1"},
+                "elements": [{"textRun": {"content": "No ID\n"}}],
+            }},
+        ]}
+        result = get_document_headings("doc1", body=body)
+        assert result == []
+
+    def test_skips_empty_heading_text(self):
+        from gdoc.api.docs import get_document_headings
+
+        body = {"content": [
+            {"paragraph": {
+                "paragraphStyle": {"namedStyleType": "HEADING_1", "headingId": "h.1"},
+                "elements": [{"textRun": {"content": "\n"}}],
+            }},
+        ]}
+        result = get_document_headings("doc1", body=body)
+        assert result == []
+
+    def test_concatenates_multi_run_text(self):
+        from gdoc.api.docs import get_document_headings
+
+        body = {"content": [
+            {"paragraph": {
+                "paragraphStyle": {"namedStyleType": "HEADING_1", "headingId": "h.1"},
+                "elements": [
+                    {"textRun": {"content": "Part "}},
+                    {"textRun": {"content": "One\n"}},
+                ],
+            }},
+        ]}
+        result = get_document_headings("doc1", body=body)
+        assert result[0]["text"] == "Part One"
+
+    def test_empty_body(self):
+        from gdoc.api.docs import get_document_headings
+
+        result = get_document_headings("doc1", body={"content": []})
+        assert result == []


### PR DESCRIPTION
## Summary
- Adds `gdoc toc` command that extracts document headings with deep-link URLs
- Supports `--tab`, `--max-depth`, `--no-links` flags and all output modes (json/plain/verbose/terse)
- New `get_document_headings()` API-layer function for heading extraction from document body

## Test plan
- [x] 18 tests covering basic output, max-depth filtering, all output modes, tab support, awareness system integration, and API-layer unit tests
- [x] All existing tests pass
- [x] Codex review passed with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table of contents generation with support for multiple output formats (JSON, markdown, plain, verbose)
  * Options to filter by heading depth, control link inclusion, and target specific tabs

* **Chores**
  * Version updated to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->