### PR TITLE
update: compare versions numerically, never downgrade (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] — 2026-06-05
+
+### Fixed
+- `gdoc update` compared versions with plain inequality, so a stale GitHub
+  raw cache reporting an *older* version produced a backwards
+  "Update available: 0.8.0 → 0.7.6" notice — and `gdoc update` would
+  actually downgrade. Versions are now compared numerically and only
+  strictly-newer remotes trigger the notice/install.
+
 ## [0.8.0] — 2026-06-05
 
 ### Added

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/gdoc/update.py
+++ b/gdoc/update.py
@@ -31,6 +31,21 @@ def _latest_version() -> str | None:
         return None
 
 
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Parse the numeric parts of a version string for comparison."""
+    return tuple(int(p) for p in re.findall(r"\d+", version))
+
+
+def _is_newer(latest: str, current: str) -> bool:
+    """True if latest is strictly newer than current.
+
+    Plain inequality would offer an "update" to an older version whenever
+    the GitHub raw cache lags behind the installed build (and `gdoc update`
+    would actually downgrade).
+    """
+    return _version_tuple(latest) > _version_tuple(current)
+
+
 def _read_cache() -> dict:
     try:
         return json.loads(_CACHE_FILE.read_text()) if _CACHE_FILE.exists() else {}
@@ -59,7 +74,7 @@ def check_for_update() -> None:
             latest = _latest_version()
             if latest:
                 _write_cache(latest)
-        if latest and latest != _installed_version():
+        if latest and _is_newer(latest, _installed_version()):
             print(
                 f"Update available: {_installed_version()} → {latest}. "
                 f"Run `gdoc update` to update. "
@@ -79,7 +94,7 @@ def run_update() -> int:
     if latest is None:
         print("Could not check for updates. Are you online?")
         return 1
-    if latest == current:
+    if not _is_newer(latest, current):
         print("Already up to date.")
         _write_cache(latest)
         return 0
@@ -94,6 +109,6 @@ def run_update() -> int:
         _write_cache(latest)
         return 0
     else:
-        print(f"\nUpdate failed. Try manually:")
+        print("\nUpdate failed. Try manually:")
         print(f"  uv tool install --force git+https://github.com/{_GITHUB_REPO}.git")
         return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.8.0"
+version = "0.8.1"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_update_version.py
+++ b/tests/test_update_version.py
@@ -1,0 +1,58 @@
+"""Tests for update.py version comparison."""
+
+from unittest.mock import patch
+
+from gdoc.update import _is_newer, _version_tuple, run_update
+
+
+class TestVersionTuple:
+    def test_simple(self):
+        assert _version_tuple("0.7.6") == (0, 7, 6)
+
+    def test_double_digit_parts(self):
+        assert _version_tuple("0.10.2") == (0, 10, 2)
+
+
+class TestIsNewer:
+    def test_newer(self):
+        assert _is_newer("0.8.0", "0.7.6") is True
+
+    def test_older(self):
+        assert _is_newer("0.7.6", "0.8.0") is False
+
+    def test_equal(self):
+        assert _is_newer("0.8.0", "0.8.0") is False
+
+    def test_numeric_not_lexicographic(self):
+        # String comparison would call 0.9.9 newer than 0.10.0
+        assert _is_newer("0.10.0", "0.9.9") is True
+        assert _is_newer("0.9.9", "0.10.0") is False
+
+
+class TestRunUpdateStaleRemote:
+    @patch("gdoc.update._write_cache")
+    @patch("gdoc.update.subprocess.run")
+    @patch("gdoc.update._latest_version", return_value="0.7.6")
+    @patch("gdoc.update._installed_version", return_value="0.8.0")
+    def test_no_downgrade_when_remote_is_older(
+        self, _cur, _latest, mock_run, _cache, capsys
+    ):
+        # Stale GitHub raw cache reports an older version than installed:
+        # must say up to date, never downgrade.
+        rc = run_update()
+        assert rc == 0
+        assert "Already up to date." in capsys.readouterr().out
+        mock_run.assert_not_called()
+
+    @patch("gdoc.update._write_cache")
+    @patch("gdoc.update.subprocess.run")
+    @patch("gdoc.update._latest_version", return_value="0.8.1")
+    @patch("gdoc.update._installed_version", return_value="0.8.0")
+    def test_updates_when_remote_is_newer(
+        self, _cur, _latest, mock_run, _cache, capsys
+    ):
+        mock_run.return_value.returncode = 0
+        rc = run_update()
+        assert rc == 0
+        assert "Updating: 0.8.0 → 0.8.1" in capsys.readouterr().out
+        mock_run.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## What

`gdoc update` (and the 24h update notice) compared versions with plain `!=` / `==`. Any mismatch counted as an "update" — including the remote being **older** than the installed build.

This is not hypothetical: `raw.githubusercontent.com` caches `pyproject.toml` for ~5 minutes after a merge, so right after installing 0.8.0 from a fresh merge the CLI printed

```
Update available: 0.8.0 → 0.7.6. Run `gdoc update` to update.
```

…and running `gdoc update` at that moment would have **downgraded** back to 0.7.6 and written the stale version into the 24h cache.

## How

- New `_is_newer(latest, current)` compares numeric version tuples (`re.findall(r"\d+")` → `tuple[int]`), so `0.10.0 > 0.9.9` also works where lexicographic comparison wouldn't. No new dependency.
- `check_for_update` prints the notice only for strictly-newer remotes.
- `run_update` reports "Already up to date." (instead of downgrading) when the remote is equal **or older**.
- Drive-by: fixed the pre-existing F541 (placeholder-less f-string) in the same file.

Tests in `tests/test_update_version.py` (named to avoid colliding with the in-flight auto-update work's `test_update.py`): tuple parsing, newer/older/equal, the lexicographic trap, and a regression test that a stale-older remote never triggers `subprocess.run`.

936 tests pass. Version bumped 0.8.0 → 0.8.1 so the fix is itself installable via `gdoc update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)