### PR TITLE
Fix default account auth resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] — 2026-05-23
+
+### Added
+- **`gdoc auth --set-default ACCOUNT`** — configure which authenticated
+  named account bare `gdoc` commands use when `--account` and
+  `GDOC_ACCOUNT` are omitted.
+
+### Fixed
+- The default account now resolves to the configured named account token
+  instead of requiring a separate `~/.config/gdoc/token.json` credential.
+  The legacy token remains as a fallback when no default account is
+  configured.
+
 ## [0.7.3] — 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ gdoc auth
 
 This opens a browser for the OAuth flow. Use `--no-browser` for headless environments (prints a URL to visit manually).
 
+For multiple Google accounts, authenticate each named account with
+`--account`:
+
+```bash
+gdoc auth --account pete@example.com
+gdoc auth --account work@example.com
+```
+
+The first named account you authenticate becomes the default for bare
+`gdoc` commands. To change it later without reauthenticating:
+
+```bash
+gdoc auth --set-default pete@example.com
+```
+
 ## Quick start
 
 ```bash
@@ -317,7 +332,9 @@ All files are stored under `~/.config/gdoc/`:
 | File | Purpose |
 |------|---------|
 | `credentials.json` | OAuth client credentials (from Google Cloud Console) |
-| `token.json` | Stored OAuth token (created by `gdoc auth`) |
+| `token.json` | Legacy default OAuth token (created by older `gdoc auth` flows) |
+| `accounts/<ACCOUNT>/token.json` | OAuth token for a named account |
+| `config.json` | Default account preference and other local configuration |
 | `state/<DOC_ID>.json` | Per-document state for change detection |
 
 ## Development

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/gdoc/auth.py
+++ b/gdoc/auth.py
@@ -10,7 +10,15 @@ from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 
-from gdoc.util import AuthError, CONFIG_DIR, CREDS_PATH, TOKEN_PATH, get_token_path
+from gdoc.util import (
+    CONFIG_DIR,
+    CREDS_PATH,
+    TOKEN_PATH,
+    AuthError,
+    get_default_account,
+    get_token_path,
+    set_default_account,
+)
 
 SCOPES = [
     "https://www.googleapis.com/auth/drive",
@@ -21,7 +29,7 @@ SCOPES = [
 def get_credentials() -> Credentials:
     """Load or refresh credentials. Returns valid Credentials or raises AuthError."""
     from gdoc.util import get_active_account
-    account = get_active_account()
+    account = get_active_account() or get_default_account()
     if not account:
         print("account: default (use --account to switch)", file=sys.stderr)
 
@@ -39,10 +47,11 @@ def get_credentials() -> Credentials:
         except Exception:
             pass
 
-    from gdoc.util import get_active_account
-    account = get_active_account()
     hint = f" (account: {account})" if account else ""
-    raise AuthError(f"Not authenticated{hint}. Run `gdoc auth{' --account ' + account if account else ''}` to authenticate.")
+    command_hint = f" --account {account}" if account else ""
+    raise AuthError(
+        f"Not authenticated{hint}. Run `gdoc auth{command_hint}` to authenticate."
+    )
 
 
 def authenticate(no_browser: bool = False) -> Credentials:
@@ -79,6 +88,10 @@ def authenticate(no_browser: bool = False) -> Credentials:
     token_path = get_token_path()
     token_path.parent.mkdir(parents=True, exist_ok=True)
     _save_token(creds, token_path)
+    from gdoc.util import get_active_account
+    account = get_active_account()
+    if account and not get_default_account():
+        set_default_account(account)
     print(
         f"OK authenticated successfully. Credentials stored in {token_path}",
         file=sys.stderr,
@@ -118,11 +131,15 @@ def _save_token(creds: Credentials, token_path: Path | None = None) -> None:
 def list_accounts() -> list[str]:
     """List all authenticated accounts.
 
-    Returns account names, with 'default' for the base token.
+    Returns account names. A configured default is shown as an alias to its named
+    account; the base token is shown as a legacy default fallback.
     """
     accounts = []
-    if TOKEN_PATH.exists():
-        accounts.append("default")
+    default_account = get_default_account()
+    if default_account:
+        accounts.append(f"default -> {default_account}")
+    elif TOKEN_PATH.exists():
+        accounts.append("default (legacy)")
     accounts_dir = CONFIG_DIR / "accounts"
     if accounts_dir.is_dir():
         for entry in sorted(accounts_dir.iterdir()):
@@ -153,3 +170,15 @@ def remove_account(account: str) -> None:
     except OSError:
         pass
     print(f"OK removed credentials for account: {account}", file=sys.stderr)
+
+
+def configure_default_account(account: str) -> None:
+    """Configure the default account alias."""
+    from gdoc.util import _validate_account_name
+
+    _validate_account_name(account)
+    token = CONFIG_DIR / "accounts" / account / "token.json"
+    if not token.exists():
+        raise AuthError(f"No credentials found for account: {account}")
+    set_default_account(account)
+    print(f"OK default account set to: {account}", file=sys.stderr)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1589,6 +1589,12 @@ def cmd_images(args) -> int:
 
 def cmd_auth(args) -> int:
     """Handler for `gdoc auth`."""
+    set_default = getattr(args, "set_default", None)
+    if set_default:
+        from gdoc.auth import configure_default_account
+        configure_default_account(set_default)
+        return 0
+
     if getattr(args, "list", False):
         from gdoc.auth import list_accounts
         accounts = list_accounts()
@@ -1941,15 +1947,21 @@ def build_parser() -> GdocArgumentParser:
         action="store_true",
         help="Don't open browser, print URL for manual auth",
     )
-    auth_p.add_argument(
+    auth_action = auth_p.add_mutually_exclusive_group()
+    auth_action.add_argument(
         "--list",
         action="store_true",
         help="List all authenticated accounts",
     )
-    auth_p.add_argument(
+    auth_action.add_argument(
         "--remove",
         metavar="ACCOUNT",
         help="Remove credentials for a named account",
+    )
+    auth_action.add_argument(
+        "--set-default",
+        metavar="ACCOUNT",
+        help="Use an authenticated named account when --account is omitted",
     )
     auth_p.add_argument(
         "--force", "-y",

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -1,5 +1,6 @@
 """URL-to-ID extraction, error classes, and constants."""
 
+import json
 import re
 from pathlib import Path
 
@@ -30,6 +31,7 @@ if _OLD_CONFIG_DIR.is_dir() and not CONFIG_DIR.exists():
 TOKEN_PATH = CONFIG_DIR / "token.json"
 CREDS_PATH = CONFIG_DIR / "credentials.json"
 STATE_DIR = CONFIG_DIR / "state"
+CONFIG_PATH = CONFIG_DIR / "config.json"
 
 # Multi-account support: when set, token is stored under a per-account dir
 _active_account: str | None = None
@@ -59,14 +61,55 @@ def get_active_account() -> str | None:
     return _active_account
 
 
+def _load_config() -> dict:
+    """Load gdoc config with defensive fallback for invalid JSON."""
+    if not CONFIG_PATH.exists():
+        return {}
+    try:
+        with CONFIG_PATH.open() as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _save_config(config: dict) -> None:
+    """Save gdoc config."""
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+
+
+def get_default_account() -> str | None:
+    """Return the configured default named account, if any."""
+    account = _load_config().get("default_account")
+    if isinstance(account, str) and account:
+        _validate_account_name(account)
+        return account
+    return None
+
+
+def set_default_account(account: str) -> None:
+    """Set the default named account used when --account is omitted."""
+    _validate_account_name(account)
+    config = _load_config()
+    config["default_account"] = account
+    _save_config(config)
+
+
 def get_token_path() -> Path:
     """Return the token path for the active account.
 
-    Default account uses CONFIG_DIR/token.json (backward-compatible).
+    Configured default accounts resolve to the named account token.
+    CONFIG_DIR/token.json is only a legacy fallback.
     Named accounts use CONFIG_DIR/accounts/<account>/token.json.
     """
     if _active_account:
         return CONFIG_DIR / "accounts" / _active_account / "token.json"
+    default_account = get_default_account()
+    if default_account:
+        return CONFIG_DIR / "accounts" / default_account / "token.json"
     return TOKEN_PATH
 
 _PATTERNS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.7.3"
+version = "0.7.4"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,5 @@
 """Tests for gdoc.auth: OAuth2 flow, token management, and credential storage."""
 
-import json
 import os
 import subprocess
 import sys
@@ -9,8 +8,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from gdoc.auth import _load_token, _save_token, authenticate, get_credentials
-from gdoc.util import AuthError
+from gdoc.auth import (
+    _load_token,
+    _save_token,
+    authenticate,
+    configure_default_account,
+    get_credentials,
+    list_accounts,
+)
+from gdoc.util import (
+    AuthError,
+    get_default_account,
+    get_token_path,
+    set_active_account,
+    set_default_account,
+)
 
 REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 
@@ -36,6 +48,8 @@ class TestAuthenticate:
             patch("gdoc.auth.CREDS_PATH", fake_creds),
             patch("gdoc.auth.TOKEN_PATH", fake_token),
             patch("gdoc.auth.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.TOKEN_PATH", fake_token),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
             patch(
                 "gdoc.auth.InstalledAppFlow.from_client_secrets_file",
                 return_value=mock_flow,
@@ -54,18 +68,26 @@ class TestAuthenticate:
         mock_flow = MagicMock()
         mock_creds = MagicMock()
         mock_creds.to_json.return_value = '{"token": "test"}'
-        mock_flow.authorization_url.return_value = ("https://accounts.google.com/o/oauth2/auth?...", "state")
+        mock_flow.authorization_url.return_value = (
+            "https://accounts.google.com/o/oauth2/auth?...",
+            "state",
+        )
         mock_flow.credentials = mock_creds
 
         with (
             patch("gdoc.auth.CREDS_PATH", fake_creds),
             patch("gdoc.auth.TOKEN_PATH", fake_token),
             patch("gdoc.auth.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.TOKEN_PATH", fake_token),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
             patch(
                 "gdoc.auth.InstalledAppFlow.from_client_secrets_file",
                 return_value=mock_flow,
             ),
-            patch("builtins.input", return_value="http://localhost:1/?code=test-auth-code&scope=test"),
+            patch(
+                "builtins.input",
+                return_value="http://localhost:1/?code=test-auth-code&scope=test",
+            ),
         ):
             result = authenticate(no_browser=True)
 
@@ -82,21 +104,59 @@ class TestAuthenticate:
         fake_token = tmp_path / "token.json"
 
         mock_flow = MagicMock()
-        mock_flow.authorization_url.return_value = ("https://accounts.google.com/o/oauth2/auth?...", "state")
+        mock_flow.authorization_url.return_value = (
+            "https://accounts.google.com/o/oauth2/auth?...",
+            "state",
+        )
         mock_flow.fetch_token.side_effect = Exception("invalid_grant")
 
         with (
             patch("gdoc.auth.CREDS_PATH", fake_creds),
             patch("gdoc.auth.TOKEN_PATH", fake_token),
             patch("gdoc.auth.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.TOKEN_PATH", fake_token),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
             patch(
                 "gdoc.auth.InstalledAppFlow.from_client_secrets_file",
                 return_value=mock_flow,
             ),
-            patch("builtins.input", return_value="http://localhost:1/?code=bad-code&scope=test"),
+            patch(
+                "builtins.input",
+                return_value="http://localhost:1/?code=bad-code&scope=test",
+            ),
         ):
-            with pytest.raises(AuthError, match="Failed to exchange authorization code"):
+            with pytest.raises(
+                AuthError, match="Failed to exchange authorization code"
+            ):
                 authenticate(no_browser=True)
+
+    def test_named_auth_sets_default_account_when_missing(self, tmp_path):
+        fake_creds = tmp_path / "credentials.json"
+        fake_creds.write_text("{}")
+        fake_config = tmp_path / "config.json"
+
+        mock_flow = MagicMock()
+        mock_creds = MagicMock()
+        mock_creds.to_json.return_value = '{"token": "test"}'
+        mock_flow.run_local_server.return_value = mock_creds
+
+        with (
+            patch("gdoc.auth.CREDS_PATH", fake_creds),
+            patch("gdoc.util.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_PATH", fake_config),
+            patch(
+                "gdoc.auth.InstalledAppFlow.from_client_secrets_file",
+                return_value=mock_flow,
+            ),
+        ):
+            set_active_account("pete@example.com")
+            try:
+                authenticate(no_browser=False)
+                assert get_default_account() == "pete@example.com"
+            finally:
+                set_active_account(None)
+
+        assert (tmp_path / "accounts" / "pete@example.com" / "token.json").exists()
 
 
 class TestGetCredentials:
@@ -146,6 +206,79 @@ class TestGetCredentials:
         ):
             with pytest.raises(AuthError, match="Not authenticated"):
                 get_credentials()
+
+
+class TestDefaultAccount:
+    def test_configured_default_resolves_to_named_token(self, tmp_path):
+        with (
+            patch("gdoc.util.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
+            patch("gdoc.util.TOKEN_PATH", tmp_path / "token.json"),
+        ):
+            set_active_account(None)
+            set_default_account("pete@example.com")
+
+            assert get_token_path() == (
+                tmp_path / "accounts" / "pete@example.com" / "token.json"
+            )
+
+    def test_explicit_account_overrides_configured_default(self, tmp_path):
+        with (
+            patch("gdoc.util.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
+            patch("gdoc.util.TOKEN_PATH", tmp_path / "token.json"),
+        ):
+            set_default_account("pete@example.com")
+            set_active_account("work@example.com")
+            try:
+                assert get_token_path() == (
+                    tmp_path / "accounts" / "work@example.com" / "token.json"
+                )
+            finally:
+                set_active_account(None)
+
+    def test_can_configure_default_to_existing_named_account(self, tmp_path):
+        account_token = tmp_path / "accounts" / "pete@example.com" / "token.json"
+        account_token.parent.mkdir(parents=True)
+        account_token.write_text("{}")
+
+        with (
+            patch("gdoc.auth.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
+        ):
+            configure_default_account("pete@example.com")
+
+            assert get_default_account() == "pete@example.com"
+
+    def test_configure_default_requires_existing_named_account(self, tmp_path):
+        with (
+            patch("gdoc.auth.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
+        ):
+            with pytest.raises(AuthError, match="No credentials found"):
+                configure_default_account("missing@example.com")
+
+    def test_list_accounts_shows_configured_default_as_alias(self, tmp_path):
+        legacy_token = tmp_path / "token.json"
+        legacy_token.write_text("{}")
+        account_token = tmp_path / "accounts" / "pete@example.com" / "token.json"
+        account_token.parent.mkdir(parents=True)
+        account_token.write_text("{}")
+
+        with (
+            patch("gdoc.auth.CONFIG_DIR", tmp_path),
+            patch("gdoc.auth.TOKEN_PATH", legacy_token),
+            patch("gdoc.util.CONFIG_DIR", tmp_path),
+            patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"),
+        ):
+            set_default_account("pete@example.com")
+
+            assert list_accounts() == [
+                "default -> pete@example.com",
+                "pete@example.com",
+            ]
 
 
 class TestLoadToken:

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
- make the default account a config alias to a named account instead of a separate token slot
- add `gdoc auth --set-default ACCOUNT` for repairing/changing the default without reauthenticating
- keep `~/.config/gdoc/token.json` as a legacy fallback when no default account is configured
- update auth docs and changelog

## Why
With multi-account auth, `gdoc auth --account pete@example.com` stores a valid named token, but bare `gdoc ...` still reads `~/.config/gdoc/token.json`. If that legacy default token is stale or missing, users can appear to have lost auth even though the named account token is valid.

## Tests
- `uv run pytest tests/test_auth.py`
- `uv run ruff check gdoc/auth.py gdoc/util.py tests/test_auth.py`
- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gdoc auth --set-default ACCOUNT` command to configure which named account is used by default for all commands

* **Bug Fixes**
  * Default account now properly resolves to configured named account credentials instead of requiring a separate legacy token file

* **Documentation**
  * Updated authentication guide with examples for multi-account setup and default account configuration
  * Clarified token storage locations for legacy and per-account credentials

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucaDeLeo/gdoc/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->