### PR TITLE
Google Sheets support: transparent reads, explicit writes (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-06-05
+
+### Added
+- **Google Sheets support.** `cat`, `tabs`, and `info` now detect
+  spreadsheets and read cell values via the Sheets API: `cat` prints a
+  markdown table (`--plain` for TSV, `--json` for raw rows), `--tab` selects
+  a worksheet by title or sheet id, and `--range A1:C10` reads a slice.
+  `tabs` lists worksheets with their dimensions; `info` shows them instead
+  of a word count.
+- **`gdoc cells SHEET RANGE`** — write values into a spreadsheet range from
+  `-v` flags, a CSV/TSV file (`--file`), or TSV on stdin (`--stdin`).
+  `--append` inserts rows below the existing table; `--user-entered` parses
+  values as if typed in the UI (formulas, dates, numbers). Uses the existing
+  OAuth scope — no re-authentication needed.
+
 ## [0.7.6] — 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,9 +97,19 @@ gdoc images DOC_ID
 
 # Download images to a local directory
 gdoc images --download /tmp/imgs DOC_ID
+
+# Read a spreadsheet (markdown table; --plain for TSV)
+gdoc cat SHEET_ID
+
+# Read a specific worksheet / range
+gdoc cat --tab "Data" --range B2:D10 SHEET_ID
+
+# Write cell values to a spreadsheet
+gdoc cells SHEET_ID B2 -v "Yes"
+gdoc cells SHEET_ID A1 --file rows.csv
 ```
 
-All commands accept a full Google Docs URL or a bare document ID:
+All commands accept a full Google Docs/Sheets URL or a bare document ID:
 
 ```bash
 gdoc cat https://docs.google.com/document/d/1aBcDeFg.../edit
@@ -116,8 +126,9 @@ gdoc cat 1aBcDeFg...
 | `cat --tab NAME DOC` | Read a specific tab by title or ID |
 | `cat --all-tabs DOC` | Read all tabs with headers |
 | `cat --comments DOC` | Line-numbered content with inline comment annotations |
-| `tabs DOC` | List all tabs in a document |
-| `info DOC` | Show title, owner, modified date, word count |
+| `cat SHEET` | Print a spreadsheet as a markdown table (`--plain` for TSV, `--range A1:C10` for a slice; `--tab`/`--all-tabs` select worksheets) |
+| `tabs DOC` | List all tabs in a document (or worksheets in a spreadsheet) |
+| `info DOC` | Show title, owner, modified date, word count (tab list for spreadsheets) |
 | `ls [FOLDER]` | List files in Drive root or a folder (`--type docs\|sheets\|all`) |
 | `images DOC` | List images, charts, and drawings (`--download DIR` to save locally) |
 | `find QUERY` | Search files by name or content |
@@ -129,6 +140,7 @@ gdoc cat 1aBcDeFg...
 | `edit DOC OLD NEW` | Find and replace text with Markdown formatting, including text inside tables (`--all` for all; `--normalize` to match through smart quotes/dashes; `-` reads an argument from stdin) |
 | `edit DOC --cell ADDR NEW` | Replace a table cell by label or `ROW,COL` coordinates (`--col`, `--table`) |
 | `write DOC FILE` | Overwrite document from a local markdown file |
+| `cells SHEET RANGE` | Write values into a spreadsheet range (`-v VALUE` per cell, `--file rows.csv`, `--stdin` for TSV; `--append` adds rows, `--user-entered` parses formulas/dates) |
 | `new TITLE` | Create a blank document (`--folder` to specify location, `--file` to import markdown with images) |
 | `cp DOC TITLE` | Duplicate a document |
 
@@ -202,6 +214,36 @@ gdoc write DOC draft.md    # OK written
 ```
 
 Use `--force` to skip conflict detection. Use `--quiet` to skip pre-flight checks entirely (saves 2 API calls).
+
+## Spreadsheets
+
+`cat`, `tabs`, and `info` detect Google Sheets automatically — point them at a
+spreadsheet URL and they read cell values instead of exporting markdown.
+`cat` prints a markdown table by default, TSV with `--plain`, and raw rows
+with `--json`; `--tab` selects a worksheet by title or numeric sheet id
+(the `gid` in the URL), and `--range` limits output to an A1 range.
+Reading defaults to the first worksheet — a stderr hint tells you when more
+tabs exist.
+
+Writes go through `gdoc cells`:
+
+```bash
+# One row of values, starting at B2
+gdoc cells SHEET_ID B2:C2 -v "Y" -v "quote here"
+
+# Bulk rows from a CSV (or TSV) file
+gdoc cells SHEET_ID A2 --file rows.csv
+
+# Pipe TSV from another tool
+grep done report.tsv | gdoc cells SHEET_ID A2 --stdin
+
+# Append below the existing table; parse values like the UI would
+gdoc cells SHEET_ID A1 --append --user-entered -v "=SUM(B:B)"
+```
+
+Values are written literally by default (`RAW`); use `--user-entered` for
+formulas, dates, and number parsing. The existing OAuth scope already covers
+the Sheets API, so no re-authentication is needed.
 
 ## Annotated view
 

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.7.6"
+__version__ = "0.8.0"

--- a/gdoc/api/__init__.py
+++ b/gdoc/api/__init__.py
@@ -17,3 +17,16 @@ def get_drive_service():
 
     creds = get_credentials()
     return build("drive", "v3", credentials=creds)
+
+
+@lru_cache(maxsize=1)
+def get_sheets_service():
+    """Build and cache a Sheets API v4 service object.
+
+    The existing ``drive`` OAuth scope covers the Sheets API, so no
+    re-authentication is needed.
+    """
+    from gdoc.auth import get_credentials
+
+    creds = get_credentials()
+    return build("sheets", "v4", credentials=creds)

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -175,7 +175,7 @@ def resolve_tab(tabs: list[dict], tab_name: str) -> dict:
         if t["title"].lower() == tab_name.lower():
             return t
     for t in tabs:
-        if t["id"] == tab_name:
+        if str(t["id"]) == tab_name:
             return t
     raise GdocError(f"tab not found: {tab_name}", exit_code=3)
 

--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -175,7 +175,8 @@ def update_doc_content(doc_id: str, content: str) -> int:
 def get_file_version(doc_id: str) -> dict:
     """Get lightweight version metadata for pre-flight checks.
 
-    Returns dict with keys: modifiedTime, version (int), lastModifyingUser.
+    Returns dict with keys: modifiedTime, version (int), lastModifyingUser,
+    mimeType.
     """
     try:
         service = get_drive_service()
@@ -183,7 +184,8 @@ def get_file_version(doc_id: str) -> dict:
             service.files()
             .get(
                 fileId=doc_id,
-                fields="modifiedTime, version, lastModifyingUser(displayName, emailAddress)",
+                fields="modifiedTime, version, mimeType, "
+                "lastModifyingUser(displayName, emailAddress)",
                 supportsAllDrives=True,
             )
             .execute()

--- a/gdoc/api/sheets.py
+++ b/gdoc/api/sheets.py
@@ -104,7 +104,7 @@ def batch_get_values(spreadsheet_id: str, ranges: list[str]) -> list[dict]:
         value_ranges = result.get("valueRanges", [])
         return [
             {"range": vr.get("range", rng), "values": vr.get("values", [])}
-            for vr, rng in zip(value_ranges, ranges)
+            for vr, rng in zip(value_ranges, ranges, strict=True)
         ]
     except HttpError as e:
         _translate_http_error(e, spreadsheet_id)

--- a/gdoc/api/sheets.py
+++ b/gdoc/api/sheets.py
@@ -1,0 +1,144 @@
+"""Sheets API wrapper functions with error translation."""
+
+from googleapiclient.errors import HttpError
+
+from gdoc.api import get_sheets_service
+from gdoc.util import AuthError, GdocError
+
+
+def _translate_http_error(e: HttpError, spreadsheet_id: str) -> None:
+    """Translate a googleapiclient HttpError into GdocError or AuthError."""
+    status = int(e.resp.status)
+    reason = e.reason if hasattr(e, "reason") and e.reason else ""
+
+    if status == 401:
+        raise AuthError("Authentication expired. Run `gdoc auth`.")
+
+    if status == 403:
+        raise GdocError(f"Permission denied: {spreadsheet_id}")
+
+    if status == 404:
+        raise GdocError(f"Spreadsheet not found: {spreadsheet_id}")
+
+    if status == 400:
+        if "Unable to parse range" in reason:
+            raise GdocError(f"Invalid range: {reason}", exit_code=3)
+        raise GdocError(f"Sheets API error: {reason}")
+
+    raise GdocError(f"API error ({status}): {reason}")
+
+
+def get_spreadsheet_meta(spreadsheet_id: str) -> dict:
+    """Get spreadsheet title and per-sheet (tab) properties.
+
+    Returns dict with keys: title, sheets — where sheets is a list of
+    {id, title, index, rows, cols}.
+    """
+    try:
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .get(
+                spreadsheetId=spreadsheet_id,
+                fields="properties.title,sheets.properties",
+            )
+            .execute()
+        )
+    except HttpError as e:
+        _translate_http_error(e, spreadsheet_id)
+
+    sheets = []
+    for s in result.get("sheets", []):
+        props = s.get("properties", {})
+        grid = props.get("gridProperties", {})
+        sheets.append(
+            {
+                "id": props.get("sheetId"),
+                "title": props.get("title", ""),
+                "index": props.get("index", 0),
+                "rows": grid.get("rowCount", 0),
+                "cols": grid.get("columnCount", 0),
+            }
+        )
+    return {
+        "title": result.get("properties", {}).get("title", ""),
+        "sheets": sheets,
+    }
+
+
+def get_values(spreadsheet_id: str, range_: str) -> dict:
+    """Read a range of cell values.
+
+    Returns dict with keys: range (the resolved A1 range) and values
+    (list of rows; trailing empty cells are omitted by the API).
+    """
+    try:
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .values()
+            .get(spreadsheetId=spreadsheet_id, range=range_)
+            .execute()
+        )
+        return {
+            "range": result.get("range", range_),
+            "values": result.get("values", []),
+        }
+    except HttpError as e:
+        _translate_http_error(e, spreadsheet_id)
+
+
+def batch_get_values(spreadsheet_id: str, ranges: list[str]) -> list[dict]:
+    """Read multiple ranges in one round-trip.
+
+    Returns one {range, values} dict per requested range, in order.
+    """
+    try:
+        service = get_sheets_service()
+        result = (
+            service.spreadsheets()
+            .values()
+            .batchGet(spreadsheetId=spreadsheet_id, ranges=ranges)
+            .execute()
+        )
+        value_ranges = result.get("valueRanges", [])
+        return [
+            {"range": vr.get("range", rng), "values": vr.get("values", [])}
+            for vr, rng in zip(value_ranges, ranges)
+        ]
+    except HttpError as e:
+        _translate_http_error(e, spreadsheet_id)
+
+
+def write_values(
+    spreadsheet_id: str,
+    range_: str,
+    values: list[list],
+    user_entered: bool = False,
+    append: bool = False,
+) -> dict:
+    """Write values to a range, or append rows after the table at range_.
+
+    Returns {range, rows, cells} from the API update summary.
+    """
+    try:
+        service = get_sheets_service()
+        kwargs = {
+            "spreadsheetId": spreadsheet_id,
+            "range": range_,
+            "valueInputOption": "USER_ENTERED" if user_entered else "RAW",
+            "body": {"values": values},
+        }
+        api = service.spreadsheets().values()
+        if append:
+            result = api.append(insertDataOption="INSERT_ROWS", **kwargs).execute()
+            result = result.get("updates", {})
+        else:
+            result = api.update(**kwargs).execute()
+        return {
+            "range": result.get("updatedRange", range_),
+            "rows": result.get("updatedRows", 0),
+            "cells": result.get("updatedCells", 0),
+        }
+    except HttpError as e:
+        _translate_http_error(e, spreadsheet_id)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -624,7 +624,7 @@ def _read_cell_rows(args) -> list[list[str]]:
                     return list(csv.reader(f))
                 return [line.rstrip("\n").split("\t") for line in f]
         except OSError as e:
-            raise GdocError(f"cannot read {file_path}: {e}", exit_code=3)
+            raise GdocError(f"cannot read {file_path}: {e}", exit_code=3) from e
 
     rows = [line.rstrip("\n").split("\t") for line in sys.stdin]
     if not rows:
@@ -650,6 +650,11 @@ def cmd_cells(args) -> int:
         SPREADSHEET_MIME,
     ):
         raise GdocError(f"not a spreadsheet: {doc_id}", exit_code=3)
+
+    # Conflict warning (warn but don't block, matching `edit` semantics for
+    # surgical writes; only full-document overwrites hard-block).
+    if change_info and change_info.has_conflict:
+        print("WARN: doc changed since last read", file=sys.stderr)
 
     from gdoc.api.sheets import write_values
 

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from gdoc import __version__
-from gdoc.util import AuthError, GdocError
+from gdoc.util import SPREADSHEET_MIME, AuthError, GdocError
 
 
 class GdocArgumentParser(argparse.ArgumentParser):
@@ -39,6 +39,143 @@ def _resolve_doc_id(raw: str) -> str:
         raise GdocError(str(e), exit_code=3)
 
 
+
+def _file_mime(doc_id: str, change_info) -> str:
+    """Get the file's mimeType, reusing the pre-flight metadata when available."""
+    if change_info is not None and change_info.mime_type:
+        return change_info.mime_type
+    from gdoc.api.drive import get_file_version
+
+    return get_file_version(doc_id).get("mimeType", "")
+
+
+def _require_doc(doc_id: str, change_info) -> None:
+    """Reject spreadsheets early on doc-only commands.
+
+    Only fires when pre-flight already fetched the mime — quiet mode falls
+    through to the API's own error rather than paying an extra lookup.
+    """
+    if change_info is not None and change_info.mime_type == SPREADSHEET_MIME:
+        raise GdocError(
+            f"not a Google Doc: {doc_id} "
+            "(spreadsheets support cat/tabs/info/cells only)",
+            exit_code=3,
+        )
+
+
+def _quote_sheet_title(title: str) -> str:
+    """Quote a sheet title for use in an A1 range reference."""
+    return "'" + title.replace("'", "''") + "'"
+
+
+def _pad_rows(values: list[list]) -> list[list[str]]:
+    """Pad rows to equal width (the API omits trailing empty cells)."""
+    width = max((len(r) for r in values), default=0)
+    return [[str(c) for c in r] + [""] * (width - len(r)) for r in values]
+
+
+def _format_sheet_tsv(values: list[list]) -> str:
+    """Format cell values as TSV. Tabs/newlines inside cells become spaces."""
+    rows = _pad_rows(values)
+    clean = [
+        "\t".join(c.replace("\t", " ").replace("\n", " ") for c in r)
+        for r in rows
+    ]
+    return "\n".join(clean) + ("\n" if clean else "")
+
+
+def _format_sheet_table(values: list[list]) -> str:
+    """Format cell values as a markdown table (first row as header)."""
+    rows = _pad_rows(values)
+    if not rows:
+        return "(no values)\n"
+    rows = [[c.replace("|", "\\|").replace("\n", " ") for c in r] for r in rows]
+    widths = [max(len(r[i]) for r in rows) for i in range(len(rows[0]))]
+    widths = [max(w, 3) for w in widths]
+
+    def fmt(row):
+        return "| " + " | ".join(c.ljust(w) for c, w in zip(row, widths)) + " |"
+
+    lines = [fmt(rows[0]), "| " + " | ".join("-" * w for w in widths) + " |"]
+    lines.extend(fmt(r) for r in rows[1:])
+    return "\n".join(lines) + "\n"
+
+
+def _cat_sheet(args, doc_id: str, change_info) -> int:
+    """Spreadsheet branch of `gdoc cat`: print cell values."""
+    if getattr(args, "comments", False):
+        raise GdocError("--comments is not supported for spreadsheets", exit_code=3)
+
+    quiet = getattr(args, "quiet", False)
+    tab = getattr(args, "tab", None)
+    all_tabs = getattr(args, "all_tabs", False)
+    range_ = getattr(args, "range", None)
+    max_bytes = getattr(args, "max_bytes", 0)
+
+    from gdoc.api.docs import resolve_tab
+    from gdoc.api.sheets import batch_get_values, get_spreadsheet_meta, get_values
+    from gdoc.format import format_json, get_output_mode
+
+    meta = get_spreadsheet_meta(doc_id)
+    sheets = sorted(meta["sheets"], key=lambda s: s["index"])
+    if not sheets:
+        raise GdocError("spreadsheet has no worksheets")
+
+    mode = get_output_mode(args)
+    formatter = _format_sheet_tsv if mode == "plain" else _format_sheet_table
+
+    if all_tabs:
+        if range_:
+            raise GdocError(
+                "--range and --all-tabs are mutually exclusive", exit_code=3
+            )
+        ranges = [_quote_sheet_title(s["title"]) for s in sheets]
+        results = list(zip(sheets, batch_get_values(doc_id, ranges)))
+        if mode == "json":
+            print(
+                format_json(
+                    tabs=[
+                        {
+                            "title": s["title"],
+                            "range": d["range"],
+                            "values": d["values"],
+                        }
+                        for s, d in results
+                    ]
+                )
+            )
+        else:
+            parts = []
+            for s, d in results:
+                parts.append(f"=== Tab: {s['title']} ===\n")
+                parts.append(formatter(d["values"]))
+            print(_truncate_bytes("".join(parts), max_bytes), end="")
+    else:
+        if tab:
+            target = resolve_tab(sheets, tab)
+        else:
+            target = sheets[0]
+            if len(sheets) > 1 and not quiet:
+                print(
+                    f"--- {len(sheets)} tabs; showing \"{target['title']}\" "
+                    "(use --tab or --all-tabs) ---",
+                    file=sys.stderr,
+                )
+        a1 = _quote_sheet_title(target["title"])
+        if range_:
+            a1 += f"!{range_}"
+        data = get_values(doc_id, a1)
+        if mode == "json":
+            print(format_json(range=data["range"], values=data["values"]))
+        else:
+            print(_truncate_bytes(formatter(data["values"]), max_bytes), end="")
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(doc_id, change_info, command="cat", quiet=quiet)
+    return 0
+
+
 def cmd_cat(args) -> int:
     """Handler for `gdoc cat`."""
     doc_id = _resolve_doc_id(args.doc)
@@ -59,10 +196,16 @@ def cmd_cat(args) -> int:
     max_bytes = getattr(args, "max_bytes", 0)
     no_images = getattr(args, "no_images", False)
 
-    if tab or all_tabs:
-        from gdoc.notify import pre_flight
-        change_info = pre_flight(doc_id, quiet=quiet)
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
 
+    if _file_mime(doc_id, change_info) == SPREADSHEET_MIME:
+        return _cat_sheet(args, doc_id, change_info)
+
+    if getattr(args, "range", None):
+        raise GdocError("--range is only supported for spreadsheets", exit_code=3)
+
+    if tab or all_tabs:
         from gdoc.api.docs import get_document_tabs, get_tab_text
 
         tabs = get_document_tabs(doc_id)
@@ -118,9 +261,6 @@ def cmd_cat(args) -> int:
 
     if getattr(args, "comments", False):
         # Annotated view: line-numbered content + inline comment annotations
-        from gdoc.notify import pre_flight
-        change_info = pre_flight(doc_id, quiet=quiet)
-
         from gdoc.api.drive import export_doc
         markdown = export_doc(doc_id, mime_type="text/markdown")
 
@@ -152,10 +292,6 @@ def cmd_cat(args) -> int:
 
         return 0
 
-    # Pre-flight awareness check
-    from gdoc.notify import pre_flight
-    change_info = pre_flight(doc_id, quiet=quiet)
-
     mime_type = "text/plain" if getattr(args, "plain", False) else "text/markdown"
 
     from gdoc.api.drive import export_doc
@@ -181,6 +317,33 @@ def cmd_cat(args) -> int:
     return 0
 
 
+def _tabs_sheet(args, doc_id: str, change_info) -> int:
+    """Spreadsheet branch of `gdoc tabs`: list worksheets."""
+    quiet = getattr(args, "quiet", False)
+
+    from gdoc.api.sheets import get_spreadsheet_meta
+    from gdoc.format import format_json, get_output_mode
+
+    sheets = sorted(get_spreadsheet_meta(doc_id)["sheets"], key=lambda s: s["index"])
+
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(tabs=sheets))
+    elif mode == "plain":
+        for s in sheets:
+            print(f"{s['id']}\t{s['title']}")
+    elif not sheets:
+        print("No tabs.")
+    else:
+        for s in sheets:
+            print(f"{s['id']}\t{s['title']}\t{s['rows']}x{s['cols']}")
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(doc_id, change_info, command="tabs", quiet=quiet)
+    return 0
+
+
 def cmd_tabs(args) -> int:
     """Handler for `gdoc tabs`."""
     doc_id = _resolve_doc_id(args.doc)
@@ -188,6 +351,9 @@ def cmd_tabs(args) -> int:
 
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
+
+    if _file_mime(doc_id, change_info) == SPREADSHEET_MIME:
+        return _tabs_sheet(args, doc_id, change_info)
 
     from gdoc.api.docs import get_document_tabs
 
@@ -233,6 +399,7 @@ def cmd_toc(args) -> int:
     from gdoc.notify import pre_flight
 
     change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
 
     from gdoc.api.docs import get_document_headings
 
@@ -302,6 +469,7 @@ def cmd_add_tab(args) -> int:
 
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
 
     from gdoc.api.docs import add_tab
     result = add_tab(doc_id, title)
@@ -431,6 +599,87 @@ def cmd_insert(args) -> int:
     return 0
 
 
+def _read_cell_rows(args) -> list[list[str]]:
+    """Collect cell values for `gdoc cells` from -v/--file/--stdin."""
+    values = getattr(args, "value", None)
+    file_path = getattr(args, "file", None)
+    use_stdin = getattr(args, "stdin", False)
+
+    sources = sum(1 for s in (values, file_path, use_stdin) if s)
+    if sources != 1:
+        raise GdocError(
+            "provide values via exactly one of -v/--value, --file, or --stdin",
+            exit_code=3,
+        )
+
+    if values:
+        return [list(values)]
+
+    if file_path:
+        try:
+            with open(file_path, encoding="utf-8", newline="") as f:
+                if file_path.lower().endswith(".csv"):
+                    import csv
+
+                    return list(csv.reader(f))
+                return [line.rstrip("\n").split("\t") for line in f]
+        except OSError as e:
+            raise GdocError(f"cannot read {file_path}: {e}", exit_code=3)
+
+    rows = [line.rstrip("\n").split("\t") for line in sys.stdin]
+    if not rows:
+        raise GdocError("no values on stdin", exit_code=3)
+    return rows
+
+
+def cmd_cells(args) -> int:
+    """Handler for `gdoc cells`: write values into a spreadsheet range."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+
+    rows = _read_cell_rows(args)
+
+    from gdoc.notify import pre_flight
+
+    change_info = pre_flight(doc_id, quiet=quiet)
+
+    # Only checked when pre-flight already fetched the mime — the Sheets API
+    # rejects non-spreadsheets anyway, so --quiet skips the extra lookup.
+    if change_info is not None and change_info.mime_type not in (
+        "",
+        SPREADSHEET_MIME,
+    ):
+        raise GdocError(f"not a spreadsheet: {doc_id}", exit_code=3)
+
+    from gdoc.api.sheets import write_values
+
+    append = getattr(args, "append", False)
+    result = write_values(
+        doc_id,
+        args.range,
+        rows,
+        user_entered=getattr(args, "user_entered", False),
+        append=append,
+    )
+    verb = "Appended" if append else "Updated"
+
+    from gdoc.format import format_json, get_output_mode
+
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(**result))
+    elif mode == "plain":
+        print(f"range\t{result['range']}")
+        print(f"cells\t{result['cells']}")
+    else:
+        print(f"{verb} {result['range']} ({result['cells']} cells)")
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(doc_id, change_info, command="cells", quiet=quiet)
+    return 0
+
+
 def cmd_info(args) -> int:
     """Handler for `gdoc info`."""
     doc_id = _resolve_doc_id(args.doc)
@@ -444,14 +693,22 @@ def cmd_info(args) -> int:
     from gdoc.format import get_output_mode, format_json
 
     metadata = get_file_info(doc_id)
-    try:
-        text = export_doc(doc_id, mime_type="text/plain")
-        word_count = len(text.split())
-    except GdocError as e:
-        if "file is not a Google Docs editor document" in str(e):
-            word_count = None
-        else:
-            raise
+
+    sheet_tabs = None
+    if metadata.get("mimeType") == SPREADSHEET_MIME:
+        from gdoc.api.sheets import get_spreadsheet_meta
+
+        sheet_tabs = get_spreadsheet_meta(doc_id)["sheets"]
+        word_count = None
+    else:
+        try:
+            text = export_doc(doc_id, mime_type="text/plain")
+            word_count = len(text.split())
+        except GdocError as e:
+            if "file is not a Google Docs editor document" in str(e):
+                word_count = None
+            else:
+                raise
 
     title = metadata.get("name", "")
     owners = metadata.get("owners", [])
@@ -468,7 +725,15 @@ def cmd_info(args) -> int:
 
     mode = get_output_mode(args)
 
-    words_display = word_count if word_count is not None else "N/A"
+    if sheet_tabs is not None:
+        label, json_extra = "Tabs", {"tabs": sheet_tabs}
+        value = ", ".join(
+            f"{s['title']} ({s['rows']}x{s['cols']})" for s in sheet_tabs
+        )
+    else:
+        label = "Words"
+        value = word_count if word_count is not None else "N/A"
+        json_extra = {"words": value}
 
     if mode == "json":
         print(
@@ -477,14 +742,14 @@ def cmd_info(args) -> int:
                 title=title,
                 owner=owner,
                 modified=modified,
-                words=words_display,
+                **json_extra,
             )
         )
     elif mode == "plain":
         print(f"title\t{title}")
         print(f"owner\t{owner}")
         print(f"modified\t{modified}")
-        print(f"words\t{words_display}")
+        print(f"{label.lower()}\t{value}")
     elif mode == "verbose":
         print(f"Title: {title}")
         print(f"Owner: {owner}")
@@ -493,12 +758,12 @@ def cmd_info(args) -> int:
         print(f"Last editor: {last_editor}")
         print(f"Type: {mime_type}")
         print(f"Size: {size or 'N/A'}")
-        print(f"Words: {words_display}")
+        print(f"{label}: {value}")
     else:
         print(f"Title: {title}")
         print(f"Owner: {owner}")
         print(f"Modified: {modified[:10]}")
-        print(f"Words: {words_display}")
+        print(f"{label}: {value}")
 
     # Update state after success (version from get_file_info, Decision #14)
     command_version = metadata.get("version")
@@ -687,6 +952,7 @@ def cmd_edit(args) -> int:
     from gdoc.notify import pre_flight
 
     change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
 
     # Conflict warning (warn but don't block, per spec)
     if change_info and change_info.has_conflict:
@@ -792,6 +1058,7 @@ def _check_write_conflict(doc_id: str, quiet: bool, force: bool):
         from gdoc.notify import pre_flight
 
         change_info = pre_flight(doc_id, quiet=False)
+        _require_doc(doc_id, change_info)
 
         if not force:
             if change_info.last_read_version is None:
@@ -929,6 +1196,7 @@ def cmd_pull(args) -> int:
     from gdoc.notify import pre_flight
 
     change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
 
     # Export doc as markdown
     from gdoc.api.drive import export_doc, get_file_info
@@ -1212,6 +1480,7 @@ def cmd_diff(args) -> int:
     from gdoc.notify import pre_flight
 
     change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
 
     # Export doc
     from gdoc.api.drive import export_doc
@@ -1584,6 +1853,7 @@ def cmd_images(args) -> int:
     from gdoc.notify import pre_flight
 
     change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
 
     from gdoc.api.docs import list_inline_objects
 
@@ -2052,7 +2322,10 @@ def build_parser() -> GdocArgumentParser:
     find_p.set_defaults(func=cmd_find)
 
     # cat
-    cat_p = sub.add_parser("cat", parents=[output_parent], help="Export doc as markdown")
+    cat_p = sub.add_parser(
+        "cat", parents=[output_parent],
+        help="Export doc as markdown (spreadsheets print as a table)",
+    )
     cat_p.add_argument("doc", help="Document ID or URL")
     cat_p.add_argument(
         "--comments", action="store_true", help="Include comment annotations"
@@ -2069,6 +2342,10 @@ def build_parser() -> GdocArgumentParser:
         "--all-tabs", action="store_true", help="Read all tabs"
     )
     cat_p.add_argument(
+        "--range",
+        help="A1 range to read, e.g. B2:D10 (spreadsheets only)",
+    )
+    cat_p.add_argument(
         "--max-bytes", type=int, default=0,
         help="Truncate output at N bytes (0 = unlimited)",
     )
@@ -2082,12 +2359,49 @@ def build_parser() -> GdocArgumentParser:
     cat_p.set_defaults(func=cmd_cat)
 
     # tabs
-    tabs_p = sub.add_parser("tabs", parents=[output_parent], help="List tabs in a doc")
+    tabs_p = sub.add_parser(
+        "tabs", parents=[output_parent],
+        help="List tabs in a doc (or worksheets in a spreadsheet)",
+    )
     tabs_p.add_argument("doc", help="Document ID or URL")
     tabs_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     tabs_p.set_defaults(func=cmd_tabs)
+
+    # cells
+    cells_p = sub.add_parser(
+        "cells", parents=[output_parent],
+        help="Write values into a spreadsheet range",
+    )
+    cells_p.add_argument("doc", help="Spreadsheet ID or URL")
+    cells_p.add_argument(
+        "range",
+        help="A1 range to write, e.g. B2 or 'Sheet1'!B2:C4",
+    )
+    cells_values_group = cells_p.add_mutually_exclusive_group()
+    cells_values_group.add_argument(
+        "-v", "--value", action="append",
+        help="Cell value; repeat for multiple cells in one row",
+    )
+    cells_values_group.add_argument(
+        "--file", help="Read rows from a local file (.csv, or TSV otherwise)"
+    )
+    cells_values_group.add_argument(
+        "--stdin", action="store_true", help="Read TSV rows from stdin"
+    )
+    cells_p.add_argument(
+        "--append", action="store_true",
+        help="Append rows after the table containing the range",
+    )
+    cells_p.add_argument(
+        "--user-entered", action="store_true",
+        help="Parse values as if typed in the UI (formulas, numbers, dates)",
+    )
+    cells_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    cells_p.set_defaults(func=cmd_cells)
 
     # toc
     toc_p = sub.add_parser(

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -663,6 +663,12 @@ def cmd_cells(args) -> int:
     )
     verb = "Appended" if append else "Updated"
 
+    # Record the post-write version so the next pre-flight doesn't report
+    # this command's own write as an external edit.
+    from gdoc.api.drive import get_file_version
+
+    command_version = get_file_version(doc_id).get("version")
+
     from gdoc.format import format_json, get_output_mode
 
     mode = get_output_mode(args)
@@ -676,7 +682,10 @@ def cmd_cells(args) -> int:
 
     from gdoc.state import update_state_after_command
 
-    update_state_after_command(doc_id, change_info, command="cells", quiet=quiet)
+    update_state_after_command(
+        doc_id, change_info, command="cells",
+        quiet=quiet, command_version=command_version,
+    )
     return 0
 
 

--- a/gdoc/notify.py
+++ b/gdoc/notify.py
@@ -32,6 +32,9 @@ class ChangeInfo:
     all_comment_ids: list[str] = field(default_factory=list)
     all_resolved_ids: list[str] = field(default_factory=list)
 
+    # File mimeType from the pre-flight files.get (spreadsheet detection)
+    mime_type: str = ""
+
     @property
     def has_changes(self) -> bool:
         """True if any changes were detected."""
@@ -93,6 +96,7 @@ def pre_flight(doc_id: str, quiet: bool = False) -> ChangeInfo | None:
         current_version=current_version,
         preflight_timestamp=preflight_ts,
         last_read_version=last_read_version,
+        mime_type=version_data.get("mimeType", ""),
     )
 
     if state is None:

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -28,6 +28,8 @@ if _OLD_CONFIG_DIR.is_dir() and not CONFIG_DIR.exists():
     CONFIG_DIR.parent.mkdir(parents=True, exist_ok=True)
     _OLD_CONFIG_DIR.rename(CONFIG_DIR)
 
+SPREADSHEET_MIME = "application/vnd.google-apps.spreadsheet"
+
 TOKEN_PATH = CONFIG_DIR / "token.json"
 CREDS_PATH = CONFIG_DIR / "credentials.json"
 STATE_DIR = CONFIG_DIR / "state"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.7.6"
+version = "0.8.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,18 @@
 """Shared test fixtures. Added as needed."""
+
+import pytest
+
+DOC_MIME = "application/vnd.google-apps.document"
+
+
+@pytest.fixture
+def doc_mime(monkeypatch):
+    """Pin pre-flight mime detection to a plain Google Doc.
+
+    Patches the Drive boundary that gdoc.cli._file_mime falls back to when
+    pre_flight is mocked away, keeping spreadsheet routing on the Docs path.
+    """
+    monkeypatch.setattr(
+        "gdoc.api.drive.get_file_version",
+        lambda doc_id: {"mimeType": DOC_MIME, "version": 1, "modifiedTime": ""},
+    )

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -31,6 +31,11 @@ def _make_args(**overrides):
     return SimpleNamespace(**defaults)
 
 
+
+@pytest.fixture(autouse=True)
+def _doc_mime(doc_mime):
+    """Keep spreadsheet detection on the Docs path for this module."""
+
 class TestCatMarkdown:
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)

--- a/tests/test_cat_tabs.py
+++ b/tests/test_cat_tabs.py
@@ -11,6 +11,11 @@ from gdoc.notify import ChangeInfo
 from gdoc.util import GdocError
 
 
+@pytest.fixture(autouse=True)
+def _doc_mime(doc_mime):
+    """Keep spreadsheet detection on the Docs path for this module."""
+
+
 def _make_args(**overrides):
     defaults = {
         "command": "cat",

--- a/tests/test_sheets_api.py
+++ b/tests/test_sheets_api.py
@@ -31,8 +31,9 @@ def _mock_service():
 class TestTranslateHttpError:
     def test_401_raises_auth_error(self):
         err = _make_http_error(401)
-        with pytest.raises(AuthError, match="Authentication expired"):
+        with pytest.raises(AuthError, match="Authentication expired") as exc_info:
             _translate_http_error(err, "abc123")
+        assert exc_info.value.exit_code == 2
 
     def test_403_raises_gdoc_error(self):
         err = _make_http_error(403, reason="forbidden")
@@ -46,8 +47,9 @@ class TestTranslateHttpError:
 
     def test_400_bad_range(self):
         err = _make_http_error(400, reason="Unable to parse range: 'Nope'!ZZ")
-        with pytest.raises(GdocError, match="Invalid range"):
+        with pytest.raises(GdocError, match="Invalid range") as exc_info:
             _translate_http_error(err, "abc123")
+        assert exc_info.value.exit_code == 3
 
     def test_400_other(self):
         err = _make_http_error(400, reason="something else")

--- a/tests/test_sheets_api.py
+++ b/tests/test_sheets_api.py
@@ -1,0 +1,192 @@
+"""Tests for gdoc.api.sheets: Sheets API wrapper functions with mocked service."""
+
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc.api.sheets import (
+    _translate_http_error,
+    batch_get_values,
+    get_spreadsheet_meta,
+    get_values,
+    write_values,
+)
+from gdoc.util import AuthError, GdocError
+
+
+def _make_http_error(status: int, reason: str = "") -> HttpError:
+    """Create a mock HttpError with the given status and reason."""
+    resp = httplib2.Response({"status": str(status)})
+    error = HttpError(resp, b"")
+    error.reason = reason
+    return error
+
+
+def _mock_service():
+    return MagicMock()
+
+
+class TestTranslateHttpError:
+    def test_401_raises_auth_error(self):
+        err = _make_http_error(401)
+        with pytest.raises(AuthError, match="Authentication expired"):
+            _translate_http_error(err, "abc123")
+
+    def test_403_raises_gdoc_error(self):
+        err = _make_http_error(403, reason="forbidden")
+        with pytest.raises(GdocError, match="Permission denied: abc123"):
+            _translate_http_error(err, "abc123")
+
+    def test_404_raises_gdoc_error(self):
+        err = _make_http_error(404)
+        with pytest.raises(GdocError, match="Spreadsheet not found: abc123"):
+            _translate_http_error(err, "abc123")
+
+    def test_400_bad_range(self):
+        err = _make_http_error(400, reason="Unable to parse range: 'Nope'!ZZ")
+        with pytest.raises(GdocError, match="Invalid range"):
+            _translate_http_error(err, "abc123")
+
+    def test_400_other(self):
+        err = _make_http_error(400, reason="something else")
+        with pytest.raises(GdocError, match="Sheets API error: something else"):
+            _translate_http_error(err, "abc123")
+
+    def test_other_status(self):
+        err = _make_http_error(500, reason="boom")
+        with pytest.raises(GdocError, match=r"API error \(500\): boom"):
+            _translate_http_error(err, "abc123")
+
+
+class TestGetSpreadsheetMeta:
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_returns_title_and_sheets(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        service.spreadsheets().get().execute.return_value = {
+            "properties": {"title": "Budget"},
+            "sheets": [
+                {
+                    "properties": {
+                        "sheetId": 0,
+                        "title": "Sheet1",
+                        "index": 0,
+                        "gridProperties": {"rowCount": 100, "columnCount": 26},
+                    }
+                },
+                {
+                    "properties": {
+                        "sheetId": 99,
+                        "title": "Data",
+                        "index": 1,
+                        "gridProperties": {"rowCount": 5, "columnCount": 3},
+                    }
+                },
+            ],
+        }
+        meta = get_spreadsheet_meta("sheet123")
+        assert meta["title"] == "Budget"
+        assert meta["sheets"] == [
+            {"id": 0, "title": "Sheet1", "index": 0, "rows": 100, "cols": 26},
+            {"id": 99, "title": "Data", "index": 1, "rows": 5, "cols": 3},
+        ]
+
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_http_error_translated(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        service.spreadsheets().get().execute.side_effect = _make_http_error(404)
+        with pytest.raises(GdocError, match="Spreadsheet not found"):
+            get_spreadsheet_meta("sheet123")
+
+
+class TestGetValues:
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_returns_range_and_values(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        service.spreadsheets().values().get().execute.return_value = {
+            "range": "Sheet1!A1:B2",
+            "values": [["a", "b"], ["c"]],
+        }
+        data = get_values("sheet123", "'Sheet1'")
+        assert data == {"range": "Sheet1!A1:B2", "values": [["a", "b"], ["c"]]}
+
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_empty_sheet_has_no_values_key(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        service.spreadsheets().values().get().execute.return_value = {
+            "range": "Sheet1!A1:Z100",
+        }
+        data = get_values("sheet123", "'Sheet1'")
+        assert data["values"] == []
+
+
+class TestWriteValues:
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_update_raw(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        update = service.spreadsheets().values().update
+        update().execute.return_value = {
+            "updatedRange": "Sheet1!B2:C3",
+            "updatedRows": 2,
+            "updatedCells": 4,
+        }
+        update.reset_mock()
+        result = write_values("sheet123", "B2:C3", [["a", "b"], ["c", "d"]])
+        assert result == {"range": "Sheet1!B2:C3", "rows": 2, "cells": 4}
+        kwargs = update.call_args.kwargs
+        assert kwargs["valueInputOption"] == "RAW"
+        assert kwargs["body"] == {"values": [["a", "b"], ["c", "d"]]}
+
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_update_user_entered(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        update = service.spreadsheets().values().update
+        update().execute.return_value = {}
+        update.reset_mock()
+        write_values("sheet123", "B2", [["=SUM(A:A)"]], user_entered=True)
+        assert update.call_args.kwargs["valueInputOption"] == "USER_ENTERED"
+
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_append(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        append = service.spreadsheets().values().append
+        append().execute.return_value = {
+            "updates": {
+                "updatedRange": "Sheet1!A5:B5",
+                "updatedRows": 1,
+                "updatedCells": 2,
+            }
+        }
+        append.reset_mock()
+        result = write_values("sheet123", "A1", [["x", "y"]], append=True)
+        assert result == {"range": "Sheet1!A5:B5", "rows": 1, "cells": 2}
+        assert append.call_args.kwargs["insertDataOption"] == "INSERT_ROWS"
+
+
+class TestBatchGetValues:
+    @patch("gdoc.api.sheets.get_sheets_service")
+    def test_one_round_trip_in_order(self, mock_svc):
+        service = _mock_service()
+        mock_svc.return_value = service
+        batch = service.spreadsheets().values().batchGet
+        batch().execute.return_value = {
+            "valueRanges": [
+                {"range": "Sheet1!A1:B2", "values": [["a"]]},
+                {"range": "Two!A1:C3"},
+            ]
+        }
+        batch.reset_mock()
+        result = batch_get_values("sheet123", ["'Sheet1'", "'Two'"])
+        assert result == [
+            {"range": "Sheet1!A1:B2", "values": [["a"]]},
+            {"range": "Two!A1:C3", "values": []},
+        ]
+        assert batch.call_args.kwargs["ranges"] == ["'Sheet1'", "'Two'"]

--- a/tests/test_sheets_cmd.py
+++ b/tests/test_sheets_cmd.py
@@ -1,0 +1,366 @@
+"""Tests for spreadsheet handling in `gdoc cat`/`tabs`/`cells`."""
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gdoc.cli import (
+    _format_sheet_table,
+    _format_sheet_tsv,
+    _quote_sheet_title,
+    cmd_cat,
+    cmd_cells,
+    cmd_tabs,
+)
+from gdoc.notify import ChangeInfo
+from gdoc.util import GdocError
+
+SHEET_MIME = "application/vnd.google-apps.spreadsheet"
+
+
+@pytest.fixture(autouse=True)
+def _sheet_mime(monkeypatch):
+    """Pin spreadsheet detection to the Sheets path for this module."""
+    monkeypatch.setattr(
+        "gdoc.cli._file_mime", lambda doc_id, change_info: SHEET_MIME
+    )
+
+
+def _make_args(**overrides):
+    defaults = {
+        "command": "cat",
+        "doc": "sheet123",
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": False,
+        "tab": None,
+        "all_tabs": False,
+        "range": None,
+        "comments": False,
+        "max_bytes": 0,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _meta(*sheets):
+    return {"title": "Test", "sheets": list(sheets)}
+
+
+def _sheet(id=0, title="Sheet1", index=0, rows=100, cols=26):
+    return {"id": id, "title": title, "index": index, "rows": rows, "cols": cols}
+
+
+class TestFormatters:
+    def test_quote_sheet_title(self):
+        assert _quote_sheet_title("Sheet1") == "'Sheet1'"
+        assert _quote_sheet_title("It's") == "'It''s'"
+
+    def test_tsv_pads_and_cleans(self):
+        out = _format_sheet_tsv([["a", "b\tc"], ["d"]])
+        assert out == "a\tb c\nd\t\n"
+
+    def test_table_first_row_is_header(self):
+        out = _format_sheet_table([["Name", "Y/N"], ["Ada", "Y"]])
+        lines = out.splitlines()
+        assert lines[0] == "| Name | Y/N |"
+        assert lines[1] == "| ---- | --- |"
+        assert lines[2] == "| Ada  | Y   |"
+
+    def test_table_escapes_pipes(self):
+        out = _format_sheet_table([["a|b"], ["c"]])
+        assert "a\\|b" in out
+
+    def test_table_empty(self):
+        assert _format_sheet_table([]) == "(no values)\n"
+
+
+class TestCatSheet:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_default_first_sheet_markdown(
+        self, mock_meta, mock_values, _pf, _update, capsys
+    ):
+        mock_meta.return_value = _meta(_sheet())
+        mock_values.return_value = {
+            "range": "Sheet1!A1:B2",
+            "values": [["Name", "OK"], ["Ada", "Y"]],
+        }
+        rc = cmd_cat(_make_args())
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "| Name | OK" in out
+        assert "| Ada " in out
+        mock_values.assert_called_once_with("sheet123", "'Sheet1'")
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_multi_tab_hint_on_stderr(
+        self, mock_meta, mock_values, _pf, _update, capsys
+    ):
+        mock_meta.return_value = _meta(_sheet(), _sheet(id=1, title="Two", index=1))
+        mock_values.return_value = {"range": "Sheet1!A1", "values": [["x"]]}
+        cmd_cat(_make_args())
+        err = capsys.readouterr().err
+        assert "2 tabs" in err
+        assert "--all-tabs" in err
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_tab_and_range(self, mock_meta, mock_values, _pf, _update, capsys):
+        mock_meta.return_value = _meta(_sheet(), _sheet(id=7, title="Data", index=1))
+        mock_values.return_value = {"range": "Data!B2:C3", "values": [["1", "2"]]}
+        cmd_cat(_make_args(tab="data", range="B2:C3"))
+        mock_values.assert_called_once_with("sheet123", "'Data'!B2:C3")
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_tab_by_sheet_id(self, mock_meta, mock_values, _pf, _update):
+        mock_meta.return_value = _meta(_sheet(), _sheet(id=7, title="Data", index=1))
+        mock_values.return_value = {"range": "Data!A1", "values": []}
+        cmd_cat(_make_args(tab="7"))
+        mock_values.assert_called_once_with("sheet123", "'Data'")
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_tab_not_found(self, mock_meta, _pf, _update):
+        mock_meta.return_value = _meta(_sheet())
+        with pytest.raises(GdocError, match="tab not found: Nope"):
+            cmd_cat(_make_args(tab="Nope"))
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_plain_tsv(self, mock_meta, mock_values, _pf, _update, capsys):
+        mock_meta.return_value = _meta(_sheet())
+        mock_values.return_value = {
+            "range": "Sheet1!A1:B2",
+            "values": [["Name", "OK"], ["Ada"]],
+        }
+        cmd_cat(_make_args(plain=True))
+        out = capsys.readouterr().out
+        assert out == "Name\tOK\nAda\t\n"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_json_output(self, mock_meta, mock_values, _pf, _update, capsys):
+        mock_meta.return_value = _meta(_sheet())
+        mock_values.return_value = {"range": "Sheet1!A1", "values": [["x"]]}
+        cmd_cat(_make_args(json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data == {"ok": True, "range": "Sheet1!A1", "values": [["x"]]}
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.batch_get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_all_tabs(self, mock_meta, mock_batch, _pf, _update, capsys):
+        mock_meta.return_value = _meta(_sheet(), _sheet(id=1, title="Two", index=1))
+        mock_batch.return_value = [
+            {"range": "Sheet1!A1", "values": [["a"]]},
+            {"range": "Two!A1", "values": [["b"]]},
+        ]
+        cmd_cat(_make_args(all_tabs=True))
+        out = capsys.readouterr().out
+        assert "=== Tab: Sheet1 ===" in out
+        assert "=== Tab: Two ===" in out
+        mock_batch.assert_called_once_with("sheet123", ["'Sheet1'", "'Two'"])
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_all_tabs_with_range_rejected(self, mock_meta, _pf, _update):
+        mock_meta.return_value = _meta(_sheet())
+        with pytest.raises(GdocError, match="mutually exclusive"):
+            cmd_cat(_make_args(all_tabs=True, range="A1:B2"))
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_comments_rejected(self, _pf, _update):
+        with pytest.raises(GdocError, match="not supported for spreadsheets"):
+            cmd_cat(_make_args(comments=True))
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight")
+    @patch("gdoc.api.sheets.get_values")
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_mime_from_preflight(
+        self, mock_meta, mock_values, mock_pf, _update, capsys, monkeypatch
+    ):
+        # Use the real _file_mime: detection comes from ChangeInfo.mime_type.
+        from gdoc.cli import _file_mime
+
+        monkeypatch.setattr("gdoc.cli._file_mime", _file_mime)
+        mock_pf.return_value = ChangeInfo(mime_type=SHEET_MIME)
+        mock_meta.return_value = _meta(_sheet())
+        mock_values.return_value = {"range": "Sheet1!A1", "values": [["x"]]}
+        rc = cmd_cat(_make_args())
+        assert rc == 0
+
+
+class TestCatDocRangeRejected:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_range_on_doc_rejected(self, _pf, _update, monkeypatch):
+        monkeypatch.setattr(
+            "gdoc.cli._file_mime",
+            lambda doc_id, change_info: "application/vnd.google-apps.document",
+        )
+        with pytest.raises(GdocError, match="only supported for spreadsheets"):
+            cmd_cat(_make_args(range="A1:B2"))
+
+
+class TestTabsSheet:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_terse_lists_dims(self, mock_meta, _pf, _update, capsys):
+        mock_meta.return_value = _meta(
+            _sheet(), _sheet(id=7, title="Data", index=1, rows=5, cols=3)
+        )
+        rc = cmd_tabs(_make_args(command="tabs"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "0\tSheet1\t100x26" in out
+        assert "7\tData\t5x3" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_json(self, mock_meta, _pf, _update, capsys):
+        mock_meta.return_value = _meta(_sheet())
+        cmd_tabs(_make_args(command="tabs", json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data["tabs"][0]["title"] == "Sheet1"
+        assert data["tabs"][0]["rows"] == 100
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.get_spreadsheet_meta")
+    def test_plain(self, mock_meta, _pf, _update, capsys):
+        mock_meta.return_value = _meta(_sheet())
+        cmd_tabs(_make_args(command="tabs", plain=True))
+        assert capsys.readouterr().out == "0\tSheet1\n"
+
+
+def _cells_args(**overrides):
+    defaults = {
+        "command": "cells",
+        "doc": "sheet123",
+        "range": "B2",
+        "value": None,
+        "file": None,
+        "stdin": False,
+        "append": False,
+        "user_entered": False,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestCells:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_single_value(self, mock_update, _pf, _state, capsys):
+        mock_update.return_value = {"range": "Sheet1!B2", "rows": 1, "cells": 1}
+        rc = cmd_cells(_cells_args(value=["Y"]))
+        assert rc == 0
+        mock_update.assert_called_once_with(
+            "sheet123", "B2", [["Y"]], user_entered=False, append=False
+        )
+        assert "Updated Sheet1!B2 (1 cells)" in capsys.readouterr().out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_multiple_values_one_row(self, mock_update, _pf, _state):
+        mock_update.return_value = {"range": "Sheet1!B2:C2", "rows": 1, "cells": 2}
+        cmd_cells(_cells_args(range="B2:C2", value=["Y", "quote"]))
+        assert mock_update.call_args.args[2] == [["Y", "quote"]]
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_stdin_tsv(self, mock_update, _pf, _state, monkeypatch):
+        monkeypatch.setattr("sys.stdin", io.StringIO("a\tb\nc\td\n"))
+        mock_update.return_value = {"range": "Sheet1!A1:B2", "rows": 2, "cells": 4}
+        cmd_cells(_cells_args(range="A1", stdin=True))
+        assert mock_update.call_args.args[2] == [["a", "b"], ["c", "d"]]
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_csv_file(self, mock_update, _pf, _state, tmp_path):
+        f = tmp_path / "vals.csv"
+        f.write_text('a,"b,c"\nd,e\n', encoding="utf-8")
+        mock_update.return_value = {"range": "Sheet1!A1:B2", "rows": 2, "cells": 4}
+        cmd_cells(_cells_args(range="A1", file=str(f)))
+        assert mock_update.call_args.args[2] == [["a", "b,c"], ["d", "e"]]
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_append(self, mock_write, _pf, _state, capsys):
+        mock_write.return_value = {"range": "Sheet1!A5", "rows": 1, "cells": 1}
+        cmd_cells(_cells_args(range="A1", value=["new"], append=True))
+        assert mock_write.call_args.kwargs["append"] is True
+        assert "Appended" in capsys.readouterr().out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_user_entered(self, mock_update, _pf, _state):
+        mock_update.return_value = {"range": "Sheet1!B2", "rows": 1, "cells": 1}
+        cmd_cells(_cells_args(value=["=SUM(A:A)"], user_entered=True))
+        assert mock_update.call_args.kwargs["user_entered"] is True
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_no_value_source_rejected(self, _pf, _state):
+        with pytest.raises(GdocError, match="exactly one of"):
+            cmd_cells(_cells_args())
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_two_value_sources_rejected(self, _pf, _state):
+        with pytest.raises(GdocError, match="exactly one of"):
+            cmd_cells(_cells_args(value=["x"], stdin=True))
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch(
+        "gdoc.notify.pre_flight",
+        return_value=ChangeInfo(mime_type="application/vnd.google-apps.document"),
+    )
+    def test_not_a_spreadsheet(self, _pf, _state):
+        with pytest.raises(GdocError, match="not a spreadsheet"):
+            cmd_cells(_cells_args(value=["x"]))
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_json_output(self, mock_update, _pf, _state, capsys):
+        mock_update.return_value = {"range": "Sheet1!B2", "rows": 1, "cells": 1}
+        cmd_cells(_cells_args(value=["Y"], json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data == {"ok": True, "range": "Sheet1!B2", "rows": 1, "cells": 1}

--- a/tests/test_sheets_cmd.py
+++ b/tests/test_sheets_cmd.py
@@ -362,6 +362,23 @@ class TestCells:
             cmd_cells(_cells_args(value=["x"]))
 
     @patch("gdoc.state.update_state_after_command")
+    @patch(
+        "gdoc.notify.pre_flight",
+        return_value=ChangeInfo(
+            mime_type=SHEET_MIME, current_version=5, last_read_version=3
+        ),
+    )
+    @patch("gdoc.api.sheets.write_values")
+    def test_conflict_warns_but_writes(self, mock_update, _pf, _state, capsys):
+        mock_update.return_value = {"range": "Sheet1!B2", "rows": 1, "cells": 1}
+        rc = cmd_cells(_cells_args(value=["Y"]))
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "WARN: doc changed since last read" in captured.err
+        assert "Updated" in captured.out
+        mock_update.assert_called_once()
+
+    @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
     @patch("gdoc.api.sheets.write_values")
     def test_records_post_write_version(self, mock_update, _pf, mock_state):

--- a/tests/test_sheets_cmd.py
+++ b/tests/test_sheets_cmd.py
@@ -27,6 +27,11 @@ def _sheet_mime(monkeypatch):
     monkeypatch.setattr(
         "gdoc.cli._file_mime", lambda doc_id, change_info: SHEET_MIME
     )
+    # cmd_cells re-fetches the version after writing
+    monkeypatch.setattr(
+        "gdoc.api.drive.get_file_version",
+        lambda doc_id: {"mimeType": SHEET_MIME, "version": 7, "modifiedTime": ""},
+    )
 
 
 def _make_args(**overrides):
@@ -355,6 +360,14 @@ class TestCells:
     def test_not_a_spreadsheet(self, _pf, _state):
         with pytest.raises(GdocError, match="not a spreadsheet"):
             cmd_cells(_cells_args(value=["x"]))
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.sheets.write_values")
+    def test_records_post_write_version(self, mock_update, _pf, mock_state):
+        mock_update.return_value = {"range": "Sheet1!B2", "rows": 1, "cells": 1}
+        cmd_cells(_cells_args(value=["Y"]))
+        assert mock_state.call_args.kwargs["command_version"] == 7
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)

--- a/tests/test_tabs_cmd.py
+++ b/tests/test_tabs_cmd.py
@@ -11,6 +11,11 @@ from gdoc.notify import ChangeInfo
 from gdoc.util import GdocError
 
 
+@pytest.fixture(autouse=True)
+def _doc_mime(doc_mime):
+    """Keep spreadsheet detection on the Docs path for this module."""
+
+
 def _make_args(**overrides):
     defaults = {
         "command": "tabs",

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.7.6"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## What

`gdoc` now handles Google Sheets. Reads are transparent — point existing commands at a spreadsheet URL and they do the right thing; writes get one new command.

### Reads
- `cat SHEET` prints a markdown table (`--plain` → TSV, `--json` → raw rows)
- `--tab` selects a worksheet by title or numeric sheet id (the `gid`), `--range A1:C10` reads a slice
- `--all-tabs` fetches every worksheet in **one** `values.batchGet` round-trip
- `tabs SHEET` lists worksheets with dimensions; `info SHEET` shows the tab list instead of a word count (previously crashed with `API error (400): The requested conversion is not supported.`)
- Default read is the first worksheet, with a stderr hint when more tabs exist

### Writes
- `cells SHEET RANGE` — values from repeated `-v` flags, a CSV/TSV `--file`, or TSV `--stdin`
- `--append` inserts rows below the existing table; `--user-entered` parses formulas/dates/numbers like the UI

### Guard rails
Doc-only commands (`edit`/`write`/`pull`/`push`/`insert`/`toc`/`add-tab`/`diff`/`images`) now reject spreadsheets with `not a Google Doc: … (spreadsheets support cat/tabs/info/cells only)` instead of the cryptic conversion error or a misleading "Document not found".

## How

- New `gdoc/api/sheets.py` (meta, `get_values`, `batch_get_values`, `write_values`) following the established per-API error-translation pattern; `get_sheets_service()` in the service factory
- Detection is free in the normal path: `mimeType` piggybacks on the pre-flight `files.get` (`ChangeInfo.mime_type`); only `--quiet` pays one extra metadata call on `cat`/`tabs`
- The existing `drive` OAuth scope covers the Sheets API v4 — **no re-authentication needed**
- `resolve_tab` id comparison coerced to `str()` so it serves both docs (string ids) and sheets (int gids)
- Pre-flight banners, state tracking, and `--account` work unchanged on spreadsheets

## Testing

- 926 tests pass (43 new across `test_sheets_api.py` / `test_sheets_cmd.py`)
- New shared `conftest.py` `doc_mime` fixture pins mime detection at the Drive boundary for doc-path test modules (`test_cat.py` previously passed only by MagicMock accident)
- Live-tested against a real multi-owner spreadsheet: table/TSV/JSON reads, `--tab`/`--range`, idempotent `cells` write, and the doc-only guard error
- Ruff: new files clean; touched files below the pre-existing error baseline

Version bumped 0.7.6 → 0.8.0 (new feature, semver minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Google Sheets support with commands to read, list worksheets, and write cell ranges
- New `cells` command for writing spreadsheet data via CLI values, files, or stdin
- Spreadsheet output formats: TSV (`--plain`) and JSON
- `--range`, `--tab`, `--all-tabs`, `--append`, and `--user-entered` flags for spreadsheet operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->