### PR TITLE
feat(write): tab-aware writes, insert command, multi-tab safety (0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to `gdoc` are documented here. This project follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.7.1] — 2026-04-11
+
+### Added
+- **`gdoc insert DOC --tab NAME FILE`** — new command for populating a
+  specific tab from a local markdown file. Works on empty tabs, which
+  was previously impossible via the CLI (`add-tab` + `edit --tab`
+  couldn't find an anchor in an empty body). Strips YAML frontmatter
+  automatically. `--position start|end` controls where in the tab body
+  to insert.
+- **`gdoc write --tab NAME`** — scoped write that replaces exactly one
+  tab's body via the Docs API, leaving sibling tabs untouched.
+- **`gdoc add-tab`** now prints a clickable
+  `https://docs.google.com/document/d/DOC/edit?tab=ID` URL alongside
+  the bare `tabId`.
+- New `insert_markdown_into_tab` and `count_document_tabs` helpers in
+  `gdoc.api.docs`. `count_document_tabs` uses a fields mask so the
+  new per-write safety check fetches only tab IDs — no body content.
+
+### Changed
+- **`gdoc write`** now refuses to collapse multi-tab documents into a
+  single tab. When the remote doc has more than one tab and you don't
+  pass `--tab`, `write` exits with code 3 and points you at
+  `--tab NAME`, `gdoc insert`, or the new `--force-collapse-tabs`
+  opt-in. The old collapsing behavior remains available, but you have
+  to ask for it. This closes the biggest footgun in the previous
+  `pull`/`write` asymmetry.
+- **`gdoc write`** now strips YAML frontmatter from the input file
+  before upload. `pull` adds frontmatter; leaving it in the upload
+  used to dump visible YAML into the doc body.
+- **`gdoc edit --old-file FILE`** is now usable on its own — it deletes
+  the matched range. Previously `--old-file` and `--new-file` were
+  required together. `--new-file` alone still errors (no anchor text)
+  and now points users at `gdoc insert` for anchorless writes.
+- `gdoc write --help` documents the single-tab limitation explicitly.
+
+### Fixed
+- `replace_formatted` no longer builds `deleteContentRange` requests
+  for zero-width matches. The Docs API rejects empty ranges with
+  `"The range should not be empty"`, which broke any flow that tried
+  to use a zero-width match as a pure insert (e.g., `edit --tab` on
+  an empty tab).
+- `__version__` was drifting from `pyproject.toml` again; resynced.
+
+## [0.7.0] — 2026-04-09
+
+### Added
+- `gdoc toc DOC` — table of contents with deep links to headings.
+- Multi-account support via `--account` flag.
+- `--no-images` flag on `gdoc cat` to skip image placeholders.
+- `supportsAllDrives=True` on all Drive API calls.
+- `modifiedByMeTime` in `list_files` response.
+
+### Fixed
+- Trailing newline handling in `replace_formatted`.
+
+## [0.6.0] — Earlier releases
+
+See the git history prior to 0.7.0 for detail. Earlier releases covered
+authentication, read operations, the awareness system, write operations,
+comments and annotations, file management, local-file sync
+(`pull`/`push`/`_sync-hook`), and the `gogcli` feature set (byte
+truncation, native tables, image import).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ All notable changes to `gdoc` are documented here. This project follows
   `"The range should not be empty"`, which broke any flow that tried
   to use a zero-width match as a pure insert (e.g., `edit --tab` on
   an empty tab).
+- `parse_frontmatter` no longer strips a leading `---\n...\n---\n`
+  block unless it contains at least one `key: value` line. Previous
+  behavior could silently eat content from markdown files that open
+  with a thematic break followed by another `---`. All
+  frontmatter-consuming commands (`write`, `insert`, `push`,
+  `_pull-hook`, etc.) benefit.
 - `__version__` was drifting from `pyproject.toml` again; resynced.
 
 ## [0.7.0] — 2026-04-09

--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ uv run pytest tests/test_cat.py -k "test_name" -v
 uv run ruff check gdoc/ tests/
 ```
 
+## Changelog
+
+Release notes and upgrade highlights live in [CHANGELOG.md](./CHANGELOG.md).
+
 ## License
 
 MIT

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.6.3"
+__version__ = "0.7.1"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -124,6 +124,35 @@ def get_document_tabs(doc_id: str) -> list[dict]:
         _translate_http_error(e, doc_id)
 
 
+def count_document_tabs(doc_id: str) -> int:
+    """Return the total tab count (including nested child tabs).
+
+    Uses a fields mask so only tab IDs come back — no body content — so
+    the call is cheap enough to run as a per-write safety check.
+    """
+    try:
+        service = get_docs_service()
+        doc = (
+            service.documents()
+            .get(
+                documentId=doc_id,
+                fields="tabs(tabProperties/tabId,childTabs)",
+            )
+            .execute()
+        )
+    except HttpError as e:
+        _translate_http_error(e, doc_id)
+
+    def _walk(tabs: list[dict]) -> int:
+        total = 0
+        for tab in tabs:
+            total += 1
+            total += _walk(tab.get("childTabs", []))
+        return total
+
+    return _walk(doc.get("tabs", []))
+
+
 def get_tab_text(tab: dict) -> str:
     """Extract plain text from a tab's body content.
 
@@ -680,6 +709,119 @@ def _build_cleanup_requests(
     return requests
 
 
+def _tab_body_range(body: dict) -> tuple[int, int]:
+    """Return (startIndex, endIndex_exclusive_final_newline) for a tab body.
+
+    A tab body always begins at index 1. The "end" is one less than the
+    final element's endIndex because Docs stores a trailing newline that
+    cannot be deleted. Returns (1, 1) for an empty body.
+    """
+    last_end = 1
+    for elem in body.get("content", []):
+        end = elem.get("endIndex")
+        if end is not None and end > last_end:
+            last_end = end
+    if last_end <= 1:
+        return (1, 1)
+    return (1, last_end - 1)
+
+
+def insert_markdown_into_tab(
+    doc_id: str,
+    tab_name: str,
+    markdown: str,
+    position: str = "start",
+    replace: bool = False,
+) -> dict:
+    """Insert (or replace) markdown content in a tab via Docs API.
+
+    Bypasses Drive's markdown importer so multi-tab docs are never
+    collapsed. Reused by both `gdoc insert` and `gdoc write --tab`.
+
+    Args:
+        doc_id: Document ID.
+        tab_name: Tab title (case-insensitive) or tab ID.
+        markdown: Markdown source to insert (frontmatter should be
+            stripped by the caller).
+        position: "start" or "end". Ignored when replace=True.
+        replace: If True, delete the tab body first then insert at the
+            body start.
+
+    Returns:
+        Dict with "tab_id", "tab_title", "insert_index".
+    """
+    from gdoc.mdparse import parse_markdown, to_docs_requests
+
+    doc = get_document_with_tabs(doc_id)
+    revision_id = doc.get("revisionId", "")
+    tabs = flatten_tabs(doc.get("tabs", []))
+    tab_match = resolve_tab(tabs, tab_name)
+    tab_id = tab_match["id"]
+    body = tab_match["body"]
+
+    body_start, body_end = _tab_body_range(body)
+
+    if replace:
+        insert_index = body_start
+    elif position == "end":
+        insert_index = body_end
+    else:
+        insert_index = body_start
+
+    parsed = parse_markdown(markdown)
+
+    # Strip trailing \n — the existing paragraph already owns one.
+    # Without this, every insert leaves an extra blank line behind.
+    if parsed.plain_text.endswith("\n"):
+        old_len = len(parsed.plain_text)
+        parsed.plain_text = parsed.plain_text[:-1]
+        for s in parsed.styles:
+            if s.end == old_len:
+                s.end = old_len - 1
+
+    requests: list[dict] = []
+
+    if replace and body_end > body_start:
+        delete_range = {
+            "startIndex": body_start,
+            "endIndex": body_end,
+            "tabId": tab_id,
+        }
+        requests.append({"deleteContentRange": {"range": delete_range}})
+
+    requests.extend(
+        to_docs_requests(parsed, insert_index, tab_id=tab_id)
+    )
+
+    if requests:
+        try:
+            service = get_docs_service()
+            service.documents().batchUpdate(
+                documentId=doc_id,
+                body={
+                    "requests": requests,
+                    "writeControl": {"requiredRevisionId": revision_id},
+                },
+            ).execute()
+        except HttpError as e:
+            _translate_http_error(e, doc_id)
+
+    if parsed.tables:
+        for table in reversed(parsed.tables):
+            _insert_table(
+                doc_id,
+                insert_index + table.plain_text_offset,
+                table,
+                tab_id=tab_id,
+            )
+
+    return {
+        "tab_id": tab_id,
+        "tab_title": tab_match["title"],
+        "insert_index": insert_index,
+    }
+
+
 def replace_formatted(
     doc_id: str,
     matches: list[dict],
@@ -725,18 +867,21 @@ def replace_formatted(
     all_requests: list[dict] = []
 
     for match in sorted_matches:
-        # Delete the matched range
-        delete_range = {
-            "startIndex": match["startIndex"],
-            "endIndex": match["endIndex"],
-        }
-        if tab_id:
-            delete_range["tabId"] = tab_id
-        all_requests.append({
-            "deleteContentRange": {
-                "range": delete_range,
+        # Delete the matched range (skip empty ranges — Docs API rejects
+        # them with "The range should not be empty", and a zero-width
+        # match is a pure insert).
+        if match["endIndex"] > match["startIndex"]:
+            delete_range = {
+                "startIndex": match["startIndex"],
+                "endIndex": match["endIndex"],
             }
-        })
+            if tab_id:
+                delete_range["tabId"] = tab_id
+            all_requests.append({
+                "deleteContentRange": {
+                    "range": delete_range,
+                }
+            })
 
         # Insert formatted replacement
         insert_requests = to_docs_requests(

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -127,8 +127,10 @@ def get_document_tabs(doc_id: str) -> list[dict]:
 def count_document_tabs(doc_id: str) -> int:
     """Return the total tab count (including nested child tabs).
 
-    Uses a fields mask so only tab IDs come back — no body content — so
-    the call is cheap enough to run as a per-write safety check.
+    Passes `includeTabsContent=True` because the Docs API only populates
+    Document.tabs when that flag is set, and a fields mask so the server
+    still only returns tab IDs (no body content) — keeping the call
+    cheap enough to run as a per-write safety check.
     """
     try:
         service = get_docs_service()
@@ -136,6 +138,7 @@ def count_document_tabs(doc_id: str) -> int:
             service.documents()
             .get(
                 documentId=doc_id,
+                includeTabsContent=True,
                 fields="tabs(tabProperties/tabId,childTabs)",
             )
             .execute()

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -306,9 +306,8 @@ def cmd_add_tab(args) -> int:
     from gdoc.api.drive import get_file_version
     command_version = get_file_version(doc_id).get("version")
 
-    url = (
-        f"https://docs.google.com/document/d/{doc_id}/edit?tab={tab_id}"
-    )
+    from gdoc.util import build_doc_url
+    url = build_doc_url(doc_id, tab_id=tab_id)
 
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -306,23 +306,29 @@ def cmd_add_tab(args) -> int:
     from gdoc.api.drive import get_file_version
     command_version = get_file_version(doc_id).get("version")
 
+    url = (
+        f"https://docs.google.com/document/d/{doc_id}/edit?tab={tab_id}"
+    )
+
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)
     if mode == "json":
         print(format_json(
             id=tab_id, title=result["title"],
-            index=result["index"], doc_id=doc_id,
+            index=result["index"], doc_id=doc_id, url=url,
         ))
     elif mode == "verbose":
         print(f"Added tab: {result['title']}")
         print(f"ID: {tab_id}")
         print(f"Index: {result['index']}")
+        print(f"URL: {url}")
     elif mode == "plain":
         print(f"id\t{tab_id}")
         print(f"title\t{result['title']}")
         print(f"index\t{result['index']}")
+        print(f"url\t{url}")
     else:
-        print(f"{tab_id}\t{result['title']}")
+        print(f"{tab_id}\t{result['title']}\t{url}")
 
     from gdoc.state import update_state_after_command
     update_state_after_command(
@@ -330,6 +336,95 @@ def cmd_add_tab(args) -> int:
         command_version=command_version,
     )
 
+    return 0
+
+
+def _print_tab_write_result(
+    mode: str, doc_id: str, result: dict, version, verb: str,
+) -> None:
+    """Print the output for a successful per-tab write (insert or write --tab).
+
+    `verb` is one of "inserted" / "wrote"; it controls the terse line, the
+    verbose phrasing, the `status` column for plain mode, and the JSON
+    boolean key (`inserted` vs `written`).
+    """
+    from gdoc.format import format_json
+
+    json_key = "inserted" if verb == "inserted" else "written"
+    status = "inserted" if verb == "inserted" else "updated"
+    title = result["tab_title"]
+
+    if mode == "json":
+        print(format_json(**{
+            json_key: True,
+            "tab_id": result["tab_id"],
+            "tab_title": title,
+            "version": version,
+        }))
+    elif mode == "plain":
+        print(f"id\t{doc_id}")
+        print(f"tab_id\t{result['tab_id']}")
+        print(f"status\t{status}")
+    elif mode == "verbose":
+        label = "Inserted into tab" if verb == "inserted" else "Wrote tab"
+        print(f'{label}: "{title}"')
+        print(f"Tab ID: {result['tab_id']}")
+    else:
+        terse = (
+            f'OK inserted into "{title}"' if verb == "inserted"
+            else f'OK wrote "{title}"'
+        )
+        print(terse)
+
+
+def cmd_insert(args) -> int:
+    """Handler for `gdoc insert`."""
+    import os
+
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    force = getattr(args, "force", False)
+    tab_name = args.tab
+    position = getattr(args, "position", "start")
+    file_path = args.file
+
+    if not os.path.isfile(file_path):
+        raise GdocError(f"file not found: {file_path}", exit_code=3)
+    try:
+        with open(file_path) as f:
+            content = f.read()
+    except OSError as e:
+        raise GdocError(f"cannot read file: {e}", exit_code=3)
+
+    from gdoc.frontmatter import parse_frontmatter
+    _, content = parse_frontmatter(content)
+
+    if not content.strip():
+        raise GdocError("input file has no content to insert", exit_code=3)
+
+    change_info = _check_write_conflict(doc_id, quiet, force)
+
+    from gdoc.api.docs import insert_markdown_into_tab
+
+    result = insert_markdown_into_tab(
+        doc_id, tab_name, content, position=position, replace=False,
+    )
+
+    from gdoc.api.drive import get_file_version
+    version_data = get_file_version(doc_id)
+    command_version = version_data.get("version")
+
+    from gdoc.format import get_output_mode
+    _print_tab_write_result(
+        get_output_mode(args), doc_id, result, command_version,
+        verb="inserted",
+    )
+
+    from gdoc.state import update_state_after_command
+    update_state_after_command(
+        doc_id, change_info, command="insert",
+        quiet=quiet, command_version=command_version,
+    )
     return 0
 
 
@@ -524,13 +619,18 @@ def cmd_edit(args) -> int:
     new_file = getattr(args, "new_file", None)
 
     if old_file or new_file:
-        if not (old_file and new_file):
+        if new_file and not old_file:
             raise GdocError(
-                "--old-file and --new-file must be used together",
+                "--new-file requires --old-file (needs an anchor). "
+                "To add content without an anchor, use `gdoc insert`.",
                 exit_code=3,
             )
         old_text = _read_file(old_file)
-        new_text = _read_file(new_file)
+        if new_file:
+            new_text = _read_file(new_file)
+        else:
+            # --old-file alone → delete the matched range.
+            new_text = ""
     elif old_text is None or new_text is None:
         raise GdocError(
             "old_text and new_text required "
@@ -683,6 +783,8 @@ def cmd_write(args) -> int:
     doc_id = _resolve_doc_id(args.doc)
     quiet = getattr(args, "quiet", False)
     force = getattr(args, "force", False)
+    tab_name = getattr(args, "tab", None)
+    force_collapse = getattr(args, "force_collapse_tabs", False)
     file_path = args.file
 
     # Read local file first (fail fast on missing file)
@@ -694,27 +796,56 @@ def cmd_write(args) -> int:
     except OSError as e:
         raise GdocError(f"cannot read file: {e}", exit_code=3)
 
+    # Strip frontmatter — pull prepends it, and leaving it in the upload
+    # dumps visible YAML into the doc body.
+    from gdoc.frontmatter import parse_frontmatter
+    _, content = parse_frontmatter(content)
+
     # Conflict detection
     change_info = _check_write_conflict(doc_id, quiet, force)
 
-    # Upload content via Drive API
-    from gdoc.api.drive import update_doc_content
-
-    command_version = update_doc_content(doc_id, content)
-
-    # Output
     from gdoc.format import format_json, get_output_mode
-
     mode = get_output_mode(args)
-    if mode == "json":
-        print(format_json(written=True, version=command_version))
-    elif mode == "plain":
-        print(f"id\t{doc_id}")
-        print(f"status\tupdated")
-    else:
-        print("OK written")
 
-    # Update state (Decision #4: last_version only)
+    if tab_name:
+        from gdoc.api.docs import insert_markdown_into_tab
+        result = insert_markdown_into_tab(
+            doc_id, tab_name, content, replace=True,
+        )
+
+        from gdoc.api.drive import get_file_version
+        version_data = get_file_version(doc_id)
+        command_version = version_data.get("version")
+
+        _print_tab_write_result(
+            mode, doc_id, result, command_version, verb="wrote",
+        )
+    else:
+        # Refuse destructive multi-tab collapse unless the user opts in.
+        if not force_collapse:
+            from gdoc.api.docs import count_document_tabs
+            tab_count = count_document_tabs(doc_id)
+            if tab_count > 1:
+                raise GdocError(
+                    f"write would collapse {tab_count} tabs into 1. "
+                    "Use `gdoc write --tab NAME FILE` for per-tab "
+                    "writes, `gdoc insert --tab NAME FILE` to populate "
+                    "a tab, or pass --force-collapse-tabs to confirm.",
+                    exit_code=3,
+                )
+
+        from gdoc.api.drive import update_doc_content
+        command_version = update_doc_content(doc_id, content)
+
+        if mode == "json":
+            print(format_json(written=True, version=command_version))
+        elif mode == "plain":
+            print(f"id\t{doc_id}")
+            print("status\tupdated")
+        else:
+            print("OK written")
+
+    # Update state
     from gdoc.state import update_state_after_command
 
     update_state_after_command(
@@ -1920,9 +2051,28 @@ def build_parser() -> GdocArgumentParser:
     diff_p.set_defaults(func=cmd_diff)
 
     # write
-    write_p = sub.add_parser("write", parents=[output_parent], help="Overwrite doc from local file")
+    write_p = sub.add_parser(
+        "write", parents=[output_parent],
+        help="Overwrite doc (or one tab) from local file",
+        description=(
+            "Upload a markdown file and replace the doc's contents. "
+            "Without --tab, write replaces the entire document and "
+            "collapses any additional tabs into one — use --tab NAME "
+            "for per-tab writes, or `gdoc insert` to add content to an "
+            "existing tab. YAML frontmatter in the input is stripped "
+            "automatically."
+        ),
+    )
     write_p.add_argument("doc", help="Document ID or URL")
     write_p.add_argument("file", help="Local markdown file")
+    write_p.add_argument(
+        "--tab",
+        help="Replace only this tab (by title or ID); leaves siblings alone",
+    )
+    write_p.add_argument(
+        "--force-collapse-tabs", action="store_true",
+        help="Confirm you intend to collapse a multi-tab doc into one tab",
+    )
     write_p.add_argument(
         "--force", action="store_true", help="Force overwrite even if doc changed"
     )
@@ -1930,6 +2080,34 @@ def build_parser() -> GdocArgumentParser:
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     write_p.set_defaults(func=cmd_write)
+
+    # insert
+    insert_p = sub.add_parser(
+        "insert", parents=[output_parent],
+        help="Insert local markdown into an existing tab",
+        description=(
+            "Insert the contents of a markdown file into a specific tab "
+            "without touching any other tab. Frontmatter is stripped "
+            "before upload."
+        ),
+    )
+    insert_p.add_argument("doc", help="Document ID or URL")
+    insert_p.add_argument("file", help="Local markdown file")
+    insert_p.add_argument(
+        "--tab", required=True,
+        help="Target tab by title or ID",
+    )
+    insert_p.add_argument(
+        "--position", choices=["start", "end"], default="start",
+        help="Insert at the start (default) or end of the tab body",
+    )
+    insert_p.add_argument(
+        "--force", action="store_true", help="Skip conflict detection"
+    )
+    insert_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    insert_p.set_defaults(func=cmd_insert)
 
     # pull
     pull_p = sub.add_parser("pull", parents=[output_parent], help="Download doc as local markdown")

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -393,7 +393,7 @@ def cmd_insert(args) -> int:
         with open(file_path) as f:
             content = f.read()
     except OSError as e:
-        raise GdocError(f"cannot read file: {e}", exit_code=3)
+        raise GdocError(f"cannot read file: {e}", exit_code=3) from e
 
     from gdoc.frontmatter import parse_frontmatter
     _, content = parse_frontmatter(content)
@@ -793,7 +793,7 @@ def cmd_write(args) -> int:
         with open(file_path) as f:
             content = f.read()
     except OSError as e:
-        raise GdocError(f"cannot read file: {e}", exit_code=3)
+        raise GdocError(f"cannot read file: {e}", exit_code=3) from e
 
     # Strip frontmatter — pull prepends it, and leaving it in the upload
     # dumps visible YAML into the doc body.
@@ -2101,7 +2101,8 @@ def build_parser() -> GdocArgumentParser:
         help="Insert at the start (default) or end of the tab body",
     )
     insert_p.add_argument(
-        "--force", action="store_true", help="Skip conflict detection"
+        "--force", action="store_true",
+        help="Proceed even if the doc changed since the last read",
     )
     insert_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"

--- a/gdoc/frontmatter.py
+++ b/gdoc/frontmatter.py
@@ -11,6 +11,12 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
     Returns (metadata_dict, body_without_frontmatter).
     If no valid frontmatter, returns ({}, content).
     Only supports flat key: value pairs.
+
+    A leading `---\\n...\\n---\\n` block is only treated as frontmatter
+    when at least one `key: value` line parses out of it. Empty blocks
+    or blocks containing only prose (for example, a thematic break
+    followed by another `---`) are left in place to avoid silently
+    eating content.
     """
     match = _FRONTMATTER_RE.match(content)
     if not match:
@@ -29,6 +35,9 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
         value = line[colon + 1 :].strip()
         if key:
             metadata[key] = value
+
+    if not metadata:
+        return {}, content
 
     body = content[match.end() :]
     return metadata, body

--- a/gdoc/update.py
+++ b/gdoc/update.py
@@ -11,6 +11,7 @@ from urllib.request import urlopen
 _GITHUB_REPO = "LucaDeLeo/gdoc"
 _PACKAGE_NAME = "gdoc"
 _CACHE_FILE = Path.home() / ".config" / "gdoc" / "update_check.json"
+_CHANGELOG_URL = f"https://github.com/{_GITHUB_REPO}/blob/main/CHANGELOG.md"
 
 
 def _installed_version() -> str:
@@ -61,7 +62,8 @@ def check_for_update() -> None:
         if latest and latest != _installed_version():
             print(
                 f"Update available: {_installed_version()} → {latest}. "
-                f"Run `gdoc update` to update.",
+                f"Run `gdoc update` to update. "
+                f"Changelog: {_CHANGELOG_URL}",
                 file=sys.stderr,
             )
     except Exception:
@@ -88,6 +90,7 @@ def run_update() -> int:
     )
     if result.returncode == 0:
         print(f"\nUpdated to v{latest}.")
+        print(f"Changelog: {_CHANGELOG_URL}")
         _write_cache(latest)
         return 0
     else:

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -95,6 +95,14 @@ def confirm_destructive(message: str, force: bool = False) -> None:
         raise GdocError("Cancelled", exit_code=3)
 
 
+def build_doc_url(doc_id: str, tab_id: str | None = None) -> str:
+    """Build a Google Docs URL, optionally pointing at a specific tab."""
+    url = f"https://docs.google.com/document/d/{doc_id}/edit"
+    if tab_id:
+        url += f"?tab={tab_id}"
+    return url
+
+
 def extract_doc_id(input_str: str) -> str:
     """Extract document ID from a URL or bare ID string.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.7.0"
+version = "0.7.1"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -527,17 +527,20 @@ class TestCountDocumentTabs:
         assert count_document_tabs("doc1") == 4
 
     @patch("gdoc.api.docs.get_docs_service")
-    def test_uses_fields_mask(self, mock_svc):
+    def test_requests_tabs_content_with_minimal_fields(self, mock_svc):
         from gdoc.api.docs import count_document_tabs
 
         mock_svc.return_value.documents.return_value \
             .get.return_value.execute.return_value = {"tabs": []}
         count_document_tabs("doc1")
-        # The fields mask must request only tab IDs (and childTabs for
-        # recursion) — never full body content — so the safety check is
-        # cheap enough to run on every full-doc write.
         call_kwargs = mock_svc.return_value.documents.return_value \
             .get.call_args.kwargs
+        # includeTabsContent=True is required — without it the Docs API
+        # leaves Document.tabs unpopulated and the safety check silently
+        # reports 0 tabs.
+        assert call_kwargs.get("includeTabsContent") is True
+        # The fields mask keeps the server response minimal: only tab
+        # IDs (and childTabs for recursion), never body content.
         assert "fields" in call_kwargs
         assert "tabId" in call_kwargs["fields"]
         assert "content" not in call_kwargs["fields"]

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -471,3 +471,209 @@ class TestAddTab:
 
         with pytest.raises(GdocError, match="Unexpected API response"):
             add_tab("doc1", "Notes")
+
+
+def _capture_batch_updates(mock_svc):
+    """Wire mock_svc so every documents().batchUpdate(...) is captured.
+
+    Returns a list that accumulates each call's body kwarg.
+    """
+    captured: list = []
+
+    def _bu(documentId, body):
+        captured.append(body)
+        inner = MagicMock()
+        inner.execute.return_value = {}
+        return inner
+
+    mock_svc.return_value.documents.return_value \
+        .batchUpdate.side_effect = _bu
+    return captured
+
+
+class TestCountDocumentTabs:
+    """count_document_tabs uses a fields mask and counts nested tabs."""
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_flat_tab_list(self, mock_svc):
+        from gdoc.api.docs import count_document_tabs
+
+        mock_svc.return_value.documents.return_value \
+            .get.return_value.execute.return_value = {
+                "tabs": [
+                    {"tabProperties": {"tabId": "t1"}},
+                    {"tabProperties": {"tabId": "t2"}},
+                ],
+            }
+        assert count_document_tabs("doc1") == 2
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_nested_child_tabs_counted(self, mock_svc):
+        from gdoc.api.docs import count_document_tabs
+
+        mock_svc.return_value.documents.return_value \
+            .get.return_value.execute.return_value = {
+                "tabs": [
+                    {
+                        "tabProperties": {"tabId": "t1"},
+                        "childTabs": [
+                            {"tabProperties": {"tabId": "t1a"}},
+                            {"tabProperties": {"tabId": "t1b"}},
+                        ],
+                    },
+                    {"tabProperties": {"tabId": "t2"}},
+                ],
+            }
+        assert count_document_tabs("doc1") == 4
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_uses_fields_mask(self, mock_svc):
+        from gdoc.api.docs import count_document_tabs
+
+        mock_svc.return_value.documents.return_value \
+            .get.return_value.execute.return_value = {"tabs": []}
+        count_document_tabs("doc1")
+        # The fields mask must request only tab IDs (and childTabs for
+        # recursion) — never full body content — so the safety check is
+        # cheap enough to run on every full-doc write.
+        call_kwargs = mock_svc.return_value.documents.return_value \
+            .get.call_args.kwargs
+        assert "fields" in call_kwargs
+        assert "tabId" in call_kwargs["fields"]
+        assert "content" not in call_kwargs["fields"]
+
+
+class TestZeroWidthReplace:
+    """Zero-width matches in replace_formatted act as pure inserts — no
+    deleteContentRange is emitted (Docs API rejects empty ranges)."""
+
+    @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_zero_width_match_skips_delete(self, mock_svc, _cleanup):
+        from gdoc.api.docs import replace_formatted
+
+        captured = _capture_batch_updates(mock_svc)
+        mock_svc.return_value.documents.return_value \
+            .get.return_value.execute.return_value = {"body": {"content": []}}
+
+        matches = [{"startIndex": 1, "endIndex": 1}]
+        replace_formatted("doc1", matches, "hello", "rev1")
+
+        assert captured, "batchUpdate not called"
+        reqs = captured[0]["requests"]
+        delete_reqs = [r for r in reqs if "deleteContentRange" in r]
+        insert_reqs = [r for r in reqs if "insertText" in r]
+        assert delete_reqs == []
+        assert len(insert_reqs) == 1
+        assert insert_reqs[0]["insertText"]["text"] == "hello"
+
+
+class TestInsertMarkdownIntoTab:
+    def _tabs_doc(self, body_content=None):
+        return {
+            "revisionId": "rev-xyz",
+            "tabs": [{
+                "tabProperties": {
+                    "tabId": "t.todo", "title": "TODO", "index": 0,
+                },
+                "documentTab": {
+                    "body": {"content": body_content or []},
+                },
+            }],
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_insert_empty_tab_start(self, mock_get, mock_svc):
+        from gdoc.api.docs import insert_markdown_into_tab
+
+        mock_get.return_value = self._tabs_doc()
+        captured = _capture_batch_updates(mock_svc)
+
+        result = insert_markdown_into_tab(
+            "doc1", "TODO", "hello\n", position="start", replace=False,
+        )
+
+        assert result["tab_id"] == "t.todo"
+        assert result["insert_index"] == 1
+        assert len(captured) == 1
+        reqs = captured[0]["requests"]
+        delete_reqs = [r for r in reqs if "deleteContentRange" in r]
+        insert_reqs = [r for r in reqs if "insertText" in r]
+        assert delete_reqs == []
+        assert len(insert_reqs) == 1
+        # parse_markdown emits "hello\n\n" for "hello\n"; single trailing
+        # \n strip matches replace_formatted's behavior, leaving one \n as
+        # the paragraph marker.
+        assert insert_reqs[0]["insertText"]["text"] == "hello\n"
+        assert captured[0]["writeControl"] == {
+            "requiredRevisionId": "rev-xyz",
+        }
+        assert insert_reqs[0]["insertText"]["location"]["tabId"] == "t.todo"
+
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_insert_nonempty_tab_end(self, mock_get, mock_svc):
+        from gdoc.api.docs import insert_markdown_into_tab
+
+        mock_get.return_value = self._tabs_doc(body_content=[
+            {"startIndex": 1, "endIndex": 20, "paragraph": {}},
+        ])
+        captured = _capture_batch_updates(mock_svc)
+
+        result = insert_markdown_into_tab(
+            "doc1", "TODO", "tail", position="end", replace=False,
+        )
+
+        assert result["insert_index"] == 19
+        reqs = captured[0]["requests"]
+        insert_reqs = [r for r in reqs if "insertText" in r]
+        assert insert_reqs[0]["insertText"]["location"]["index"] == 19
+        assert insert_reqs[0]["insertText"]["text"] == "tail"
+
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_replace_tab_body(self, mock_get, mock_svc):
+        from gdoc.api.docs import insert_markdown_into_tab
+
+        mock_get.return_value = self._tabs_doc(body_content=[
+            {"startIndex": 1, "endIndex": 30, "paragraph": {}},
+        ])
+        captured = _capture_batch_updates(mock_svc)
+
+        insert_markdown_into_tab(
+            "doc1", "TODO", "new content", replace=True,
+        )
+
+        reqs = captured[0]["requests"]
+        delete_reqs = [r for r in reqs if "deleteContentRange" in r]
+        assert len(delete_reqs) == 1
+        d_range = delete_reqs[0]["deleteContentRange"]["range"]
+        assert d_range["startIndex"] == 1
+        assert d_range["endIndex"] == 29
+        assert d_range["tabId"] == "t.todo"
+
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_replace_empty_tab_no_delete(self, mock_get, mock_svc):
+        from gdoc.api.docs import insert_markdown_into_tab
+
+        mock_get.return_value = self._tabs_doc()
+        captured = _capture_batch_updates(mock_svc)
+
+        insert_markdown_into_tab(
+            "doc1", "TODO", "content", replace=True,
+        )
+
+        reqs = captured[0]["requests"]
+        delete_reqs = [r for r in reqs if "deleteContentRange" in r]
+        assert delete_reqs == []
+
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_missing_tab_errors(self, mock_get):
+        from gdoc.api.docs import insert_markdown_into_tab
+
+        mock_get.return_value = self._tabs_doc()
+
+        with pytest.raises(GdocError, match="tab not found"):
+            insert_markdown_into_tab("doc1", "Not A Real Tab", "hi")

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -404,17 +404,27 @@ class TestEditFileInput:
             "abc123", _single_match(), "world", "rev123", tab_id=None,
         )
 
-    def test_missing_new_file_flag(self, tmp_path):
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.find_text_in_document", return_value=_single_match())
+    @patch("gdoc.api.docs.get_document", return_value=_mock_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_old_file_alone_deletes(
+        self, _pf, _doc, _find, mock_replace, _ver, _update, tmp_path,
+    ):
+        """--old-file alone → delete the matched range."""
         old_f = tmp_path / "old.txt"
         old_f.write_text("hello")
         args = _make_args(
             old_text=None, new_text=None,
             old_file=str(old_f), new_file=None,
         )
-        msg = "--old-file and --new-file must be used together"
-        with pytest.raises(GdocError, match=msg) as exc_info:
-            cmd_edit(args)
-        assert exc_info.value.exit_code == 3
+        cmd_edit(args)
+        # new_text defaults to empty string for a pure delete.
+        mock_replace.assert_called_once_with(
+            "abc123", _single_match(), "", "rev123", tab_id=None,
+        )
 
     def test_missing_old_file_flag(self, tmp_path):
         new_f = tmp_path / "new.txt"
@@ -423,10 +433,12 @@ class TestEditFileInput:
             old_text=None, new_text=None,
             old_file=None, new_file=str(new_f),
         )
-        msg = "--old-file and --new-file must be used together"
-        with pytest.raises(GdocError, match=msg) as exc_info:
+        with pytest.raises(
+            GdocError, match="--new-file requires --old-file",
+        ) as exc_info:
             cmd_edit(args)
         assert exc_info.value.exit_code == 3
+        assert "gdoc insert" in str(exc_info.value)
 
     def test_file_not_found(self, tmp_path):
         missing = str(tmp_path / "nope.txt")

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -33,11 +33,23 @@ class TestParseFrontmatter:
         assert meta == {}
         assert body == content
 
-    def test_empty_frontmatter(self):
+    def test_empty_frontmatter_left_in_place(self):
+        # A leading `---\\n\\n---\\n` block with no key:value content
+        # isn't treated as frontmatter — otherwise a markdown file that
+        # opens with a thematic break would silently lose its first
+        # section.
         content = "---\n\n---\nBody here."
         meta, body = parse_frontmatter(content)
         assert meta == {}
-        assert body == "Body here."
+        assert body == content
+
+    def test_thematic_break_with_prose_not_stripped(self):
+        # Innocent markdown that happens to start with `---` and has
+        # another `---` later must round-trip unchanged.
+        content = "---\n\n# Real heading\n\nFirst paragraph.\n\n---\nFooter"
+        meta, body = parse_frontmatter(content)
+        assert meta == {}
+        assert body == content
 
     def test_value_with_colons(self):
         content = "---\nurl: https://example.com:8080/path\n---\nBody"

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,0 +1,168 @@
+"""Tests for the `gdoc insert` command handler."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gdoc.cli import cmd_insert
+from gdoc.notify import ChangeInfo
+from gdoc.util import GdocError
+
+
+def _make_args(**overrides):
+    defaults = {
+        "command": "insert",
+        "doc": "abc123",
+        "file": "/tmp/content.md",
+        "tab": "TODO",
+        "position": "start",
+        "force": False,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _insert_result(tab_id="t.todo", tab_title="TODO", insert_index=1):
+    return {
+        "tab_id": tab_id,
+        "tab_title": tab_title,
+        "insert_index": insert_index,
+    }
+
+
+def _preflight_ok():
+    return ChangeInfo(current_version=10, last_read_version=10)
+
+
+class TestInsertBasic:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_terse_output(
+        self, _pf, mock_insert, _ver, _update, tmp_path, capsys,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("# Hello")
+        args = _make_args(file=str(f))
+        rc = cmd_insert(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert 'OK inserted into "TODO"' in out
+        mock_insert.assert_called_once_with(
+            "abc123", "TODO", "# Hello",
+            position="start", replace=False,
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_json_output(
+        self, _pf, _mock_insert, _ver, _update, tmp_path, capsys,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("hi")
+        args = _make_args(file=str(f), json=True)
+        rc = cmd_insert(args)
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["inserted"] is True
+        assert data["tab_id"] == "t.todo"
+        assert data["tab_title"] == "TODO"
+        assert data["version"] == 11
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_position_end_is_forwarded(
+        self, _pf, mock_insert, _ver, _update, tmp_path,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("tail")
+        args = _make_args(file=str(f), position="end")
+        cmd_insert(args)
+        mock_insert.assert_called_once_with(
+            "abc123", "TODO", "tail",
+            position="end", replace=False,
+        )
+
+
+class TestInsertFrontmatterStrip:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_frontmatter_stripped(
+        self, _pf, mock_insert, _ver, _update, tmp_path,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text(
+            "---\ngdoc: abc123\ntitle: Whatever\n---\n# Real content\n",
+        )
+        args = _make_args(file=str(f))
+        cmd_insert(args)
+        body = mock_insert.call_args.args[2]
+        assert body.startswith("# Real content")
+        assert "---" not in body
+        assert "gdoc:" not in body
+
+
+class TestInsertFileErrors:
+    def test_file_not_found(self):
+        args = _make_args(file="/nonexistent/missing.md")
+        with pytest.raises(GdocError, match="file not found") as exc:
+            cmd_insert(args)
+        assert exc.value.exit_code == 3
+
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_empty_file_after_frontmatter_strip(self, _pf, tmp_path):
+        f = tmp_path / "content.md"
+        f.write_text("---\ngdoc: abc123\n---\n\n\n")
+        args = _make_args(file=str(f))
+        with pytest.raises(GdocError, match="no content") as exc:
+            cmd_insert(args)
+        assert exc.value.exit_code == 3
+
+
+class TestInsertConflict:
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_blocks_on_conflict(
+        self, mock_pf, mock_insert, _ver, tmp_path,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("hi")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=5,
+        )
+        args = _make_args(file=str(f))
+        with pytest.raises(GdocError, match="doc changed"):
+            cmd_insert(args)
+        mock_insert.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight")
+    def test_force_bypasses_conflict(
+        self, mock_pf, mock_insert, _ver, _update, tmp_path,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("hi")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=5,
+        )
+        args = _make_args(file=str(f), force=True)
+        rc = cmd_insert(args)
+        assert rc == 0
+        mock_insert.assert_called_once()

--- a/tests/test_tabs_cmd.py
+++ b/tests/test_tabs_cmd.py
@@ -206,6 +206,8 @@ class TestAddTab:
         assert rc == 0
         out = capsys.readouterr().out
         assert "t99\tNew Tab" in out
+        # Clickable URL is now part of the default output.
+        assert "https://docs.google.com/document/d/abc123/edit?tab=t99" in out
         mock_add.assert_called_once_with("abc123", "New Tab")
 
     @patch("gdoc.state.update_state_after_command")
@@ -222,6 +224,9 @@ class TestAddTab:
         assert data["title"] == "New Tab"
         assert data["index"] == 2
         assert data["doc_id"] == "abc123"
+        assert data["url"] == (
+            "https://docs.google.com/document/d/abc123/edit?tab=t99"
+        )
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 10})
@@ -235,6 +240,7 @@ class TestAddTab:
         assert "Added tab: New Tab" in out
         assert "ID: t99" in out
         assert "Index: 2" in out
+        assert "URL: https://docs.google.com/document/d/abc123/edit?tab=t99" in out
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 10})
@@ -248,6 +254,10 @@ class TestAddTab:
         assert "id\tt99" in out
         assert "title\tNew Tab" in out
         assert "index\t2" in out
+        assert (
+            "url\thttps://docs.google.com/document/d/abc123/edit?tab=t99"
+            in out
+        )
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 10})

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,30 @@ from unittest.mock import patch
 
 import pytest
 
-from gdoc.util import AuthError, GdocError, confirm_destructive, extract_doc_id
+from gdoc.util import (
+    AuthError,
+    GdocError,
+    build_doc_url,
+    confirm_destructive,
+    extract_doc_id,
+)
+
+
+class TestBuildDocUrl:
+    def test_without_tab(self):
+        assert (
+            build_doc_url("abc123")
+            == "https://docs.google.com/document/d/abc123/edit"
+        )
+
+    def test_with_tab(self):
+        assert (
+            build_doc_url("abc123", tab_id="t.xyz")
+            == "https://docs.google.com/document/d/abc123/edit?tab=t.xyz"
+        )
+
+    def test_tab_id_none_omits_param(self):
+        assert "?tab=" not in build_doc_url("abc123", tab_id=None)
 
 
 class TestExtractDocId:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -14,7 +14,12 @@ from gdoc.util import AuthError, GdocError
 
 
 def _make_args(**overrides):
-    """Build a SimpleNamespace mimicking parsed write args."""
+    """Build a SimpleNamespace mimicking parsed write args.
+
+    Defaults `force_collapse_tabs=True` so the safety check doesn't
+    require patching `get_document_tabs` in every legacy test. Tests
+    that exercise the multi-tab safety path should override it.
+    """
     defaults = {
         "command": "write",
         "doc": "abc123",
@@ -23,6 +28,8 @@ def _make_args(**overrides):
         "json": False,
         "verbose": False,
         "quiet": False,
+        "tab": None,
+        "force_collapse_tabs": True,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -597,3 +604,161 @@ class TestWritePlain:
         out = capsys.readouterr().out
         assert "id\tabc123" in out
         assert "status\tupdated" in out
+
+
+class TestWriteFrontmatterStrip:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.notify.pre_flight")
+    def test_frontmatter_stripped_from_upload(
+        self, mock_pf, mock_update, _update_state, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text(
+            "---\ngdoc: abc123\ntitle: Demo\n---\n# Real body\n",
+        )
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(file=str(f))
+        cmd_write(args)
+        uploaded = mock_update.call_args.args[1]
+        assert "---" not in uploaded
+        assert "gdoc:" not in uploaded
+        assert uploaded.startswith("# Real body")
+
+
+class TestWriteCollapseSafety:
+    """Writes against multi-tab docs without --force-collapse-tabs fail."""
+
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.api.docs.count_document_tabs", return_value=2)
+    @patch("gdoc.notify.pre_flight")
+    def test_refuses_multi_tab_without_flag(
+        self, mock_pf, _mock_count, mock_update, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("content")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(file=str(f), force_collapse_tabs=False)
+        with pytest.raises(GdocError, match="collapse 2 tabs") as exc:
+            cmd_write(args)
+        msg = str(exc.value)
+        assert "--force-collapse-tabs" in msg
+        assert "--tab" in msg
+        assert "insert" in msg
+        mock_update.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.api.docs.count_document_tabs", return_value=1)
+    @patch("gdoc.notify.pre_flight")
+    def test_single_tab_passes_through(
+        self, mock_pf, _mock_count, mock_update, _u, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("content")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(file=str(f), force_collapse_tabs=False)
+        rc = cmd_write(args)
+        assert rc == 0
+        mock_update.assert_called_once()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.api.docs.count_document_tabs")
+    @patch("gdoc.notify.pre_flight")
+    def test_force_collapse_bypasses_check(
+        self, mock_pf, mock_count, mock_update, _u, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("content")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(file=str(f), force_collapse_tabs=True)
+        rc = cmd_write(args)
+        assert rc == 0
+        # With the opt-in flag, no count lookup happens at all.
+        mock_count.assert_not_called()
+        mock_update.assert_called_once()
+
+
+class TestWriteTabScoped:
+    """--tab NAME writes only to that tab via Docs API."""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_tab_scoped_uses_docs_api(
+        self, mock_pf, mock_insert, _ver, _update, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("# New body\n")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        mock_insert.return_value = {
+            "tab_id": "t.todo",
+            "tab_title": "TODO for Mark",
+            "insert_index": 1,
+        }
+        args = _make_args(file=str(f), tab="TODO for Mark")
+        rc = cmd_write(args)
+        assert rc == 0
+        mock_insert.assert_called_once_with(
+            "abc123", "TODO for Mark", "# New body\n", replace=True,
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.api.docs.count_document_tabs")
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_tab_scoped_does_not_touch_drive(
+        self, mock_pf, mock_insert, mock_tabs, mock_update_doc, _ver,
+        _update, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("body")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        mock_insert.return_value = {
+            "tab_id": "t.todo", "tab_title": "TODO", "insert_index": 1,
+        }
+        args = _make_args(file=str(f), tab="TODO")
+        cmd_write(args)
+        mock_update_doc.assert_not_called()
+        # The tab-count safety check runs only on the full-doc path;
+        # --tab writes must not invoke it.
+        mock_tabs.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_tab_scoped_strips_frontmatter(
+        self, mock_pf, mock_insert, _ver, _update, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text(
+            "---\ngdoc: abc123\n---\n# Real body\n",
+        )
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        mock_insert.return_value = {
+            "tab_id": "t.a", "tab_title": "A", "insert_index": 1,
+        }
+        args = _make_args(file=str(f), tab="A")
+        cmd_write(args)
+        uploaded = mock_insert.call_args.args[2]
+        assert "---" not in uploaded
+        assert uploaded.startswith("# Real body")

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -16,9 +16,11 @@ from gdoc.util import AuthError, GdocError
 def _make_args(**overrides):
     """Build a SimpleNamespace mimicking parsed write args.
 
-    Defaults `force_collapse_tabs=True` so the safety check doesn't
-    require patching `get_document_tabs` in every legacy test. Tests
-    that exercise the multi-tab safety path should override it.
+    Defaults match what `build_parser()` produces: `tab=None`,
+    `force_collapse_tabs=False`. Tests that need to bypass the
+    multi-tab safety gate either pass `force_collapse_tabs=True`
+    or rely on the module-level `_stub_single_tab` autouse fixture
+    below, which pretends the remote doc has a single tab.
     """
     defaults = {
         "command": "write",
@@ -29,10 +31,26 @@ def _make_args(**overrides):
         "verbose": False,
         "quiet": False,
         "tab": None,
-        "force_collapse_tabs": True,
+        "force_collapse_tabs": False,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _stub_single_tab():
+    """Default `count_document_tabs` to `1` for the whole test module.
+
+    Keeps legacy success-path tests honest to the real CLI defaults
+    (force_collapse_tabs=False) without forcing every test to decorate
+    the patch. Tests that need a different count (e.g.
+    `TestWriteCollapseSafety.test_refuses_multi_tab_without_flag`)
+    stack their own `@patch("gdoc.api.docs.count_document_tabs", ...)`
+    on top — unittest.mock.patch is LIFO so the inner patch wins for
+    the duration of the test.
+    """
+    with patch("gdoc.api.docs.count_document_tabs", return_value=1):
+        yield
 
 
 class TestWriteBasic:

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.6.3"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Adds the missing CLI surface for populating tabs in multi-tab docs and stops `write` from silently collapsing them. Closes the biggest footgun in the `pull`/`write` asymmetry.

### New commands

- **`gdoc insert DOC --tab NAME FILE`** — populate a specific tab from a local markdown file. Works on empty tabs (previously impossible: `add-tab` + `edit --tab` couldn't find an anchor in an empty body). Strips YAML frontmatter. `--position start|end` controls insertion point.
- **`gdoc write --tab NAME`** — scoped write replacing one tab's body via the Docs API; siblings untouched.

### Behavior changes

- **`gdoc write`** refuses to collapse multi-tab docs into one. Exits 3 with a message pointing at `--tab NAME`, `gdoc insert`, or the new `--force-collapse-tabs` opt-in. The legacy collapsing behavior is still available, just no longer silent.
- **`gdoc write`** strips YAML frontmatter from the input before upload. Pull→edit→write round-trips no longer dump visible YAML into the doc body.
- **`gdoc edit --old-file FILE`** is now usable alone → deletes the matched range. `--new-file` alone still errors and points at `gdoc insert`.
- **`gdoc add-tab`** prints a clickable `?tab=...` URL alongside the bare tabId.

### Fixes

- `replace_formatted` skips zero-width `deleteContentRange` requests (Docs API rejects empty ranges with `"The range should not be empty"`).
- `__version__` resynced with `pyproject.toml` (drift to 0.6.3 → 0.7.1).

### New helpers in `gdoc.api.docs`

- `insert_markdown_into_tab(doc_id, tab_name, markdown, position, replace)` — encapsulates the tab-resolve + parse_markdown + batchUpdate dance that users previously had to write by hand against the Python API.
- `count_document_tabs(doc_id)` — lightweight tab count using a `fields="tabs(tabProperties/tabId,childTabs)"` mask so the per-write safety check doesn't download tab body content.

### Release mechanics

- CHANGELOG.md added, linked from README.
- `gdoc update` notice and post-update message both link to the changelog URL.
- Version bumped to 0.7.1.

## Test plan

- [x] `uv run pytest tests/ -v` — 832 passing (21 new tests: insert handler, tab-aware write, multi-tab safety, zero-width replace, count_document_tabs, frontmatter strip, add-tab URL).
- [x] `uv run ruff check` — no new issues introduced.
- [x] `bash scripts/check-no-stubs.sh` — clean.
- [x] Smoke test end-to-end against a real Google Doc: `gdoc new` → `add-tab` (URL printed) → `insert --tab` on the empty tab → `cat --tab` verified bullets/bold/code render → `write` on multi-tab doc refused with correct exit 3 → `write --tab` scoped replacement → sibling tab untouched → frontmatter round-trip stripped → `--force-collapse-tabs` opt-in collapses as expected.

See [CHANGELOG.md](./CHANGELOG.md) for the full release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New gdoc insert command for inserting markdown into specific tabs; per-tab write support; CLI now shows clickable tab URLs.
  * CLI now points to changelog when reporting or completing updates.

* **Bug Fixes**
  * Safer find-and-replace behavior to avoid empty-range errors.
  * Version number synchronized across packaging.

* **Documentation**
  * Added comprehensive CHANGELOG and README changelog link.

* **Tests**
  * Expanded test coverage for tab operations, inserts, writes, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->