### PR TITLE
update: auto-update on top-level help (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] — 2026-06-09
+
+### Added
+- **Auto-update on help.** Bare `gdoc`, `gdoc --help`, and `gdoc -h` now
+  upgrade to the latest release before printing help, so agents inspecting
+  the CLI surface always see current help text. Only applies to `uv tool`
+  installs, checks at most once per hour, and silently falls back to the
+  current version on any failure (offline, install error). Opt out with
+  `GDOC_AUTO_UPDATE=0`.
+- README: documented installing `uv` itself, the `gdoc update` command,
+  and the new auto-update behavior.
+
 ## [0.8.1] — 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A token-efficient CLI for AI agents to read, write, and collaborate on Google Do
 
 ## Install
 
+`gdoc` is installed via [uv](https://github.com/astral-sh/uv). If you don't have it:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+See the [uv installation docs](https://docs.astral.sh/uv/getting-started/installation/) for other options (Homebrew, pipx, Windows PowerShell).
+
+Then install `gdoc`:
+
 ```bash
 uv tool install git+https://github.com/LucaDeLeo/gdoc.git
 ```
@@ -17,6 +27,16 @@ git clone https://github.com/LucaDeLeo/gdoc.git
 cd gdoc
 uv tool install .
 ```
+
+## Updating
+
+```bash
+gdoc update
+```
+
+`gdoc` also keeps itself fresh: running bare `gdoc`, `gdoc --help`, or `gdoc -h` upgrades to the latest release before printing help, so agents inspecting the CLI surface always see current help text. This only applies to `uv tool` installs, checks at most once per hour, and silently skips on any failure (offline, install error). Set `GDOC_AUTO_UPDATE=0` to disable it.
+
+Other commands never auto-update — they print a notice to stderr (at most once per day) when a newer version is available.
 
 ## Setup
 
@@ -162,6 +182,7 @@ gdoc cat 1aBcDeFg...
 |---------|-------------|
 | `auth` | Authenticate with Google (`--no-browser` for headless) |
 | `share DOC EMAIL` | Share a document (`--role reader\|writer\|commenter`) |
+| `update` | Update gdoc to the latest release |
 
 ## Output modes
 
@@ -412,6 +433,7 @@ All files are stored under `~/.config/gdoc/`:
 | `accounts/<ACCOUNT>/token.json` | OAuth token for a named account |
 | `config.json` | Default account preference and other local configuration |
 | `state/<DOC_ID>.json` | Per-document state for change detection |
+| `update_check.json` | Cached result of the last update check |
 
 ## Development
 

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2738,8 +2738,20 @@ def build_parser() -> GdocArgumentParser:
     return parser
 
 
+def _is_top_level_help_invocation(argv: list[str]) -> bool:
+    """True for `gdoc`, `gdoc --help`, `gdoc -h` — but not subcommand help."""
+    rest = argv[1:]
+    if not rest:
+        return True
+    return rest[0] in ("--help", "-h")
+
+
 def main() -> int:
     """Entry point for the gdoc CLI."""
+    if _is_top_level_help_invocation(sys.argv):
+        from gdoc.update import auto_update_for_help
+        auto_update_for_help()
+
     parser = build_parser()
     args = parser.parse_args()
 

--- a/gdoc/update.py
+++ b/gdoc/update.py
@@ -1,6 +1,7 @@
 """Update checker for gdoc."""
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -12,6 +13,12 @@ _GITHUB_REPO = "LucaDeLeo/gdoc"
 _PACKAGE_NAME = "gdoc"
 _CACHE_FILE = Path.home() / ".config" / "gdoc" / "update_check.json"
 _CHANGELOG_URL = f"https://github.com/{_GITHUB_REPO}/blob/main/CHANGELOG.md"
+_AUTO_UPDATE_THROTTLE_SECONDS = 3600  # 1h
+_NOTICE_THROTTLE_SECONDS = 86400  # 24h
+_UV_INSTALL_TIMEOUT_SECONDS = 60
+
+_ENV_AUTO_UPDATE = "GDOC_AUTO_UPDATE"
+_ENV_SKIP_CHECK = "GDOC_SKIP_UPDATE_CHECK"
 
 
 def _installed_version() -> str:
@@ -48,7 +55,9 @@ def _is_newer(latest: str, current: str) -> bool:
 
 def _read_cache() -> dict:
     try:
-        return json.loads(_CACHE_FILE.read_text()) if _CACHE_FILE.exists() else {}
+        return json.loads(_CACHE_FILE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
     except Exception:
         return {}
 
@@ -64,25 +73,108 @@ def _write_cache(latest: str) -> None:
         pass
 
 
+def _get_latest_cached(throttle_seconds: int) -> str | None:
+    """Return latest version, fetching from network only when cache is stale."""
+    cache = _read_cache()
+    if time.time() - cache.get("checked_at", 0) < throttle_seconds:
+        return cache.get("latest_version")
+    latest = _latest_version()
+    if latest:
+        _write_cache(latest)
+    return latest
+
+
 def check_for_update() -> None:
     """Print a notice to stderr if an update is available. Cached for 24h."""
     try:
-        cache = _read_cache()
-        if time.time() - cache.get("checked_at", 0) < 86400:
-            latest = cache.get("latest_version")
-        else:
-            latest = _latest_version()
-            if latest:
-                _write_cache(latest)
-        if latest and _is_newer(latest, _installed_version()):
+        latest = _get_latest_cached(_NOTICE_THROTTLE_SECONDS)
+        current = _installed_version()
+        if latest and _is_newer(latest, current):
             print(
-                f"Update available: {_installed_version()} → {latest}. "
+                f"Update available: {current} → {latest}. "
                 f"Run `gdoc update` to update. "
                 f"Changelog: {_CHANGELOG_URL}",
                 file=sys.stderr,
             )
     except Exception:
         pass
+
+
+def _is_uv_tool_install() -> bool:
+    """uv tool install lays out interpreters at `.../uv/tools/<pkg>/...`.
+
+    Adjacency check avoids false positives from paths that happen to
+    contain those segments out of order.
+    """
+    parts = Path(sys.executable).resolve().parts
+    for i in range(len(parts) - 2):
+        if (
+            parts[i] == "uv"
+            and parts[i + 1] == "tools"
+            and parts[i + 2] == _PACKAGE_NAME
+        ):
+            return True
+    return False
+
+
+def auto_update_for_help() -> None:
+    """Block on `uv tool install --force` if a newer version exists, then re-exec.
+
+    Called before argparse for top-level help requests so agents inspecting
+    the CLI surface get the freshest help text. Silent on every failure mode
+    (offline, non-uv install, upgrade error) — never blocks help output.
+    """
+    if os.environ.get(_ENV_AUTO_UPDATE, "1") == "0":
+        return
+    if os.environ.get(_ENV_SKIP_CHECK) == "1":
+        return
+    if not _is_uv_tool_install():
+        return
+
+    try:
+        latest = _get_latest_cached(_AUTO_UPDATE_THROTTLE_SECONDS)
+        if not latest:
+            return
+        current = _installed_version()
+        if not _is_newer(latest, current):
+            return
+    except Exception:
+        return
+
+    print(f"Updating gdoc: {current} → {latest}...", file=sys.stderr)
+    try:
+        result = subprocess.run(
+            ["uv", "tool", "install", "--force",
+             f"git+https://github.com/{_GITHUB_REPO}.git"],
+            capture_output=True,
+            timeout=_UV_INSTALL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            "WARN: gdoc auto-update timed out; continuing with current version",
+            file=sys.stderr,
+        )
+        return
+    except Exception:
+        print(
+            "WARN: gdoc auto-update failed; continuing with current version",
+            file=sys.stderr,
+        )
+        return
+    if result.returncode != 0:
+        print(
+            "WARN: gdoc auto-update failed; continuing with current version",
+            file=sys.stderr,
+        )
+        stderr_text = (result.stderr or b"").decode(errors="replace").strip()
+        if stderr_text:
+            print(stderr_text, file=sys.stderr)
+        return
+    print(f"✓ updated to v{latest}", file=sys.stderr)
+
+    env = os.environ.copy()
+    env[_ENV_SKIP_CHECK] = "1"
+    os.execvpe("gdoc", ["gdoc", *sys.argv[1:]], env)
 
 
 def run_update() -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.8.1"
+version = "0.9.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,199 @@
+"""Tests for gdoc.update — auto-update on help and helpers."""
+
+import json
+import subprocess
+
+import pytest
+
+from gdoc import update
+
+
+@pytest.fixture
+def cache_file(tmp_path, monkeypatch):
+    """Redirect the update cache to a tmp path."""
+    path = tmp_path / "update_check.json"
+    monkeypatch.setattr(update, "_CACHE_FILE", path)
+    return path
+
+
+@pytest.fixture
+def fake_uv_install(monkeypatch):
+    """Make _is_uv_tool_install() return True."""
+    monkeypatch.setattr(update, "_is_uv_tool_install", lambda: True)
+
+
+class TestIsUvToolInstall:
+    def test_detects_uv_tool_path(self, monkeypatch):
+        monkeypatch.setattr(
+            update.sys, "executable",
+            "/Users/foo/.local/share/uv/tools/gdoc/bin/python",
+        )
+        assert update._is_uv_tool_install() is True
+
+    def test_rejects_non_uv_path(self, monkeypatch):
+        monkeypatch.setattr(update.sys, "executable", "/usr/bin/python3")
+        assert update._is_uv_tool_install() is False
+
+    def test_rejects_pip_install(self, monkeypatch):
+        monkeypatch.setattr(
+            update.sys, "executable",
+            "/Users/foo/.venv/bin/python",
+        )
+        assert update._is_uv_tool_install() is False
+
+    def test_rejects_path_with_segments_out_of_order(self, monkeypatch):
+        # Adjacency check guards against substring-style false positives.
+        monkeypatch.setattr(
+            update.sys, "executable",
+            "/home/uv/foo/tools/gdoc/bin/python",
+        )
+        assert update._is_uv_tool_install() is False
+
+
+class TestAutoUpdateForHelpSkips:
+    def test_skips_when_opt_out(self, monkeypatch, fake_uv_install):
+        monkeypatch.setenv("GDOC_AUTO_UPDATE", "0")
+        called = []
+        monkeypatch.setattr(update, "_latest_version", lambda: called.append(1))
+        update.auto_update_for_help()
+        assert called == []
+
+    def test_skips_when_recursion_guard_set(self, monkeypatch, fake_uv_install):
+        monkeypatch.setenv("GDOC_SKIP_UPDATE_CHECK", "1")
+        called = []
+        monkeypatch.setattr(update, "_latest_version", lambda: called.append(1))
+        update.auto_update_for_help()
+        assert called == []
+
+    def test_skips_when_not_uv_install(self, monkeypatch):
+        monkeypatch.setattr(update, "_is_uv_tool_install", lambda: False)
+        called = []
+        monkeypatch.setattr(update, "_latest_version", lambda: called.append(1))
+        update.auto_update_for_help()
+        assert called == []
+
+    def test_skips_when_already_up_to_date(
+        self, monkeypatch, fake_uv_install, cache_file
+    ):
+        monkeypatch.delenv("GDOC_AUTO_UPDATE", raising=False)
+        monkeypatch.delenv("GDOC_SKIP_UPDATE_CHECK", raising=False)
+        monkeypatch.setattr(update, "_latest_version", lambda: "1.2.3")
+        monkeypatch.setattr(update, "_installed_version", lambda: "1.2.3")
+        called = []
+        monkeypatch.setattr(
+            update.subprocess, "run",
+            lambda *a, **kw: called.append(a) or subprocess.CompletedProcess(a, 0),
+        )
+        update.auto_update_for_help()
+        assert called == []
+
+    def test_skips_when_offline(self, monkeypatch, fake_uv_install, cache_file):
+        monkeypatch.delenv("GDOC_AUTO_UPDATE", raising=False)
+        monkeypatch.delenv("GDOC_SKIP_UPDATE_CHECK", raising=False)
+        monkeypatch.setattr(update, "_latest_version", lambda: None)
+        called = []
+        monkeypatch.setattr(
+            update.subprocess, "run",
+            lambda *a, **kw: called.append(a) or subprocess.CompletedProcess(a, 0),
+        )
+        update.auto_update_for_help()
+        assert called == []
+
+    def test_uses_cache_when_within_throttle(
+        self, monkeypatch, fake_uv_install, cache_file
+    ):
+        import time
+        monkeypatch.delenv("GDOC_AUTO_UPDATE", raising=False)
+        monkeypatch.delenv("GDOC_SKIP_UPDATE_CHECK", raising=False)
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({
+            "latest_version": "1.2.3",
+            "checked_at": time.time(),  # fresh
+        }))
+        fetched = []
+        monkeypatch.setattr(
+            update, "_latest_version", lambda: fetched.append(1) or "9.9.9",
+        )
+        monkeypatch.setattr(update, "_installed_version", lambda: "1.2.3")
+        update.auto_update_for_help()
+        assert fetched == []  # used cache, didn't hit network
+
+
+class TestAutoUpdateForHelpUpgrades:
+    def test_runs_upgrade_when_newer(
+        self, monkeypatch, fake_uv_install, cache_file, capsys
+    ):
+        monkeypatch.delenv("GDOC_AUTO_UPDATE", raising=False)
+        monkeypatch.delenv("GDOC_SKIP_UPDATE_CHECK", raising=False)
+        monkeypatch.setattr(update, "_latest_version", lambda: "2.0.0")
+        monkeypatch.setattr(update, "_installed_version", lambda: "1.0.0")
+        ran = []
+        monkeypatch.setattr(
+            update.subprocess, "run",
+            lambda *a, **kw: ran.append(a[0]) or subprocess.CompletedProcess(a, 0),
+        )
+        execed = []
+        monkeypatch.setattr(
+            update.os, "execvpe",
+            lambda *a, **kw: execed.append(a),
+        )
+        update.auto_update_for_help()
+
+        assert any("uv" in cmd and "tool" in cmd and "install" in cmd for cmd in ran)
+        assert len(execed) == 1
+        assert execed[0][0] == "gdoc"
+        # Recursion guard set in env
+        assert execed[0][2]["GDOC_SKIP_UPDATE_CHECK"] == "1"
+
+        captured = capsys.readouterr()
+        assert "1.0.0" in captured.err and "2.0.0" in captured.err
+
+    def test_silent_skip_when_upgrade_fails(
+        self, monkeypatch, fake_uv_install, cache_file, capsys
+    ):
+        monkeypatch.delenv("GDOC_AUTO_UPDATE", raising=False)
+        monkeypatch.delenv("GDOC_SKIP_UPDATE_CHECK", raising=False)
+        monkeypatch.setattr(update, "_latest_version", lambda: "2.0.0")
+        monkeypatch.setattr(update, "_installed_version", lambda: "1.0.0")
+        monkeypatch.setattr(
+            update.subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a, 1),  # nonzero
+        )
+        execed = []
+        monkeypatch.setattr(
+            update.os, "execvpe",
+            lambda *a, **kw: execed.append(a),
+        )
+        update.auto_update_for_help()
+
+        assert execed == []  # no re-exec on failure
+        captured = capsys.readouterr()
+        assert "WARN" in captured.err
+
+
+class TestTopLevelHelpDetection:
+    """Tests for _is_top_level_help_invocation in cli.py."""
+
+    def test_no_args_is_top_level(self):
+        from gdoc.cli import _is_top_level_help_invocation
+        assert _is_top_level_help_invocation(["gdoc"]) is True
+
+    def test_dashdash_help_is_top_level(self):
+        from gdoc.cli import _is_top_level_help_invocation
+        assert _is_top_level_help_invocation(["gdoc", "--help"]) is True
+
+    def test_dash_h_is_top_level(self):
+        from gdoc.cli import _is_top_level_help_invocation
+        assert _is_top_level_help_invocation(["gdoc", "-h"]) is True
+
+    def test_subcommand_help_is_not_top_level(self):
+        from gdoc.cli import _is_top_level_help_invocation
+        assert _is_top_level_help_invocation(["gdoc", "cat", "--help"]) is False
+
+    def test_subcommand_alone_is_not_top_level(self):
+        from gdoc.cli import _is_top_level_help_invocation
+        assert _is_top_level_help_invocation(["gdoc", "cat", "DOC"]) is False
+
+    def test_version_is_not_top_level(self):
+        from gdoc.cli import _is_top_level_help_invocation
+        assert _is_top_level_help_invocation(["gdoc", "--version"]) is False

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- **Auto-update on help.** Bare `gdoc`, `gdoc --help`, and `gdoc -h` now upgrade to the latest release before printing help, so agents inspecting the CLI surface always see current help text.
- Only activates for `uv tool` installs — detected via an adjacency check on the interpreter path (`.../uv/tools/gdoc/...`), so dev venvs and pip installs are untouched.
- Throttled to one network check per hour through the existing `update_check.json` cache; the 24h stderr notice for other commands is unchanged.
- Silent on every failure mode (offline, non-uv install, install error, timeout) — never blocks help output. On success it re-execs the new binary with `GDOC_SKIP_UPDATE_CHECK=1` as a recursion guard.
- Opt out with `GDOC_AUTO_UPDATE=0`.
- README: documents installing uv itself, the previously-undocumented `gdoc update` command, the new auto-update behavior, and the `update_check.json` cache file.
- Version bump to 0.9.0 with CHANGELOG entry.

## Test plan

- [x] 18 new tests covering uv-install detection, every skip path (opt-out, recursion guard, non-uv, up-to-date, offline, fresh cache), the upgrade+re-exec flow, failure fallback, and top-level-help detection
- [x] Full suite: 954 passed
- [x] `ruff` clean on all touched files
- [x] Smoke-tested `gdoc --help` / `gdoc --version` (auto-update correctly skipped in dev venv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-update behavior for `gdoc` invocations and help commands (throttled to once per hour; disable with `GDOC_AUTO_UPDATE=0` environment variable).

* **Documentation**
  * Updated README with installation and updating guidance.

* **Tests**
  * Added test suite for auto-update functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->