### PR TITLE
feat(safety): extend multi-tab guard to push and _sync-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] — 2026-05-23
+
+### Added
+- **`gdoc push --force-collapse-tabs`** — opt-in flag mirroring
+  `gdoc write`. Without it, `push` now refuses to overwrite a
+  multi-tab document (exits 3 before any API write) and points you at
+  `gdoc edit --tab`, `gdoc insert --tab`, or the new flag.
+
+### Changed
+- **`gdoc push`** and **`gdoc _sync-hook`** now refuse to silently
+  collapse multi-tab documents into one tab — extending the safety
+  guard 0.7.1 added to `gdoc write` across the remaining destructive
+  paths. A `pull`/`push` round-trip on a multi-tab doc previously
+  deleted every tab but the first with no warning. `_sync-hook` runs
+  non-interactively, so it hard-skips multi-tab docs and logs
+  `SYNC: skipped "<title>" (multi-tab doc; ...)` to stderr.
+
 ## [0.7.2] — 2026-05-07
 
 ### Fixed

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -920,6 +920,7 @@ def cmd_push(args) -> int:
     file_path = args.file
     quiet = getattr(args, "quiet", False)
     force = getattr(args, "force", False)
+    force_collapse = getattr(args, "force_collapse_tabs", False)
 
     # Read local file (fail fast)
     if not os.path.isfile(file_path):
@@ -944,6 +945,22 @@ def cmd_push(args) -> int:
 
     # Conflict detection (reuse shared helper)
     change_info = _check_write_conflict(doc_id, quiet, force)
+
+    # Refuse destructive multi-tab collapse unless the user opts in.
+    # `pull`/`push` round-trips a multi-tab doc through a flat markdown
+    # file, so an unguarded push silently deletes every tab but the
+    # first. Mirror the safety check from `cmd_write`.
+    if not force_collapse:
+        from gdoc.api.docs import count_document_tabs
+        tab_count = count_document_tabs(doc_id)
+        if tab_count > 1:
+            raise GdocError(
+                f"push would collapse {tab_count} tabs into 1. "
+                "Use `gdoc edit --tab NAME` for find/replace within a "
+                "tab, `gdoc insert --tab NAME FILE` to add content to a "
+                "tab, or pass --force-collapse-tabs to confirm.",
+                exit_code=3,
+            )
 
     # Upload body (frontmatter stripped)
     from gdoc.api.drive import update_doc_content
@@ -1002,6 +1019,21 @@ def cmd_sync_hook(args) -> int:
             return 0
 
         doc_id = _resolve_doc_id(metadata["gdoc"])
+
+        # Refuse to silently flatten a multi-tab doc. The hook runs
+        # without user attention on every matching file edit, so there
+        # is no safe way to surface a confirmation prompt — skip
+        # entirely and log to stderr.
+        from gdoc.api.docs import count_document_tabs
+        if count_document_tabs(doc_id) > 1:
+            title = metadata.get("title", doc_id)
+            print(
+                f'SYNC: skipped "{title}" (multi-tab doc; sync would '
+                "collapse tabs). Use `gdoc edit --tab` or "
+                "`gdoc insert --tab` to write to a specific tab.",
+                file=sys.stderr,
+            )
+            return 0
 
         from gdoc.api.drive import update_doc_content
 
@@ -2123,6 +2155,10 @@ def build_parser() -> GdocArgumentParser:
     push_p.add_argument("file", help="Local file with gdoc frontmatter")
     push_p.add_argument(
         "--force", action="store_true", help="Force overwrite even if doc changed"
+    )
+    push_p.add_argument(
+        "--force-collapse-tabs", action="store_true",
+        help="Confirm you intend to collapse a multi-tab doc into one tab",
     )
     push_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.7.2"
+version = "0.7.3"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -17,6 +17,7 @@ def _make_args(**overrides):
         "command": "push",
         "file": "/tmp/test.md",
         "force": False,
+        "force_collapse_tabs": False,
         "json": False,
         "verbose": False,
         "quiet": False,
@@ -26,6 +27,20 @@ def _make_args(**overrides):
 
 
 FRONTMATTER = "---\ngdoc: abc123\ntitle: My Doc\n---\n"
+
+
+@pytest.fixture(autouse=True)
+def _stub_single_tab():
+    """Default `count_document_tabs` to `1` for the whole test module.
+
+    Mirrors the pattern from `test_write.py`: legacy push tests assume
+    a single-tab doc, and the new multi-tab safety check would
+    otherwise call the real Docs API. Tests that need a different
+    count stack their own `@patch("gdoc.api.docs.count_document_tabs",
+    ...)` on top.
+    """
+    with patch("gdoc.api.docs.count_document_tabs", return_value=1):
+        yield
 
 
 class TestPushBasic:
@@ -278,3 +293,47 @@ class TestPushPlain:
         out = capsys.readouterr().out
         assert "id\tabc123" in out
         assert "status\tupdated" in out
+
+
+class TestPushCollapseSafety:
+    """Pushes against multi-tab docs without --force-collapse-tabs fail."""
+
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.api.docs.count_document_tabs", return_value=3)
+    @patch("gdoc.notify.pre_flight")
+    def test_refuses_multi_tab_without_flag(
+        self, mock_pf, _mock_count, mock_update, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text(FRONTMATTER + "# Hello\n")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(file=str(f), force_collapse_tabs=False)
+        with pytest.raises(GdocError, match="collapse 3 tabs") as exc:
+            cmd_push(args)
+        msg = str(exc.value)
+        assert "--force-collapse-tabs" in msg
+        assert "--tab" in msg
+        assert "insert" in msg
+        # Critical: the destructive write must not have fired.
+        mock_update.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.api.docs.count_document_tabs")
+    @patch("gdoc.notify.pre_flight")
+    def test_force_collapse_bypasses_check(
+        self, mock_pf, mock_count, mock_update, _u, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text(FRONTMATTER + "# Hello\n")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(file=str(f), force_collapse_tabs=True)
+        rc = cmd_push(args)
+        assert rc == 0
+        # With the opt-in flag, no count lookup happens at all.
+        mock_count.assert_not_called()
+        mock_update.assert_called_once()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -312,6 +312,7 @@ class TestPushCollapseSafety:
         args = _make_args(file=str(f), force_collapse_tabs=False)
         with pytest.raises(GdocError, match="collapse 3 tabs") as exc:
             cmd_push(args)
+        assert exc.value.exit_code == 3
         msg = str(exc.value)
         assert "--force-collapse-tabs" in msg
         assert "--tab" in msg

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -5,6 +5,8 @@ import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from gdoc.cli import cmd_sync_hook
 
 
@@ -15,6 +17,18 @@ def _make_args():
 def _stdin_json(file_path):
     data = {"tool_input": {"file_path": file_path}}
     return io.StringIO(json.dumps(data))
+
+
+@pytest.fixture(autouse=True)
+def _stub_single_tab():
+    """Default `count_document_tabs` to `1` for the whole test module.
+
+    The multi-tab safety check would otherwise call the real Docs API.
+    Tests asserting the multi-tab skip override this with their own
+    patch.
+    """
+    with patch("gdoc.api.docs.count_document_tabs", return_value=1):
+        yield
 
 
 class TestSyncHookBasic:
@@ -128,3 +142,25 @@ class TestSyncHookErrorHandling:
         with patch("sys.stdin", _stdin_json(str(f))):
             rc = cmd_sync_hook(args)
         assert rc == 0
+
+
+class TestSyncHookMultiTabSafety:
+    """Sync hook must not silently flatten a multi-tab doc."""
+
+    @patch("gdoc.api.docs.count_document_tabs", return_value=3)
+    @patch("gdoc.api.drive.update_doc_content")
+    def test_skip_multi_tab(
+        self, mock_update_doc, _count, tmp_path, capsys,
+    ):
+        f = tmp_path / "spec.md"
+        f.write_text("---\ngdoc: abc123\ntitle: My Doc\n---\n# Hello\n")
+        args = _make_args()
+        with patch("sys.stdin", _stdin_json(str(f))):
+            rc = cmd_sync_hook(args)
+        assert rc == 0
+        # Critical: the destructive write must not have fired.
+        mock_update_doc.assert_not_called()
+        err = capsys.readouterr().err
+        assert "SYNC: skipped" in err
+        assert "My Doc" in err
+        assert "multi-tab" in err

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.7.1"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
PR #13 added a multi-tab safety check to `gdoc write`. The same
flatten-on-write footgun still exists in `push` (silently overwrites
the whole doc) and `_sync-hook` (silently calls `update_doc_content`
on every matching file edit). This PR mirrors #13's pattern across
the two remaining destructive paths.

- `push` refuses multi-tab docs without `--force-collapse-tabs`,
  using the same flag name, error wording, exit code, and helper
  (`count_document_tabs`) as `cmd_write`. The guard runs before
  `update_doc_content` so a refused push performs no API write.
- `_sync-hook` hard-skips multi-tab docs and logs
  `SYNC: skipped "<title>" (multi-tab doc; ...)` to stderr,
  matching the existing `SYNC: pushed to "<title>"` line. The hook
  runs without user attention on every PostToolUse fire, so refusing
  via `GdocError` would be swallowed by the hook's catch-all
  `except: pass`; explicit early return is the equivalent of the
  refusal pattern in a non-interactive context.

Read-only commands (`pull`, `cat`) intentionally untouched: PR #13
was scoped to destructive operations and this PR keeps that scope.
A `pull` without a follow-up `push` is harmless, and the `push`
refusal alone closes the destruction loop.

Test changes:
- `_stub_single_tab` autouse fixture in `test_push` and
  `test_sync_hook` (mirrors the pattern in `test_write`).
- `TestPushCollapseSafety` and `TestSyncHookMultiTabSafety` test
  classes covering refusal, the `--force-collapse-tabs` bypass,
  the no-API-write invariant, and the skip log.
- 839 tests pass.

Real-world motivation: a `gdoc pull` followed by `gdoc push` on a
multi-tab call-summary doc deleted every tab but one, with no
warning, on 0.7.1. The user only noticed after re-opening the doc
and finding it stripped to a single tab. With this PR the same
sequence exits 3 at `push` time before any API write.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `gdoc push` now protects multi-tab documents from accidental overwrite; use an opt-in `--force-collapse-tabs` flag to proceed.
  * The non-interactive sync hook now detects multi-tab documents and skips syncing instead of collapsing tabs.

* **Chores**
  * Release updated to version 0.7.2 and changelog entry added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucaDeLeo/gdoc/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->