### PR TITLE
fix: correct toc deep-link tab id prefix and fragment placement

### DIFF
--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -251,11 +251,15 @@ def cmd_toc(args) -> int:
     if max_depth > 0:
         headings = [h for h in headings if h["level"] <= max_depth]
 
-    base_url = f"https://docs.google.com/document/d/{doc_id}/edit"
-    tab_suffix = f"&tab=t.{tab_id}" if tab_id else ""
+    from gdoc.util import build_doc_url
+
+    # build_doc_url emits `?tab=<tab_id>` as a query parameter before the
+    # fragment, and tab_id already carries Google's `t.` prefix. The heading
+    # anchor is the URL fragment, so it must come last.
+    base_url = build_doc_url(doc_id, tab_id=tab_id)
 
     def _link(heading_id: str) -> str:
-        return f"{base_url}#heading={heading_id}{tab_suffix}"
+        return f"{base_url}#heading={heading_id}"
 
     from gdoc.format import format_json, get_output_mode
 

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -166,13 +166,17 @@ class TestTocTab:
     def test_tab_appends_tab_id_to_links(
         self, _svc, mock_tabs, mock_resolve, mock_headings, _pf, _update, capsys,
     ):
-        mock_tabs.return_value = [{"id": "t1", "title": "Notes", "body": {}}]
-        mock_resolve.return_value = {"id": "t1", "title": "Notes", "body": {}}
+        # Google returns tabId already prefixed with "t." — pass it through
+        # verbatim as a query parameter, with the heading anchor as the fragment.
+        tab = {"id": "t.o50waw95wxfc", "title": "Notes", "body": {}}
+        mock_tabs.return_value = [tab]
+        mock_resolve.return_value = tab
         mock_headings.return_value = _headings((1, "h.abc", "Title"))
         rc = cmd_toc(_make_args(tab="Notes"))
         assert rc == 0
         out = capsys.readouterr().out
-        assert "&tab=t.t1" in out
+        assert f"{BASE_URL}?tab=t.o50waw95wxfc#heading=h.abc" in out
+        assert "t.t." not in out
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
@@ -183,13 +187,15 @@ class TestTocTab:
     def test_tab_json_includes_tab_in_links(
         self, _svc, mock_tabs, mock_resolve, mock_headings, _pf, _update, capsys,
     ):
-        mock_tabs.return_value = [{"id": "t1", "title": "Notes", "body": {}}]
-        mock_resolve.return_value = {"id": "t1", "title": "Notes", "body": {}}
+        tab = {"id": "t.o50waw95wxfc", "title": "Notes", "body": {}}
+        mock_tabs.return_value = [tab]
+        mock_resolve.return_value = tab
         mock_headings.return_value = _headings((1, "h.abc", "Title"))
         rc = cmd_toc(_make_args(tab="Notes", json=True))
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
-        assert "&tab=t.t1" in data["headings"][0]["link"]
+        link = data["headings"][0]["link"]
+        assert link == f"{BASE_URL}?tab=t.o50waw95wxfc#heading=h.abc"
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)


### PR DESCRIPTION
## Summary

`gdoc toc --tab` emits heading deep links that don't match the structure Google Docs itself produces. Each link has the tab-id prefix **doubled** (`t.t.<id>` instead of `t.<id>`) and places `tab=…` **inside the URL fragment** (after `#`) rather than as a query parameter (before `#`), so the links don't reliably open the right tab/heading.

**Observed:**
```
…/edit#heading=h.<anchor>&tab=t.t.<id>
```
**Expected (matches what Google Docs itself generates):**
```
…/edit?tab=t.<id>#heading=h.<anchor>
```

## Root cause

`cmd_toc` hand-built the URL with its own convention:

```python
tab_suffix = f"&tab=t.{tab_id}" if tab_id else ""
return f"{base_url}#heading={heading_id}{tab_suffix}"
```

- **Doubled prefix** — Google's `tabProperties.tabId` already starts with `t.` (e.g. `t.xxxxxxxx`), so prepending another `t.` yields `t.t.…`.
- **Tab in fragment** — `&tab=…` was appended *after* `#heading=…`, landing it in the fragment instead of the query string.

The rest of the codebase already builds tab URLs correctly via `build_doc_url()`, which passes the id through verbatim as `?tab=` before any fragment. The two conventions disagreed for the same field (`tabProperties.tabId`). CI missed it because both the `toc` test and the `build_doc_url`/`tabs` tests mocked fake ids *without* the real `t.` prefix.

## Fix

`cmd_toc` now reuses `build_doc_url(doc_id, tab_id=tab_id)` and appends `#heading=…` as the fragment, matching Google's own deep-link shape:

```
…/edit?tab=t.<id>#heading=h.<anchor>
```

The two `toc` tab tests now mock a realistic prefixed id and assert the canonical form (plus a `t.t.` guard).

## Verification

- Full suite: **845 passed**; no new lint errors in the touched files.
- The updated tests were confirmed to **fail against the pre-fix code** (genuine regression guards, not no-ops).
- **Live against the real Google Docs API** on a multi-tab doc (36 headings): **0** doubled prefixes, **0** tab-in-fragment, **36/36** links in canonical `?tab=t.<id>#heading=h.<anchor>` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed table of contents link generation to correctly format Google Docs URLs with both tab parameters and heading anchors, ensuring links navigate to the intended section in the correct tab view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucaDeLeo/gdoc/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->