### PR TITLE
fix: drop fields mask in count_document_tabs (issue #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] — 2026-05-07
+
+### Fixed
+- **`gdoc write`** no longer fails the per-write multi-tab safety
+  check. The Docs API now rejects the recursive `childTabs` field
+  mask, so `count_document_tabs` calls `documents.get` without a
+  mask. Issue #14.
+
 ## [0.7.1] — 2026-04-11
 
 ### Added

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -127,33 +127,11 @@ def get_document_tabs(doc_id: str) -> list[dict]:
 def count_document_tabs(doc_id: str) -> int:
     """Return the total tab count (including nested child tabs).
 
-    Passes `includeTabsContent=True` because the Docs API only populates
-    Document.tabs when that flag is set, and a fields mask so the server
-    still only returns tab IDs (no body content) — keeping the call
-    cheap enough to run as a per-write safety check.
+    No `fields` mask: the Docs API rejects masks that recursively
+    expand `childTabs` (issue #14).
     """
-    try:
-        service = get_docs_service()
-        doc = (
-            service.documents()
-            .get(
-                documentId=doc_id,
-                includeTabsContent=True,
-                fields="tabs(tabProperties/tabId,childTabs)",
-            )
-            .execute()
-        )
-    except HttpError as e:
-        _translate_http_error(e, doc_id)
-
-    def _walk(tabs: list[dict]) -> int:
-        total = 0
-        for tab in tabs:
-            total += 1
-            total += _walk(tab.get("childTabs", []))
-        return total
-
-    return _walk(doc.get("tabs", []))
+    doc = get_document_with_tabs(doc_id)
+    return len(flatten_tabs(doc.get("tabs", [])))
 
 
 def get_tab_text(tab: dict) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.7.1"
+version = "0.7.2"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -492,7 +492,7 @@ def _capture_batch_updates(mock_svc):
 
 
 class TestCountDocumentTabs:
-    """count_document_tabs uses a fields mask and counts nested tabs."""
+    """count_document_tabs requests tab content and counts nested tabs."""
 
     @patch("gdoc.api.docs.get_docs_service")
     def test_flat_tab_list(self, mock_svc):
@@ -527,7 +527,7 @@ class TestCountDocumentTabs:
         assert count_document_tabs("doc1") == 4
 
     @patch("gdoc.api.docs.get_docs_service")
-    def test_requests_tabs_content_with_minimal_fields(self, mock_svc):
+    def test_requests_tabs_content_without_fields_mask(self, mock_svc):
         from gdoc.api.docs import count_document_tabs
 
         mock_svc.return_value.documents.return_value \
@@ -535,15 +535,8 @@ class TestCountDocumentTabs:
         count_document_tabs("doc1")
         call_kwargs = mock_svc.return_value.documents.return_value \
             .get.call_args.kwargs
-        # includeTabsContent=True is required — without it the Docs API
-        # leaves Document.tabs unpopulated and the safety check silently
-        # reports 0 tabs.
         assert call_kwargs.get("includeTabsContent") is True
-        # The fields mask keeps the server response minimal: only tab
-        # IDs (and childTabs for recursion), never body content.
-        assert "fields" in call_kwargs
-        assert "tabId" in call_kwargs["fields"]
-        assert "content" not in call_kwargs["fields"]
+        assert "fields" not in call_kwargs
 
 
 class TestZeroWidthReplace:


### PR DESCRIPTION
## Summary
- Fixes #14 — `gdoc write` against a non-tabbed doc was failing with `Field mask cannot retrieve comment-specific fields when include_comments is false` on every call. The Docs API now rejects the recursive `childTabs` selector in `count_document_tabs`'s field mask.
- Dropped the mask and collapsed the function from 18 lines to 2 by reusing the existing `get_document_with_tabs` and `flatten_tabs` helpers.
- Bumped version to `0.7.2` (in `pyproject.toml` + `gdoc/__init__.py`) so installed clients pick up the fix.

## Test plan
- [x] `uv run pytest tests/` — 836 passed
- [x] Targeted: `tests/test_api_docs.py::TestCountDocumentTabs` (3 tests) and `tests/test_write.py` (39 tests) all pass
- [ ] Smoke test: run `gdoc write <doc-id> file.md` against a real single-tab doc
- [ ] Smoke test: run `gdoc write <doc-id> file.md` against a real multi-tab doc and verify it still refuses without `--force-collapse-tabs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a multi-tab safety check failure in `gdoc write` that prevented the command from completing successfully in documents with multiple tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->