### PR TITLE
edit: work inside tables, plus cell addressing, --normalize, and stdin anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.6] — 2026-06-02
 
 ### Added
 - **`gdoc edit` now works inside tables.** `find_text_in_document` descends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to `gdoc` are documented here. This project follows
   (`--cell ROW,COL`, `--table N`) indexes a cell by position. Empty cells are
   filled in place.
 - **`gdoc edit --normalize`** — match through smart-quote/dash differences
-  (e.g. `'` matches `'`). Exact by default.
+  (e.g. `’` matches `'`). Exact by default.
 - **`-` reads an argument from stdin** for `gdoc edit`, enabling heredocs and
   pipes for multi-line anchors/replacements (at most one `-`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`gdoc edit` now works inside tables.** `find_text_in_document` descends
+  into table cells (and nested tables), so search/replace finds text that was
+  previously invisible — `edit` used to return "no match found" for in-table
+  text that `cat` could read.
+- **`gdoc edit --cell ADDR`** — address a table cell directly instead of
+  anchoring on its text. Label mode (`--cell "Discussion topics"`) replaces the
+  cell to the label's right (`--col` to override); coordinate mode
+  (`--cell ROW,COL`, `--table N`) indexes a cell by position. Empty cells are
+  filled in place.
+- **`gdoc edit --normalize`** — match through smart-quote/dash differences
+  (e.g. `'` matches `'`). Exact by default.
+- **`-` reads an argument from stdin** for `gdoc edit`, enabling heredocs and
+  pipes for multi-line anchors/replacements (at most one `-`).
+
+### Changed
+- A failed `edit` match now explains why (smart-quote or whitespace near-match)
+  instead of a bare "no match found".
+
 ## [0.7.5] — 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ gdoc cat 1aBcDeFg...
 
 | Command | Description |
 |---------|-------------|
-| `edit DOC OLD NEW` | Find and replace text with markdown formatting, including text inside tables (`--all` for all; `--normalize` to match through smart quotes/dashes; `-` reads an argument from stdin) |
+| `edit DOC OLD NEW` | Find and replace text with Markdown formatting, including text inside tables (`--all` for all; `--normalize` to match through smart quotes/dashes; `-` reads an argument from stdin) |
 | `edit DOC --cell ADDR NEW` | Replace a table cell by label or `ROW,COL` coordinates (`--col`, `--table`) |
 | `write DOC FILE` | Overwrite document from a local markdown file |
 | `new TITLE` | Create a blank document (`--folder` to specify location, `--file` to import markdown with images) |
@@ -281,11 +281,11 @@ gdoc edit DOC --cell 7,1 "new value"
 gdoc edit DOC --cell "Status" --col 2 "Done"
 ```
 
-Cell edits preserve the cell's paragraph structure; an empty cell is filled in place. The replacement supports the same markdown formatting as a normal `edit`.
+Cell edits preserve the cell's paragraph structure; an empty cell is filled in place. The replacement supports the same Markdown formatting as a normal `edit`.
 
 ### Matching tolerance
 
-By default matching is exact. If an anchor isn't found, `edit` explains why — most often a smart-quote apostrophe (`'` vs `'`) or a line break where the anchor had a space. Pass `--normalize` to match through smart-quote and dash differences:
+By default matching is exact. If an anchor isn't found, `edit` explains why — most often a smart-quote apostrophe (`’` vs `'`) or a line break where the anchor had a space. Pass `--normalize` to match through smart-quote and dash differences:
 
 ```bash
 gdoc edit DOC "JP's job" "JP's role" --normalize   # matches "JP's job" in the doc

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ gdoc cat 1aBcDeFg...
 
 | Command | Description |
 |---------|-------------|
-| `edit DOC OLD NEW` | Find and replace text with markdown formatting, including tables (`--all` for all) |
+| `edit DOC OLD NEW` | Find and replace text with markdown formatting, including text inside tables (`--all` for all; `--normalize` to match through smart quotes/dashes; `-` reads an argument from stdin) |
+| `edit DOC --cell ADDR NEW` | Replace a table cell by label or `ROW,COL` coordinates (`--col`, `--table`) |
 | `write DOC FILE` | Overwrite document from a local markdown file |
 | `new TITLE` | Create a blank document (`--folder` to specify location, `--file` to import markdown with images) |
 | `cp DOC TITLE` | Duplicate a document |
@@ -264,6 +265,39 @@ gdoc edit DOC "placeholder" "| Name | Score |
 ```
 
 Tables require a single match — use without `--all` when the replacement contains a table.
+
+## Editing inside tables
+
+`edit` searches and replaces text inside table cells, not just plain paragraphs. For label/value grids (a label in one column, the value in the next), address a cell directly instead of anchoring on its current text:
+
+```bash
+# Replace the cell to the right of a label
+gdoc edit DOC --tab "Tab 1" --cell "Discussion topics from JP" "Show and tell; Q2 planning"
+
+# Address by ROW,COL coordinates (0-based) within the Nth table (--table, default 0)
+gdoc edit DOC --cell 7,1 "new value"
+
+# --col overrides which column to write (default: the one right of the label)
+gdoc edit DOC --cell "Status" --col 2 "Done"
+```
+
+Cell edits preserve the cell's paragraph structure; an empty cell is filled in place. The replacement supports the same markdown formatting as a normal `edit`.
+
+### Matching tolerance
+
+By default matching is exact. If an anchor isn't found, `edit` explains why — most often a smart-quote apostrophe (`'` vs `'`) or a line break where the anchor had a space. Pass `--normalize` to match through smart-quote and dash differences:
+
+```bash
+gdoc edit DOC "JP's job" "JP's role" --normalize   # matches "JP's job" in the doc
+```
+
+### Multi-line arguments from stdin
+
+Pass `-` for the old or new argument to read it from stdin (one stream, so at most one `-`):
+
+```bash
+printf 'line one\nline two' | gdoc edit DOC --cell "Notes" -
+```
 
 ## Import from file
 

--- a/gdoc.md
+++ b/gdoc.md
@@ -20,8 +20,12 @@ gdoc cat DOC_ID --comments                   # Line-numbered with comment annota
 gdoc cat DOC_ID --plain                      # Export as plain text
 gdoc cat DOC_ID > local.md                   # Save locally
 
-gdoc edit DOC_ID "old text" "new text"       # Find unique match & replace
+gdoc edit DOC_ID "old text" "new text"       # Find unique match & replace (works inside tables)
 gdoc edit DOC_ID "old text" "new text" --all # Replace all occurrences
+gdoc edit DOC_ID "old" "new" --normalize     # Match through smart quotes/dashes (’ matches ')
+gdoc edit DOC_ID --cell "Label" "new value"  # Replace the table cell right of a label
+gdoc edit DOC_ID --cell 7,1 "new value"      # Replace cell by ROW,COL (--table N, default 0)
+printf 'multi\nline' | gdoc edit DOC_ID --cell "Notes" -  # '-' reads an arg from stdin
 gdoc write DOC_ID FILE.md                    # Overwrite doc body from local markdown
 
 gdoc comments DOC_ID                         # List open comments

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -191,6 +191,35 @@ def get_document(doc_id: str) -> dict:
         _translate_http_error(e, doc_id)
 
 
+def _collect_chars(content: list[dict], chars: list[tuple[int, str]]) -> None:
+    """Append (doc_index, char) pairs for all text in body content.
+
+    Walks paragraph.elements → textRun.content and recurses into table
+    cells (and nested tables), so text inside tables is searchable. Mirrors
+    the cell walk in get_tab_text(). Document order is preserved: a cell's
+    paragraphs end in a trailing "\\n", which keeps the concat boundary
+    between cells and prevents a match from spanning two cells — the same
+    guarantee paragraphs already have.
+    """
+    for element in content:
+        paragraph = element.get("paragraph")
+        if paragraph is not None:
+            for pe in paragraph.get("elements", []):
+                text_run = pe.get("textRun")
+                if text_run is None:
+                    continue
+                run = text_run.get("content", "")
+                start_idx = pe.get("startIndex", 0)
+                for i, ch in enumerate(run):
+                    chars.append((start_idx + i, ch))
+            continue
+        table = element.get("table")
+        if table is not None:
+            for row in table.get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    _collect_chars(cell.get("content", []), chars)
+
+
 def find_text_in_document(
     document: dict | None,
     text: str,
@@ -199,7 +228,7 @@ def find_text_in_document(
 ) -> list[dict]:
     """Find all occurrences of text within the document body.
 
-    Walks body.content → paragraph.elements → textRun.content to
+    Walks body.content (paragraphs and table cells) → textRun.content to
     build a concatenated string with position mapping, then searches.
 
     Args:
@@ -218,18 +247,7 @@ def find_text_in_document(
         if document is None:
             return []
         body = document.get("body", {})
-    for element in body.get("content", []):
-        paragraph = element.get("paragraph")
-        if paragraph is None:
-            continue
-        for pe in paragraph.get("elements", []):
-            text_run = pe.get("textRun")
-            if text_run is None:
-                continue
-            content = text_run.get("content", "")
-            start_idx = pe.get("startIndex", 0)
-            for i, ch in enumerate(content):
-                chars.append((start_idx + i, ch))
+    _collect_chars(body.get("content", []), chars)
 
     if not chars:
         return []

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -332,6 +332,102 @@ def diagnose_no_match(
     return None
 
 
+_COORD_RE = re.compile(r"^\s*(\d+)\s*,\s*(\d+)\s*$")
+
+
+def _parse_coord(spec: str) -> tuple[int, int] | None:
+    """Parse 'R,C' into (row, col) ints, or None if not coordinate form."""
+    m = _COORD_RE.match(spec)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return None
+
+
+def _cell_text_range(cell: dict) -> dict | None:
+    """Editable text range of a table cell as {startIndex, endIndex}.
+
+    Spans the cell's text but excludes the final structural paragraph mark
+    (the Docs API forbids deleting a cell's last newline). An empty cell
+    yields a zero-width range → pure insert. Returns None if no paragraph
+    element with an index can be located.
+    """
+    first_start: int | None = None
+    last_start: int | None = None
+    last_content = ""
+    for element in cell.get("content", []):
+        para = element.get("paragraph")
+        if para is None:
+            continue
+        for pe in para.get("elements", []):
+            start = pe.get("startIndex")
+            if start is None:
+                continue
+            if first_start is None:
+                first_start = start
+            tr = pe.get("textRun")
+            last_start = start
+            last_content = tr.get("content", "") if tr else ""
+    if first_start is None:
+        content = cell.get("content", [])
+        fs = content[0].get("startIndex") if content else None
+        return {"startIndex": fs, "endIndex": fs} if fs is not None else None
+    end = last_start + len(last_content)
+    if last_content.endswith("\n"):
+        end -= 1  # keep the cell's final paragraph mark
+    if end < first_start:
+        end = first_start
+    return {"startIndex": first_start, "endIndex": end}
+
+
+def resolve_cell_range(
+    body: dict,
+    cell: str,
+    col: int | None = None,
+    table_index: int = 0,
+    normalize: bool = False,
+) -> dict | None:
+    """Resolve a cell address to an editable {startIndex, endIndex} range.
+
+    Two forms, auto-detected:
+    - coordinate ('R,C'): row R, column C of table `table_index` (0-based).
+    - label (anything else): find the first row cell whose text equals
+      `cell`; the target is column `col` if given, else the cell to its
+      right. Scans every table in document order.
+
+    `normalize` folds smart quotes/dashes when comparing labels. Returns
+    None if nothing resolves.
+    """
+    tables = [el["table"] for el in body.get("content", []) if "table" in el]
+
+    coord = _parse_coord(cell)
+    if coord is not None:
+        r, c = coord
+        if not 0 <= table_index < len(tables):
+            return None
+        rows = tables[table_index].get("tableRows", [])
+        if not 0 <= r < len(rows):
+            return None
+        cells = rows[r].get("tableCells", [])
+        if not 0 <= c < len(cells):
+            return None
+        return _cell_text_range(cells[c])
+
+    target = fold_typography(cell) if normalize else cell
+    target = target.strip()
+    for table in tables:
+        for row in table.get("tableRows", []):
+            cells = row.get("tableCells", [])
+            for ci, c_ in enumerate(cells):
+                label = _extract_paragraphs_text(c_.get("content", []))
+                label = (fold_typography(label) if normalize else label).strip()
+                if label == target:
+                    target_col = col if col is not None else ci + 1
+                    if not 0 <= target_col < len(cells):
+                        return None
+                    return _cell_text_range(cells[target_col])
+    return None
+
+
 def _find_table_cell_indices(
     document: dict | None,
     table_start_index: int,

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -197,7 +197,7 @@ def _collect_segments(content: list[dict]) -> list[list[tuple[int, str]]]:
 
     Paragraph text at one level forms a single segment; each table cell is
     its own segment (recursively, for nested tables). Searching per segment
-    means a match can never span a table-cell boundary — the Docs API can't
+    means a match can never span a table-cell boundary \u2014 the Docs API can't
     delete a range that crosses cells or removes a cell's final paragraph
     mark, so such a match would produce an invalid edit.
     """
@@ -297,7 +297,7 @@ def diagnose_no_match(
 
     Returns a human-readable reason (to append to "no match found") or None
     if no near-match can explain the miss. Runs entirely on the already-
-    fetched document — no extra API calls.
+    fetched document \u2014 no extra API calls.
     """
     # Near-match that differs only in quote/dash style.
     if not already_normalized and find_text_in_document(
@@ -305,7 +305,7 @@ def diagnose_no_match(
     ):
         return (
             "but a near-match exists with different quote/dash style "
-            "(e.g. ’ vs '). Re-run with --normalize to match it"
+            "(e.g. \u2019 vs '). Re-run with --normalize to match it"
         )
 
     # Near-match that differs only in whitespace (line breaks, runs of
@@ -384,16 +384,18 @@ def resolve_cell_range(
     body: dict,
     cell: str,
     col: int | None = None,
-    table_index: int = 0,
+    table_index: int | None = None,
     normalize: bool = False,
 ) -> dict | None:
     """Resolve a cell address to an editable {startIndex, endIndex} range.
 
     Two forms, auto-detected:
-    - coordinate ('R,C'): row R, column C of table `table_index` (0-based).
+    - coordinate ('R,C'): row R, column C of a table (0-based). Uses table
+      `table_index`, or the first table when `table_index` is None.
     - label (anything else): find the first row cell whose text equals
       `cell`; the target is column `col` if given, else the cell to its
-      right. Scans every table in document order.
+      right. Searches every table by default, or only table `table_index`
+      when one is given.
 
     `normalize` folds smart quotes/dashes when comparing labels. Returns
     None if nothing resolves.
@@ -403,9 +405,10 @@ def resolve_cell_range(
     coord = _parse_coord(cell)
     if coord is not None:
         r, c = coord
-        if not 0 <= table_index < len(tables):
+        ti = 0 if table_index is None else table_index
+        if not 0 <= ti < len(tables):
             return None
-        rows = tables[table_index].get("tableRows", [])
+        rows = tables[ti].get("tableRows", [])
         if not 0 <= r < len(rows):
             return None
         cells = rows[r].get("tableCells", [])
@@ -413,9 +416,17 @@ def resolve_cell_range(
             return None
         return _cell_text_range(cells[c])
 
+    # Label mode: honor an explicit --table; otherwise scan all tables.
+    if table_index is None:
+        search_tables = tables
+    elif 0 <= table_index < len(tables):
+        search_tables = [tables[table_index]]
+    else:
+        return None
+
     target = fold_typography(cell) if normalize else cell
     target = target.strip()
-    for table in tables:
+    for table in search_tables:
         for row in table.get("tableRows", []):
             cells = row.get("tableCells", [])
             for ci, c_ in enumerate(cells):
@@ -792,7 +803,7 @@ def _build_cleanup_requests(
 ) -> list[dict]:
     """Build batchUpdate requests to clean up an empty heading paragraph.
 
-    Pure function — inspects body content and returns request dicts
+    Pure function \u2014 inspects body content and returns request dicts
     without making API calls. When the deleted text was the entire
     content of a heading paragraph, an empty "\\n" with the heading
     style remains. This returns requests that transfer that style to
@@ -920,7 +931,7 @@ def insert_markdown_into_tab(
 
     parsed = parse_markdown(markdown)
 
-    # Strip trailing \n — the existing paragraph already owns one.
+    # Strip trailing \n \u2014 the existing paragraph already owns one.
     # Without this, every insert leaves an extra blank line behind.
     if parsed.plain_text.endswith("\n"):
         old_len = len(parsed.plain_text)
@@ -999,7 +1010,7 @@ def replace_formatted(
 
     parsed = parse_markdown(new_markdown)
 
-    # Strip trailing \n — the existing paragraph in the document
+    # Strip trailing \n \u2014 the existing paragraph in the document
     # already has one.  Without this, every replacement inserts an
     # extra paragraph break.
     if parsed.plain_text.endswith("\n"):
@@ -1017,7 +1028,7 @@ def replace_formatted(
     all_requests: list[dict] = []
 
     for match in sorted_matches:
-        # Delete the matched range (skip empty ranges — Docs API rejects
+        # Delete the matched range (skip empty ranges \u2014 Docs API rejects
         # them with "The range should not be empty", and a zero-width
         # match is a pure insert).
         if match["endIndex"] > match["startIndex"]:

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1,11 +1,12 @@
 """Google Docs API v1 wrapper functions with error translation."""
 
+import re
 from functools import lru_cache
 
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from gdoc.util import AuthError, GdocError
+from gdoc.util import AuthError, GdocError, fold_typography
 
 
 @lru_cache(maxsize=1)
@@ -225,6 +226,7 @@ def find_text_in_document(
     text: str,
     match_case: bool = False,
     body: dict | None = None,
+    normalize: bool = False,
 ) -> list[dict]:
     """Find all occurrences of text within the document body.
 
@@ -236,6 +238,9 @@ def find_text_in_document(
         text: Text to search for.
         match_case: If True, case-sensitive matching.
         body: Optional body dict to search in (e.g. from a specific tab).
+        normalize: If True, fold smart quotes/dashes to ASCII on both sides
+            before matching. The fold is length-preserving, so returned
+            indices stay correct.
 
     Returns list of {"startIndex": int, "endIndex": int} in document
     coordinates.
@@ -258,9 +263,12 @@ def find_text_in_document(
 
     search_text = text
     search_in = concat
+    if normalize:
+        search_text = fold_typography(search_text)
+        search_in = fold_typography(search_in)
     if not match_case:
-        search_text = text.lower()
-        search_in = concat.lower()
+        search_text = search_text.lower()
+        search_in = search_in.lower()
 
     matches = []
     start = 0
@@ -276,6 +284,52 @@ def find_text_in_document(
         start = pos + 1
 
     return matches
+
+
+def diagnose_no_match(
+    document: dict | None,
+    text: str,
+    match_case: bool = False,
+    body: dict | None = None,
+    already_normalized: bool = False,
+) -> str | None:
+    """Explain why an exact search for `text` found nothing.
+
+    Returns a human-readable reason (to append to "no match found") or None
+    if no near-match can explain the miss. Runs entirely on the already-
+    fetched document — no extra API calls.
+    """
+    # Near-match that differs only in quote/dash style.
+    if not already_normalized and find_text_in_document(
+        document, text, match_case=match_case, body=body, normalize=True,
+    ):
+        return (
+            "but a near-match exists with different quote/dash style "
+            "(e.g. ’ vs '). Re-run with --normalize to match it"
+        )
+
+    # Near-match that differs only in whitespace (line breaks, runs of
+    # spaces, non-breaking spaces). Folded so quote style doesn't mask it.
+    if body is None and document is not None:
+        body = document.get("body", {})
+    chars: list[tuple[int, str]] = []
+    _collect_chars((body or {}).get("content", []), chars)
+    concat = fold_typography("".join(c for _, c in chars))
+    needle = fold_typography(text)
+
+    def collapse(s: str) -> str:
+        return re.sub(r"\s+", " ", s).strip()
+
+    hay_c, needle_c = collapse(concat), collapse(needle)
+    if not match_case:
+        hay_c, needle_c = hay_c.lower(), needle_c.lower()
+    if needle_c and needle_c in hay_c:
+        return (
+            "but the text appears with different whitespace (line breaks "
+            "or non-breaking spaces). Adjust the anchor to match exactly"
+        )
+
+    return None
 
 
 def _find_table_cell_indices(

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -192,16 +192,17 @@ def get_document(doc_id: str) -> dict:
         _translate_http_error(e, doc_id)
 
 
-def _collect_chars(content: list[dict], chars: list[tuple[int, str]]) -> None:
-    """Append (doc_index, char) pairs for all text in body content.
+def _collect_segments(content: list[dict]) -> list[list[tuple[int, str]]]:
+    """Group (doc_index, char) pairs into independently-searchable segments.
 
-    Walks paragraph.elements → textRun.content and recurses into table
-    cells (and nested tables), so text inside tables is searchable. Mirrors
-    the cell walk in get_tab_text(). Document order is preserved: a cell's
-    paragraphs end in a trailing "\\n", which keeps the concat boundary
-    between cells and prevents a match from spanning two cells — the same
-    guarantee paragraphs already have.
+    Paragraph text at one level forms a single segment; each table cell is
+    its own segment (recursively, for nested tables). Searching per segment
+    means a match can never span a table-cell boundary — the Docs API can't
+    delete a range that crosses cells or removes a cell's final paragraph
+    mark, so such a match would produce an invalid edit.
     """
+    segments: list[list[tuple[int, str]]] = []
+    root: list[tuple[int, str]] = []
     for element in content:
         paragraph = element.get("paragraph")
         if paragraph is not None:
@@ -212,13 +213,16 @@ def _collect_chars(content: list[dict], chars: list[tuple[int, str]]) -> None:
                 run = text_run.get("content", "")
                 start_idx = pe.get("startIndex", 0)
                 for i, ch in enumerate(run):
-                    chars.append((start_idx + i, ch))
+                    root.append((start_idx + i, ch))
             continue
         table = element.get("table")
         if table is not None:
             for row in table.get("tableRows", []):
                 for cell in row.get("tableCells", []):
-                    _collect_chars(cell.get("content", []), chars)
+                    segments.extend(_collect_segments(cell.get("content", [])))
+    if root:
+        segments.append(root)
+    return segments
 
 
 def find_text_in_document(
@@ -230,8 +234,8 @@ def find_text_in_document(
 ) -> list[dict]:
     """Find all occurrences of text within the document body.
 
-    Walks body.content (paragraphs and table cells) → textRun.content to
-    build a concatenated string with position mapping, then searches.
+    Searches body.content per segment (top-level paragraphs, and each table
+    cell on its own) so a match never crosses a table-cell boundary.
 
     Args:
         document: The full document dict (used if body is None).
@@ -243,46 +247,42 @@ def find_text_in_document(
             indices stay correct.
 
     Returns list of {"startIndex": int, "endIndex": int} in document
-    coordinates.
+    coordinates, ordered by startIndex.
     """
-    # Build a mapping: (doc_index, char) for each character in the document
-    chars: list[tuple[int, str]] = []
-
     if body is None:
         if document is None:
             return []
         body = document.get("body", {})
-    _collect_chars(body.get("content", []), chars)
-
-    if not chars:
-        return []
-
-    # Build the concatenated text and index map
-    concat = "".join(ch for _, ch in chars)
-    doc_indices = [idx for idx, _ in chars]
-
-    search_text = text
-    search_in = concat
-    if normalize:
-        search_text = fold_typography(search_text)
-        search_in = fold_typography(search_in)
-    if not match_case:
-        search_text = search_text.lower()
-        search_in = search_in.lower()
 
     matches = []
-    start = 0
-    while True:
-        pos = search_in.find(search_text, start)
-        if pos == -1:
-            break
-        end_pos = pos + len(search_text)
-        matches.append({
-            "startIndex": doc_indices[pos],
-            "endIndex": doc_indices[end_pos - 1] + 1,
-        })
-        start = pos + 1
+    for chars in _collect_segments(body.get("content", [])):
+        concat = "".join(ch for _, ch in chars)
+        doc_indices = [idx for idx, _ in chars]
 
+        search_text = text
+        search_in = concat
+        if normalize:
+            search_text = fold_typography(search_text)
+            search_in = fold_typography(search_in)
+        if not match_case:
+            search_text = search_text.lower()
+            search_in = search_in.lower()
+        if not search_text:
+            continue
+
+        start = 0
+        while True:
+            pos = search_in.find(search_text, start)
+            if pos == -1:
+                break
+            end_pos = pos + len(search_text)
+            matches.append({
+                "startIndex": doc_indices[pos],
+                "endIndex": doc_indices[end_pos - 1] + 1,
+            })
+            start = pos + 1
+
+    matches.sort(key=lambda m: m["startIndex"])
     return matches
 
 
@@ -312,9 +312,10 @@ def diagnose_no_match(
     # spaces, non-breaking spaces). Folded so quote style doesn't mask it.
     if body is None and document is not None:
         body = document.get("body", {})
-    chars: list[tuple[int, str]] = []
-    _collect_chars((body or {}).get("content", []), chars)
-    concat = fold_typography("".join(c for _, c in chars))
+    segments = _collect_segments((body or {}).get("content", []))
+    concat = fold_typography(
+        "\n".join("".join(c for _, c in seg) for seg in segments)
+    )
     needle = fold_typography(text)
 
     def collapse(s: str) -> str:

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -617,7 +617,7 @@ def cmd_edit(args) -> int:
     normalize = getattr(args, "normalize", False)
     cell = getattr(args, "cell", None)
     col = getattr(args, "col", None)
-    table_index = getattr(args, "table", 0)
+    table_index = getattr(args, "table", None)
 
     # Resolve text from args or files (fail fast before API calls)
     old_text = args.old_text
@@ -625,17 +625,15 @@ def cmd_edit(args) -> int:
     old_file = getattr(args, "old_file", None)
     new_file = getattr(args, "new_file", None)
 
-    # `-` reads that positional from stdin (one stream → at most one `-`).
-    if old_text == "-" and new_text == "-":
-        raise GdocError(
-            "only one argument can read from stdin ('-')", exit_code=3,
-        )
-    if old_text == "-" or new_text == "-":
-        stdin_data = sys.stdin.read()
-        if old_text == "-":
-            old_text = stdin_data
-        if new_text == "-":
-            new_text = stdin_data
+    # Read stdin lazily, once, and only for an argument that is actually used
+    # (`-` on a positional that cell-mode ignores must not block on stdin).
+    _stdin_data = None
+
+    def read_stdin() -> str:
+        nonlocal _stdin_data
+        if _stdin_data is None:
+            _stdin_data = sys.stdin.read()
+        return _stdin_data
 
     if cell is not None:
         # Cell mode: the cell address is the anchor, so the single positional
@@ -643,7 +641,10 @@ def cmd_edit(args) -> int:
         if new_file:
             new_text = _read_file(new_file)
         else:
-            new_text = new_text if new_text is not None else old_text
+            replacement = new_text if new_text is not None else old_text
+            if replacement == "-":
+                replacement = read_stdin()
+            new_text = replacement
         if new_text is None:
             raise GdocError(
                 "cell edit needs replacement text "
@@ -663,12 +664,24 @@ def cmd_edit(args) -> int:
         else:
             # --old-file alone → delete the matched range.
             new_text = ""
-    elif old_text is None or new_text is None:
-        raise GdocError(
-            "old_text and new_text required "
-            "(or use --old-file/--new-file)",
-            exit_code=3,
-        )
+    else:
+        # `-` reads that positional from stdin (one stream → at most one `-`).
+        if old_text == "-" and new_text == "-":
+            raise GdocError(
+                "only one argument can read from stdin ('-')", exit_code=3,
+            )
+        if old_text == "-" or new_text == "-":
+            stdin_data = read_stdin()
+            if old_text == "-":
+                old_text = stdin_data
+            if new_text == "-":
+                new_text = stdin_data
+        if old_text is None or new_text is None:
+            raise GdocError(
+                "old_text and new_text required "
+                "(or use --old-file/--new-file)",
+                exit_code=3,
+            )
 
     # Pre-flight awareness check
     from gdoc.notify import pre_flight
@@ -2129,7 +2142,7 @@ def build_parser() -> GdocArgumentParser:
     )
     edit_p.add_argument(
         "--normalize", action="store_true",
-        help="Match through smart-quote/dash differences (’ matches ')",
+        help="Match through smart-quote/dash differences (\u2019 matches ')",
     )
     edit_p.add_argument(
         "--cell",
@@ -2142,8 +2155,10 @@ def build_parser() -> GdocArgumentParser:
              "(default: the column right of the label)",
     )
     edit_p.add_argument(
-        "--table", type=int, default=0,
-        help="With --cell 'ROW,COL', which table in the body (default 0)",
+        "--table", type=int, default=None,
+        help="Which table in the body to address with --cell (0-based). "
+             "Coordinates default to the first table; a label searches all "
+             "tables unless this is set.",
     )
     edit_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -614,6 +614,7 @@ def cmd_edit(args) -> int:
     quiet = getattr(args, "quiet", False)
     replace_all = getattr(args, "all", False)
     case_sensitive = getattr(args, "case_sensitive", False)
+    normalize = getattr(args, "normalize", False)
 
     # Resolve text from args or files (fail fast before API calls)
     old_text = args.old_text
@@ -656,6 +657,8 @@ def cmd_edit(args) -> int:
     tab_name = getattr(args, "tab", None)
     tab_id = None
 
+    search_body = None
+    document = None
     if tab_name:
         from gdoc.api.docs import flatten_tabs, get_document_with_tabs, resolve_tab
         doc = get_document_with_tabs(doc_id)
@@ -663,16 +666,26 @@ def cmd_edit(args) -> int:
         tabs = flatten_tabs(doc.get("tabs", []))
         tab_match = resolve_tab(tabs, tab_name)
         tab_id = tab_match["id"]
+        search_body = tab_match["body"]
         matches = find_text_in_document(
-            None, old_text, match_case=case_sensitive, body=tab_match["body"],
+            None, old_text, match_case=case_sensitive,
+            body=search_body, normalize=normalize,
         )
     else:
         document = get_document(doc_id)
         revision_id = document.get("revisionId", "")
-        matches = find_text_in_document(document, old_text, match_case=case_sensitive)
+        matches = find_text_in_document(
+            document, old_text, match_case=case_sensitive, normalize=normalize,
+        )
 
     if not matches:
-        raise GdocError("no match found", exit_code=3)
+        from gdoc.api.docs import diagnose_no_match
+        reason = diagnose_no_match(
+            document, old_text, match_case=case_sensitive,
+            body=search_body, already_normalized=normalize,
+        )
+        msg = "no match found" + (f"; {reason}" if reason else "")
+        raise GdocError(msg, exit_code=3)
     if not replace_all and len(matches) > 1:
         raise GdocError(
             f"multiple matches ({len(matches)} found). Use --all",
@@ -2079,6 +2092,10 @@ def build_parser() -> GdocArgumentParser:
     )
     edit_p.add_argument(
         "--case-sensitive", action="store_true", help="Case-sensitive matching"
+    )
+    edit_p.add_argument(
+        "--normalize", action="store_true",
+        help="Match through smart-quote/dash differences (’ matches ')",
     )
     edit_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -615,6 +615,9 @@ def cmd_edit(args) -> int:
     replace_all = getattr(args, "all", False)
     case_sensitive = getattr(args, "case_sensitive", False)
     normalize = getattr(args, "normalize", False)
+    cell = getattr(args, "cell", None)
+    col = getattr(args, "col", None)
+    table_index = getattr(args, "table", 0)
 
     # Resolve text from args or files (fail fast before API calls)
     old_text = args.old_text
@@ -622,7 +625,20 @@ def cmd_edit(args) -> int:
     old_file = getattr(args, "old_file", None)
     new_file = getattr(args, "new_file", None)
 
-    if old_file or new_file:
+    if cell is not None:
+        # Cell mode: the cell address is the anchor, so the single positional
+        # (or --new-file) carries the replacement — no separate old_text.
+        if new_file:
+            new_text = _read_file(new_file)
+        else:
+            new_text = new_text if new_text is not None else old_text
+        if new_text is None:
+            raise GdocError(
+                "cell edit needs replacement text "
+                "(NEW_TEXT positional or --new-file)",
+                exit_code=3,
+            )
+    elif old_file or new_file:
         if new_file and not old_file:
             raise GdocError(
                 "--new-file requires --old-file (needs an anchor). "
@@ -657,8 +673,6 @@ def cmd_edit(args) -> int:
     tab_name = getattr(args, "tab", None)
     tab_id = None
 
-    search_body = None
-    document = None
     if tab_name:
         from gdoc.api.docs import flatten_tabs, get_document_with_tabs, resolve_tab
         doc = get_document_with_tabs(doc_id)
@@ -667,30 +681,38 @@ def cmd_edit(args) -> int:
         tab_match = resolve_tab(tabs, tab_name)
         tab_id = tab_match["id"]
         search_body = tab_match["body"]
+    else:
+        document = get_document(doc_id)
+        revision_id = document.get("revisionId", "")
+        search_body = document.get("body", {})
+
+    if cell is not None:
+        from gdoc.api.docs import resolve_cell_range
+        cell_range = resolve_cell_range(
+            search_body, cell, col=col, table_index=table_index,
+            normalize=normalize,
+        )
+        if cell_range is None:
+            raise GdocError(f"cell not found: {cell!r}", exit_code=3)
+        matches = [cell_range]
+    else:
         matches = find_text_in_document(
             None, old_text, match_case=case_sensitive,
             body=search_body, normalize=normalize,
         )
-    else:
-        document = get_document(doc_id)
-        revision_id = document.get("revisionId", "")
-        matches = find_text_in_document(
-            document, old_text, match_case=case_sensitive, normalize=normalize,
-        )
-
-    if not matches:
-        from gdoc.api.docs import diagnose_no_match
-        reason = diagnose_no_match(
-            document, old_text, match_case=case_sensitive,
-            body=search_body, already_normalized=normalize,
-        )
-        msg = "no match found" + (f"; {reason}" if reason else "")
-        raise GdocError(msg, exit_code=3)
-    if not replace_all and len(matches) > 1:
-        raise GdocError(
-            f"multiple matches ({len(matches)} found). Use --all",
-            exit_code=3,
-        )
+        if not matches:
+            from gdoc.api.docs import diagnose_no_match
+            reason = diagnose_no_match(
+                None, old_text, match_case=case_sensitive,
+                body=search_body, already_normalized=normalize,
+            )
+            msg = "no match found" + (f"; {reason}" if reason else "")
+            raise GdocError(msg, exit_code=3)
+        if not replace_all and len(matches) > 1:
+            raise GdocError(
+                f"multiple matches ({len(matches)} found). Use --all",
+                exit_code=3,
+            )
 
     # Check if replacement contains tables — not supported with --all
     from gdoc.mdparse import parse_markdown as _parse_md
@@ -2096,6 +2118,20 @@ def build_parser() -> GdocArgumentParser:
     edit_p.add_argument(
         "--normalize", action="store_true",
         help="Match through smart-quote/dash differences (’ matches ')",
+    )
+    edit_p.add_argument(
+        "--cell",
+        help="Target a table cell instead of searching text: a label "
+             "(replaces the cell to its right) or 'ROW,COL' coordinates",
+    )
+    edit_p.add_argument(
+        "--col", type=int,
+        help="With --cell label, the 0-based column to replace "
+             "(default: the column right of the label)",
+    )
+    edit_p.add_argument(
+        "--table", type=int, default=0,
+        help="With --cell 'ROW,COL', which table in the body (default 0)",
     )
     edit_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -625,6 +625,18 @@ def cmd_edit(args) -> int:
     old_file = getattr(args, "old_file", None)
     new_file = getattr(args, "new_file", None)
 
+    # `-` reads that positional from stdin (one stream → at most one `-`).
+    if old_text == "-" and new_text == "-":
+        raise GdocError(
+            "only one argument can read from stdin ('-')", exit_code=3,
+        )
+    if old_text == "-" or new_text == "-":
+        stdin_data = sys.stdin.read()
+        if old_text == "-":
+            old_text = stdin_data
+        if new_text == "-":
+            new_text = stdin_data
+
     if cell is not None:
         # Cell mode: the cell address is the anchor, so the single positional
         # (or --new-file) carries the replacement — no separate old_text.

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -138,6 +138,31 @@ def confirm_destructive(message: str, force: bool = False) -> None:
         raise GdocError("Cancelled", exit_code=3)
 
 
+# Smart quotes / dashes → ASCII. Each entry maps one char to exactly one
+# char, so the fold is length-preserving and an index map built on the
+# original text stays valid after folding (used by --normalize matching).
+_TYPOGRAPHY_FOLD = str.maketrans({
+    "‘": "'",  # ' left single quote
+    "’": "'",  # ' right single quote / apostrophe
+    "“": '"',  # " left double quote
+    "”": '"',  # " right double quote
+    "′": "'",  # ′ prime
+    "″": '"',  # ″ double prime
+    "–": "-",  # – en dash
+    "—": "-",  # — em dash
+})
+
+
+def fold_typography(s: str) -> str:
+    """Fold smart quotes and en/em dashes to their ASCII equivalents.
+
+    Length-preserving (1:1 per character) so a smart-quote apostrophe
+    (U+2019) matches an ASCII apostrophe in a search anchor without
+    disturbing any character-index mapping.
+    """
+    return s.translate(_TYPOGRAPHY_FOLD)
+
+
 def build_doc_url(doc_id: str, tab_id: str | None = None) -> str:
     """Build a Google Docs URL, optionally pointing at a specific tab."""
     url = f"https://docs.google.com/document/d/{doc_id}/edit"

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -138,18 +138,19 @@ def confirm_destructive(message: str, force: bool = False) -> None:
         raise GdocError("Cancelled", exit_code=3)
 
 
-# Smart quotes / dashes → ASCII. Each entry maps one char to exactly one
+# Smart quotes / dashes -> ASCII. Each entry maps one char to exactly one
 # char, so the fold is length-preserving and an index map built on the
 # original text stays valid after folding (used by --normalize matching).
+# Escapes (not literals) keep the source free of ambiguous Unicode (RUF001).
 _TYPOGRAPHY_FOLD = str.maketrans({
-    "‘": "'",  # ' left single quote
-    "’": "'",  # ' right single quote / apostrophe
-    "“": '"',  # " left double quote
-    "”": '"',  # " right double quote
-    "′": "'",  # ′ prime
-    "″": '"',  # ″ double prime
-    "–": "-",  # – en dash
-    "—": "-",  # — em dash
+    "\u2018": "'",  # left single quote
+    "\u2019": "'",  # right single quote / apostrophe
+    "\u201c": '"',  # left double quote
+    "\u201d": '"',  # right double quote
+    "\u2032": "'",  # prime
+    "\u2033": '"',  # double prime
+    "\u2013": "-",  # en dash
+    "\u2014": "-",  # em dash
 })
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.7.5"
+version = "0.7.6"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -482,6 +482,56 @@ class TestFindTextBody:
         matches = find_text_in_document(None, "world", body=body)
         assert [m["startIndex"] for m in matches] == [7, 20]
 
+    def test_normalize_matches_smart_quotes(self):
+        from gdoc.api.docs import find_text_in_document
+
+        body = {"content": [{
+            "paragraph": {"elements": [{
+                "startIndex": 1, "textRun": {"content": "JP’s job\n"},
+            }]},
+        }]}
+        assert find_text_in_document(None, "JP's job", body=body) == []
+        m = find_text_in_document(None, "JP's job", body=body, normalize=True)
+        assert len(m) == 1 and m[0]["startIndex"] == 1
+
+
+class TestDiagnoseNoMatch:
+    @staticmethod
+    def _para_body(text):
+        return {"content": [{
+            "paragraph": {"elements": [{
+                "startIndex": 1, "textRun": {"content": text},
+            }]},
+        }]}
+
+    def test_suggests_normalize_on_quote_mismatch(self):
+        from gdoc.api.docs import diagnose_no_match
+
+        reason = diagnose_no_match(None, "JP's job", body=self._para_body("JP’s job\n"))
+        assert reason is not None and "--normalize" in reason
+
+    def test_reports_whitespace_difference(self):
+        from gdoc.api.docs import diagnose_no_match
+
+        reason = diagnose_no_match(
+            None, "a b", body=self._para_body("a\nb\n"),
+        )
+        assert reason is not None and "whitespace" in reason
+
+    def test_no_near_match_returns_none(self):
+        from gdoc.api.docs import diagnose_no_match
+
+        assert diagnose_no_match(None, "zzz", body=self._para_body("abc\n")) is None
+
+    def test_already_normalized_skips_quote_suggestion(self):
+        from gdoc.api.docs import diagnose_no_match
+
+        reason = diagnose_no_match(
+            None, "JP's job", body=self._para_body("JP’s job\n"),
+            already_normalized=True,
+        )
+        assert reason is None or "--normalize" not in reason
+
 
 class TestAddTab:
     @patch("gdoc.api.docs.get_docs_service")

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -467,7 +467,7 @@ class TestFindTextBody:
             ]}]},
         }]}
         # Neither a plain concatenation ("foobar") nor a newline-spanning
-        # anchor ("foo\nbar") may match across the cell boundary — that would
+        # anchor ("foo\nbar") may match across the cell boundary \u2014 that would
         # yield an invalid cross-cell delete range.
         assert find_text_in_document(None, "foobar", body=body) == []
         assert find_text_in_document(None, "foo\nbar", body=body) == []
@@ -494,7 +494,7 @@ class TestFindTextBody:
 
         body = {"content": [{
             "paragraph": {"elements": [{
-                "startIndex": 1, "textRun": {"content": "JP’s job\n"},
+                "startIndex": 1, "textRun": {"content": "JP\u2019s job\n"},
             }]},
         }]}
         assert find_text_in_document(None, "JP's job", body=body) == []
@@ -514,7 +514,7 @@ class TestDiagnoseNoMatch:
     def test_suggests_normalize_on_quote_mismatch(self):
         from gdoc.api.docs import diagnose_no_match
 
-        reason = diagnose_no_match(None, "JP's job", body=self._para_body("JP’s job\n"))
+        reason = diagnose_no_match(None, "JP's job", body=self._para_body("JP\u2019s job\n"))
         assert reason is not None and "--normalize" in reason
 
     def test_reports_whitespace_difference(self):
@@ -534,7 +534,7 @@ class TestDiagnoseNoMatch:
         from gdoc.api.docs import diagnose_no_match
 
         reason = diagnose_no_match(
-            None, "JP's job", body=self._para_body("JP’s job\n"),
+            None, "JP's job", body=self._para_body("JP\u2019s job\n"),
             already_normalized=True,
         )
         assert reason is None or "--normalize" not in reason
@@ -659,7 +659,7 @@ class TestCountDocumentTabs:
 
 
 class TestZeroWidthReplace:
-    """Zero-width matches in replace_formatted act as pure inserts — no
+    """Zero-width matches in replace_formatted act as pure inserts \u2014 no
     deleteContentRange is emitted (Docs API rejects empty ranges)."""
 
     @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -466,7 +466,14 @@ class TestFindTextBody:
                 self._cell("bar\n", 30),
             ]}]},
         }]}
+        # Neither a plain concatenation ("foobar") nor a newline-spanning
+        # anchor ("foo\nbar") may match across the cell boundary — that would
+        # yield an invalid cross-cell delete range.
         assert find_text_in_document(None, "foobar", body=body) == []
+        assert find_text_in_document(None, "foo\nbar", body=body) == []
+        # Each cell is still searchable on its own.
+        assert find_text_in_document(None, "foo", body=body)[0]["startIndex"] == 10
+        assert find_text_in_document(None, "bar", body=body)[0]["startIndex"] == 30
 
     def test_paragraph_and_table_coexist(self):
         from gdoc.api.docs import find_text_in_document

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -420,6 +420,68 @@ class TestFindTextBody:
 
         assert find_text_in_document(None, "text") == []
 
+    @staticmethod
+    def _cell(text, start):
+        return {"content": [{
+            "paragraph": {
+                "elements": [{"startIndex": start, "textRun": {"content": text}}],
+            },
+        }]}
+
+    def test_find_text_in_table_cell(self):
+        from gdoc.api.docs import find_text_in_document
+
+        body = {"content": [{
+            "table": {"tableRows": [{"tableCells": [
+                self._cell("Label\n", 5),
+                self._cell("Answer here\n", 20),
+            ]}]},
+        }]}
+        matches = find_text_in_document(None, "Answer", body=body)
+        assert len(matches) == 1
+        assert matches[0]["startIndex"] == 20
+        assert matches[0]["endIndex"] == 26
+
+    def test_find_text_in_nested_table(self):
+        from gdoc.api.docs import find_text_in_document
+
+        inner = {"table": {"tableRows": [{"tableCells": [
+            self._cell("deep value\n", 50),
+        ]}]}}
+        body = {"content": [{
+            "table": {"tableRows": [{"tableCells": [
+                {"content": [inner]},
+            ]}]},
+        }]}
+        matches = find_text_in_document(None, "deep", body=body)
+        assert len(matches) == 1
+        assert matches[0]["startIndex"] == 50
+
+    def test_match_does_not_span_cells(self):
+        from gdoc.api.docs import find_text_in_document
+
+        body = {"content": [{
+            "table": {"tableRows": [{"tableCells": [
+                self._cell("foo\n", 10),
+                self._cell("bar\n", 30),
+            ]}]},
+        }]}
+        assert find_text_in_document(None, "foobar", body=body) == []
+
+    def test_paragraph_and_table_coexist(self):
+        from gdoc.api.docs import find_text_in_document
+
+        body = {"content": [
+            {"paragraph": {"elements": [
+                {"startIndex": 1, "textRun": {"content": "hello world\n"}},
+            ]}},
+            {"table": {"tableRows": [{"tableCells": [
+                self._cell("world\n", 20),
+            ]}]}},
+        ]}
+        matches = find_text_in_document(None, "world", body=body)
+        assert [m["startIndex"] for m in matches] == [7, 20]
+
 
 class TestAddTab:
     @patch("gdoc.api.docs.get_docs_service")

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -698,3 +698,43 @@ class TestEditTab:
         args = _make_args(tab="Notes")
         with pytest.raises(GdocError, match="Document not found"):
             cmd_edit(args)
+
+
+class TestEditStdin:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.find_text_in_document", return_value=_single_match())
+    @patch("gdoc.api.docs.get_document", return_value=_mock_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_new_text_dash_reads_stdin(
+        self, _pf, _doc, _find, mock_replace, _ver, _update,
+    ):
+        args = _make_args(old_text="hello", new_text="-")
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "from stdin"
+            cmd_edit(args)
+        assert mock_replace.call_args[0][2] == "from stdin"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.find_text_in_document", return_value=_single_match())
+    @patch("gdoc.api.docs.get_document", return_value=_mock_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_old_text_dash_reads_stdin(
+        self, _pf, _doc, mock_find, _replace, _ver, _update,
+    ):
+        args = _make_args(old_text="-", new_text="world")
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "anchor text"
+            cmd_edit(args)
+        # The stdin content becomes the search anchor.
+        assert mock_find.call_args[0][1] == "anchor text"
+
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_both_dash_errors(self, _pf):
+        args = _make_args(old_text="-", new_text="-")
+        with pytest.raises(GdocError, match="only one argument") as exc:
+            cmd_edit(args)
+        assert exc.value.exit_code == 3

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -197,7 +197,7 @@ class TestEditNormalize:
         assert mock_find.call_args[1]["normalize"] is True
 
     @patch("gdoc.api.docs.replace_formatted")
-    @patch("gdoc.api.docs.get_document", return_value=_doc_with("JP’s job\n"))
+    @patch("gdoc.api.docs.get_document", return_value=_doc_with("JP\u2019s job\n"))
     @patch("gdoc.notify.pre_flight", return_value=None)
     def test_miss_suggests_normalize(self, _pf, _doc, mock_replace):
         """Exact search with an ASCII apostrophe misses smart-quote text."""
@@ -210,7 +210,7 @@ class TestEditNormalize:
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
     @patch("gdoc.api.docs.replace_formatted", return_value=1)
-    @patch("gdoc.api.docs.get_document", return_value=_doc_with("JP’s job\n"))
+    @patch("gdoc.api.docs.get_document", return_value=_doc_with("JP\u2019s job\n"))
     @patch("gdoc.notify.pre_flight", return_value=None)
     def test_normalize_matches_smart_quotes(
         self, _pf, _doc, mock_replace, _ver, _update, capsys,

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -20,6 +20,7 @@ def _make_args(**overrides):
         "new_text": "world",
         "all": False,
         "case_sensitive": False,
+        "normalize": False,
         "json": False,
         "verbose": False,
         "plain": False,
@@ -167,6 +168,70 @@ class TestEditPrecheck:
         args = _make_args(old_text="hello")
         rc = cmd_edit(args)
         assert rc == 0
+
+
+def _doc_with(text, revision_id="rev123"):
+    """A document whose single paragraph contains `text`."""
+    return {
+        "revisionId": revision_id,
+        "body": {"content": [{
+            "paragraph": {"elements": [{
+                "startIndex": 1,
+                "textRun": {"content": text},
+            }]},
+        }]},
+    }
+
+
+class TestEditNormalize:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.find_text_in_document", return_value=_single_match())
+    @patch("gdoc.api.docs.get_document", return_value=_mock_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_normalize_threaded_into_find(
+        self, _pf, _doc, mock_find, _replace, _ver, _update,
+    ):
+        cmd_edit(_make_args(normalize=True))
+        assert mock_find.call_args[1]["normalize"] is True
+
+    @patch("gdoc.api.docs.replace_formatted")
+    @patch("gdoc.api.docs.get_document", return_value=_doc_with("JP’s job\n"))
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_miss_suggests_normalize(self, _pf, _doc, mock_replace):
+        """Exact search with an ASCII apostrophe misses smart-quote text."""
+        args = _make_args(old_text="JP's job", new_text="x")
+        with pytest.raises(GdocError, match="--normalize") as exc:
+            cmd_edit(args)
+        assert exc.value.exit_code == 3
+        mock_replace.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.get_document", return_value=_doc_with("JP’s job\n"))
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_normalize_matches_smart_quotes(
+        self, _pf, _doc, mock_replace, _ver, _update, capsys,
+    ):
+        """With --normalize, the ASCII anchor matches the smart-quote text."""
+        args = _make_args(old_text="JP's job", new_text="x", normalize=True)
+        rc = cmd_edit(args)
+        assert rc == 0
+        assert "OK replaced 1 occurrence" in capsys.readouterr().out
+        mock_replace.assert_called_once()
+
+    @patch("gdoc.api.docs.replace_formatted")
+    @patch("gdoc.api.docs.get_document", return_value=_doc_with("line one\nline two\n"))
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_miss_reports_whitespace_difference(self, _pf, _doc, mock_replace):
+        """A space where the doc has a newline → whitespace diagnostic."""
+        args = _make_args(old_text="line one line two", new_text="x")
+        with pytest.raises(GdocError, match="whitespace") as exc:
+            cmd_edit(args)
+        assert exc.value.exit_code == 3
+        mock_replace.assert_not_called()
 
 
 class TestEditJson:

--- a/tests/test_edit_cell.py
+++ b/tests/test_edit_cell.py
@@ -1,0 +1,162 @@
+"""Tests for cell-addressed `gdoc edit` (--cell/--col/--table)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gdoc.api.docs import (
+    _cell_text_range,
+    _parse_coord,
+    resolve_cell_range,
+)
+from gdoc.cli import cmd_edit
+from gdoc.util import GdocError
+
+
+def _cell(text, start):
+    return {"content": [{
+        "paragraph": {"elements": [
+            {"startIndex": start, "textRun": {"content": text}},
+        ]},
+    }]}
+
+
+def _table(rows):
+    return {"table": {"tableRows": [
+        {"tableCells": [_cell(t, s) for (t, s) in row]} for row in rows
+    ]}}
+
+
+# A 2-column label/value grid, plus an empty value cell.
+GRID = {"content": [_table([
+    [("Label A\n", 5), ("Value A\n", 20)],
+    [("Discussion topics from JP\n", 40), ("\n", 70)],
+])]}
+
+
+class TestParseCoord:
+    def test_parses_coordinates(self):
+        assert _parse_coord("0,1") == (0, 1)
+        assert _parse_coord(" 2 , 3 ") == (2, 3)
+
+    def test_labels_are_not_coordinates(self):
+        assert _parse_coord("Discussion topics") is None
+        assert _parse_coord("1,") is None
+
+
+class TestCellTextRange:
+    def test_non_empty_cell_excludes_final_newline(self):
+        r = _cell_text_range(_cell("Value A\n", 20))
+        assert r == {"startIndex": 20, "endIndex": 27}
+
+    def test_empty_cell_is_zero_width(self):
+        r = _cell_text_range(_cell("\n", 70))
+        assert r == {"startIndex": 70, "endIndex": 70}
+
+    def test_multi_paragraph_cell(self):
+        cell = {"content": [
+            {"paragraph": {"elements": [
+                {"startIndex": 5, "textRun": {"content": "a\n"}},
+            ]}},
+            {"paragraph": {"elements": [
+                {"startIndex": 7, "textRun": {"content": "b\n"}},
+            ]}},
+        ]}
+        assert _cell_text_range(cell) == {"startIndex": 5, "endIndex": 8}
+
+
+class TestResolveCellRange:
+    def test_label_targets_cell_to_the_right(self):
+        assert resolve_cell_range(GRID, "Label A") == {"startIndex": 20, "endIndex": 27}
+
+    def test_label_with_empty_target_cell(self):
+        assert resolve_cell_range(GRID, "Discussion topics from JP") == {
+            "startIndex": 70, "endIndex": 70,
+        }
+
+    def test_col_override(self):
+        # col 0 targets the label cell itself.
+        assert resolve_cell_range(GRID, "Label A", col=0) == {
+            "startIndex": 5, "endIndex": 12,
+        }
+
+    def test_coordinate_mode(self):
+        assert resolve_cell_range(GRID, "0,1") == {"startIndex": 20, "endIndex": 27}
+
+    def test_label_not_found(self):
+        assert resolve_cell_range(GRID, "Nope") is None
+
+    def test_coordinate_out_of_range(self):
+        assert resolve_cell_range(GRID, "9,9") is None
+        assert resolve_cell_range(GRID, "0,1", table_index=5) is None
+
+    def test_normalize_label(self):
+        body = {"content": [_table([[("JP’s job\n", 5), ("v\n", 20)]])]}
+        assert resolve_cell_range(body, "JP's job") is None
+        assert resolve_cell_range(body, "JP's job", normalize=True) == {
+            "startIndex": 20, "endIndex": 21,
+        }
+
+
+def _args(**kw):
+    base = {
+        "command": "edit", "doc": "abc123",
+        "old_text": None, "new_text": None,
+        "old_file": None, "new_file": None,
+        "all": False, "case_sensitive": False, "normalize": False,
+        "cell": None, "col": None, "table": 0,
+        "json": False, "verbose": False, "plain": False,
+        "quiet": False, "tab": None,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _doc():
+    return {"revisionId": "rev123", "body": GRID}
+
+
+def _ver():
+    return {"version": 42, "modifiedTime": "2026-01-01T00:00:00Z"}
+
+
+class TestCmdEditCell:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_ver())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.get_document", return_value=_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_label_edit_succeeds(self, _pf, _doc_, mock_replace, _v, _u, capsys):
+        # Single positional carries the replacement in cell mode.
+        rc = cmd_edit(_args(cell="Label A", old_text="new value"))
+        assert rc == 0
+        assert "OK replaced 1 occurrence" in capsys.readouterr().out
+        args, kwargs = mock_replace.call_args
+        assert args[1] == [{"startIndex": 20, "endIndex": 27}]
+        assert args[2] == "new value"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_ver())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.get_document", return_value=_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_coordinate_edit_succeeds(self, _pf, _doc_, mock_replace, _v, _u):
+        rc = cmd_edit(_args(cell="0,1", old_text="x"))
+        assert rc == 0
+        assert mock_replace.call_args[0][1] == [{"startIndex": 20, "endIndex": 27}]
+
+    @patch("gdoc.api.docs.replace_formatted")
+    @patch("gdoc.api.docs.get_document", return_value=_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_cell_not_found_errors(self, _pf, _doc_, mock_replace):
+        with pytest.raises(GdocError, match="cell not found") as exc:
+            cmd_edit(_args(cell="Nonexistent", old_text="x"))
+        assert exc.value.exit_code == 3
+        mock_replace.assert_not_called()
+
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_missing_replacement_errors(self, _pf):
+        with pytest.raises(GdocError, match="needs replacement text") as exc:
+            cmd_edit(_args(cell="Label A"))
+        assert exc.value.exit_code == 3

--- a/tests/test_edit_cell.py
+++ b/tests/test_edit_cell.py
@@ -91,8 +91,22 @@ class TestResolveCellRange:
         assert resolve_cell_range(GRID, "9,9") is None
         assert resolve_cell_range(GRID, "0,1", table_index=5) is None
 
+    def test_label_honors_explicit_table(self):
+        two = {"content": [
+            _table([[("Dup\n", 5), ("first\n", 20)]]),
+            _table([[("Dup\n", 40), ("second\n", 55)]]),
+        ]}
+        # No --table → scan all tables; first match (table 0) wins.
+        assert resolve_cell_range(two, "Dup") == {"startIndex": 20, "endIndex": 25}
+        # --table 1 selects the matching cell in the second table.
+        assert resolve_cell_range(two, "Dup", table_index=1) == {
+            "startIndex": 55, "endIndex": 61,
+        }
+        # Out-of-range table → None even if the label exists elsewhere.
+        assert resolve_cell_range(two, "Dup", table_index=9) is None
+
     def test_normalize_label(self):
-        body = {"content": [_table([[("JP’s job\n", 5), ("v\n", 20)]])]}
+        body = {"content": [_table([[("JP\u2019s job\n", 5), ("v\n", 20)]])]}
         assert resolve_cell_range(body, "JP's job") is None
         assert resolve_cell_range(body, "JP's job", normalize=True) == {
             "startIndex": 20, "endIndex": 21,
@@ -105,7 +119,7 @@ def _args(**kw):
         "old_text": None, "new_text": None,
         "old_file": None, "new_file": None,
         "all": False, "case_sensitive": False, "normalize": False,
-        "cell": None, "col": None, "table": 0,
+        "cell": None, "col": None, "table": None,
         "json": False, "verbose": False, "plain": False,
         "quiet": False, "tab": None,
     }
@@ -132,7 +146,7 @@ class TestCmdEditCell:
         rc = cmd_edit(_args(cell="Label A", old_text="new value"))
         assert rc == 0
         assert "OK replaced 1 occurrence" in capsys.readouterr().out
-        args, kwargs = mock_replace.call_args
+        args = mock_replace.call_args[0]
         assert args[1] == [{"startIndex": 20, "endIndex": 27}]
         assert args[2] == "new value"
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -129,3 +129,28 @@ class TestConfirmDestructive:
             with pytest.raises(GdocError, match="Cancelled") as exc:
                 confirm_destructive("delete something", force=False)
             assert exc.value.exit_code == 3
+
+
+class TestFoldTypography:
+    def test_folds_smart_single_quotes(self):
+        from gdoc.util import fold_typography
+
+        assert fold_typography("JP’s job") == "JP's job"
+        assert fold_typography("‘hi’") == "'hi'"
+
+    def test_folds_smart_double_quotes_and_dashes(self):
+        from gdoc.util import fold_typography
+
+        assert fold_typography("“quote”") == '"quote"'
+        assert fold_typography("a – b — c") == "a - b - c"
+
+    def test_length_preserving(self):
+        from gdoc.util import fold_typography
+
+        s = "‘a’ “b” – —"
+        assert len(fold_typography(s)) == len(s)
+
+    def test_plain_ascii_unchanged(self):
+        from gdoc.util import fold_typography
+
+        assert fold_typography("plain 'text' - ok") == "plain 'text' - ok"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -135,19 +135,19 @@ class TestFoldTypography:
     def test_folds_smart_single_quotes(self):
         from gdoc.util import fold_typography
 
-        assert fold_typography("JP’s job") == "JP's job"
-        assert fold_typography("‘hi’") == "'hi'"
+        assert fold_typography("JP\u2019s job") == "JP's job"
+        assert fold_typography("\u2018hi\u2019") == "'hi'"
 
     def test_folds_smart_double_quotes_and_dashes(self):
         from gdoc.util import fold_typography
 
-        assert fold_typography("“quote”") == '"quote"'
-        assert fold_typography("a – b — c") == "a - b - c"
+        assert fold_typography("\u201cquote\u201d") == '"quote"'
+        assert fold_typography("a \u2013 b \u2014 c") == "a - b - c"
 
     def test_length_preserving(self):
         from gdoc.util import fold_typography
 
-        s = "‘a’ “b” – —"
+        s = "\u2018a\u2019 \u201cb\u201d \u2013 \u2014"
         assert len(fold_typography(s)) == len(s)
 
     def test_plain_ascii_unchanged(self):

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Why

`gdoc edit` silently failed on any text inside a table cell — `find_text_in_document` walked only `body.content` paragraphs and skipped every `element["table"]`, so it returned `no match found` for in-table text that `gdoc cat` could read. Template docs (one table per entry) were effectively un-editable from the CLI. This fixes that and adds three ergonomics improvements the failure exposed.

## What

1. **Text search descends into table cells** (the root-cause fix). `find_text_in_document` now recurses through `tableRows/tableCells`, including nested tables, via a `_collect_chars` helper that mirrors `get_tab_text`. `replace_formatted` is unchanged — it operates on raw document coordinates, so correct in-cell indices just work.

2. **`--normalize` + honest miss diagnostics.** Matching is exact by default. On a miss, `edit` now explains *why* — a smart-quote/dash near-match (suggests `--normalize`) or a whitespace difference — instead of a bare `no match found`. `--normalize` folds smart quotes/dashes to ASCII (length-preserving, so indices stay correct).

3. **`--cell` addressing.** Target a table cell directly: `--cell "Label"` replaces the cell to the label's right (`--col` to override), or `--cell ROW,COL` (`--table N`) by coordinates. Empty cells are filled in place; the cell's paragraph structure is preserved.

4. **`-` reads an argument from stdin** for multi-line anchors/replacements via heredocs/pipes (at most one `-`).

```bash
gdoc edit DOC --tab "Tab 1" --cell "Discussion topics from JP" "Show and tell; Q2 planning"
gdoc edit DOC "JP's job" "JP's role" --normalize
printf 'line one\nline two' | gdoc edit DOC --cell "Notes" -
```

## Verification

- Full suite green (881 passing, ~40 new tests covering in-table search, nested tables, `resolve_cell_range` label/coordinate/empty/normalize, diagnostics, and stdin).
- Live end-to-end against the real Docs API on a throwaway doc (created, exercised across all four features, trashed): in-table replace, label + coordinate cell edits, multi-line stdin into a cell, and the full normalize path (bare miss → `--normalize` suggestion → successful match).
- `ruff` clean on changed lines; `scripts/check-no-stubs.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit text directly inside Google Docs tables via `--cell` using labels or ROW,COL coordinates; supports nested tables and fills empty cells in place while preserving cell paragraph structure.
  * `--normalize` matches smart quotes/dashes as ASCII equivalents.
  * Use `-` to read anchors or replacements from stdin (heredocs/pipes).
  * Match failures now report the likely reason (e.g., quote/whitespace).

* **Documentation**
  * Updated command docs with table-editing examples and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->