### PR TITLE
fix: writes advance conflict baseline; in-sync writes no-op (0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] — 2026-06-09
+
+### Fixed
+- **False write conflicts against your own pushes.** A successful `push` or
+  `write` (including the `_sync-hook` path) now advances the conflict
+  baseline (`last_read_version`) — the doc contains exactly what was sent,
+  so the write doubles as a read. Previously only `cat`/`info`/`pull`
+  advanced it, so a second push after your own write failed with
+  "doc changed since last read".
+- **Content-aware conflict detection.** When the version check fails for a
+  full-doc `push`/`write`, gdoc now exports the doc and compares it to the
+  content being written. If they match (own earlier write, cosmetic Docs
+  version bump), the command succeeds as a no-op — "OK already in sync" —
+  and heals the baseline instead of erroring. Tab writes are excluded
+  (a tab body never equals the whole-doc export).
+
 ## [0.10.0] — 2026-06-09
 
 ### Added

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -573,7 +573,7 @@ def cmd_insert(args) -> int:
     if not content.strip():
         raise GdocError("input file has no content to insert", exit_code=3)
 
-    change_info = _check_write_conflict(doc_id, quiet, force)
+    change_info, _ = _check_write_conflict(doc_id, quiet, force)
 
     from gdoc.api.docs import insert_markdown_into_tab
 
@@ -1063,10 +1063,54 @@ def cmd_edit(args) -> int:
     return 0
 
 
-def _check_write_conflict(doc_id: str, quiet: bool, force: bool):
+def _doc_matches(doc_id: str, body: str) -> bool:
+    """True if the doc's current markdown export equals the content to write."""
+    from gdoc.api.drive import export_doc
+
+    try:
+        current = export_doc(doc_id, mime_type="text/markdown")
+    except GdocError:
+        return False
+    return current.strip() == body.strip()
+
+
+def _finish_noop_write(
+    doc_id: str, change_info, args, quiet: bool, command: str,
+) -> int:
+    """Conclude a write-like command whose content already matches the doc.
+
+    Skips the upload, reports in-sync, and heals the read baseline so the
+    next write doesn't trip conflict detection again.
+    """
+    from gdoc.api.drive import get_file_version
+    from gdoc.format import format_json, get_output_mode
+    from gdoc.state import update_state_after_command
+
+    command_version = get_file_version(doc_id).get("version")
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(in_sync=True, version=command_version))
+    elif mode == "plain":
+        print(f"id\t{doc_id}")
+        print("status\tin_sync")
+    else:
+        print("OK already in sync (doc matches local content; nothing to write)")
+    update_state_after_command(
+        doc_id, change_info, command=command,
+        quiet=quiet, command_version=command_version,
+    )
+    return 0
+
+
+def _check_write_conflict(
+    doc_id: str, quiet: bool, force: bool, body: str | None = None,
+):
     """Run conflict detection for write-like commands.
 
-    Returns ChangeInfo or None. Raises GdocError(exit_code=3) on conflict.
+    Returns (change_info, in_sync). in_sync is True when the version moved
+    but the doc content already equals `body` (e.g. our own earlier write or
+    a cosmetic Docs version bump) — the caller should skip the upload.
+    Raises GdocError(exit_code=3) on a real conflict.
     """
     if not quiet:
         from gdoc.notify import pre_flight
@@ -1076,19 +1120,23 @@ def _check_write_conflict(doc_id: str, quiet: bool, force: bool):
 
         if not force:
             if change_info.last_read_version is None:
+                if body is not None and _doc_matches(doc_id, body):
+                    return change_info, True
                 raise GdocError(
                     "no read baseline. Run 'gdoc cat' first, "
                     "or use --force to overwrite.",
                     exit_code=3,
                 )
             if change_info.has_conflict:
+                if body is not None and _doc_matches(doc_id, body):
+                    return change_info, True
                 raise GdocError(
                     "doc changed since last read. "
                     "Run 'gdoc cat' first, "
                     "or use --force to overwrite.",
                     exit_code=3,
                 )
-        return change_info
+        return change_info, False
 
     if not force:
         from gdoc.state import load_state
@@ -1096,6 +1144,8 @@ def _check_write_conflict(doc_id: str, quiet: bool, force: bool):
         state = load_state(doc_id)
 
         if state is None or state.last_read_version is None:
+            if body is not None and _doc_matches(doc_id, body):
+                return None, True
             raise GdocError(
                 "no read baseline. Run 'gdoc cat' first, "
                 "or use --force to overwrite.",
@@ -1110,6 +1160,8 @@ def _check_write_conflict(doc_id: str, quiet: bool, force: bool):
             current_version is not None
             and current_version != state.last_read_version
         ):
+            if body is not None and _doc_matches(doc_id, body):
+                return None, True
             raise GdocError(
                 "doc changed since last read. "
                 "Run 'gdoc cat' first, "
@@ -1117,7 +1169,7 @@ def _check_write_conflict(doc_id: str, quiet: bool, force: bool):
                 exit_code=3,
             )
 
-    return None
+    return None, False
 
 
 def cmd_write(args) -> int:
@@ -1145,8 +1197,13 @@ def cmd_write(args) -> int:
     from gdoc.frontmatter import parse_frontmatter
     _, content = parse_frontmatter(content)
 
-    # Conflict detection
-    change_info = _check_write_conflict(doc_id, quiet, force)
+    # Conflict detection. Content comparison only applies to full-doc
+    # writes — a tab write's body never equals the whole-doc export.
+    change_info, in_sync = _check_write_conflict(
+        doc_id, quiet, force, body=None if tab_name else content,
+    )
+    if in_sync:
+        return _finish_noop_write(doc_id, change_info, args, quiet, command="write")
 
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)
@@ -1290,7 +1347,9 @@ def cmd_push(args) -> int:
     doc_id = _resolve_doc_id(metadata["gdoc"])
 
     # Conflict detection (reuse shared helper)
-    change_info = _check_write_conflict(doc_id, quiet, force)
+    change_info, in_sync = _check_write_conflict(doc_id, quiet, force, body=body)
+    if in_sync:
+        return _finish_noop_write(doc_id, change_info, args, quiet, command="push")
 
     # Refuse destructive multi-tab collapse unless the user opts in.
     # `pull`/`push` round-trips a multi-tab doc through a flat markdown

--- a/gdoc/state.py
+++ b/gdoc/state.py
@@ -108,6 +108,11 @@ def update_state_after_command(
     # (the pre-flight version is from BEFORE the mutation; this is from AFTER)
     if command_version is not None and command not in ("cat", "info"):
         state.last_version = command_version
+        # A successful full-content write doubles as a read: the doc now
+        # contains exactly what we sent, so advance the conflict baseline.
+        # Without this, a later push false-conflicts against our own write.
+        if command in ("push", "write"):
+            state.last_read_version = command_version
 
     # Apply comment mutation patch (both quiet and non-quiet)
     # Per CONTEXT.md Decision #10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.10.0"
+version = "0.10.1"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -118,10 +118,11 @@ class TestPushBasic:
 
 
 class TestPushConflict:
+    @patch("gdoc.api.drive.export_doc", return_value="something else entirely")
     @patch("gdoc.api.drive.update_doc_content")
     @patch("gdoc.notify.pre_flight")
     def test_push_blocked_on_conflict(
-        self, mock_pf, mock_update_doc, tmp_path,
+        self, mock_pf, mock_update_doc, _export, tmp_path,
     ):
         f = tmp_path / "test.md"
         f.write_text(FRONTMATTER + "Body")
@@ -134,10 +135,11 @@ class TestPushConflict:
         assert "doc changed since last read" in str(exc.value)
         mock_update_doc.assert_not_called()
 
+    @patch("gdoc.api.drive.export_doc", return_value="something else entirely")
     @patch("gdoc.api.drive.update_doc_content")
     @patch("gdoc.notify.pre_flight")
     def test_push_blocked_no_prior_read(
-        self, mock_pf, mock_update_doc, tmp_path,
+        self, mock_pf, mock_update_doc, _export, tmp_path,
     ):
         f = tmp_path / "test.md"
         f.write_text(FRONTMATTER + "Body")
@@ -147,6 +149,64 @@ class TestPushConflict:
         with pytest.raises(GdocError, match="no read baseline"):
             cmd_push(args)
         mock_update_doc.assert_not_called()
+
+
+class TestPushInSync:
+    """Version drifted but content already matches — skip the upload."""
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 12})
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc", return_value="Body")
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.notify.pre_flight")
+    def test_push_noop_when_doc_matches(
+        self, mock_pf, mock_update_doc, mock_export, mock_state, _ver,
+        tmp_path, capsys,
+    ):
+        f = tmp_path / "test.md"
+        f.write_text(FRONTMATTER + "Body")
+        mock_pf.return_value = ChangeInfo(current_version=12, last_read_version=5)
+        args = _make_args(file=str(f))
+        rc = cmd_push(args)
+        assert rc == 0
+        mock_update_doc.assert_not_called()
+        assert "already in sync" in capsys.readouterr().out
+        assert mock_state.call_args.kwargs["command_version"] == 12
+        assert mock_state.call_args.kwargs["command"] == "push"
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 12})
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc", return_value="Body")
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.notify.pre_flight")
+    def test_push_noop_without_baseline_when_doc_matches(
+        self, mock_pf, mock_update_doc, _export, _state, _ver, tmp_path,
+    ):
+        f = tmp_path / "test.md"
+        f.write_text(FRONTMATTER + "Body")
+        mock_pf.return_value = ChangeInfo(current_version=12, last_read_version=None)
+        args = _make_args(file=str(f))
+        assert cmd_push(args) == 0
+        mock_update_doc.assert_not_called()
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 12})
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc", return_value="Body")
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.notify.pre_flight")
+    def test_push_noop_json_output(
+        self, mock_pf, mock_update_doc, _export, _state, _ver,
+        tmp_path, capsys,
+    ):
+        f = tmp_path / "test.md"
+        f.write_text(FRONTMATTER + "Body")
+        mock_pf.return_value = ChangeInfo(current_version=12, last_read_version=5)
+        args = _make_args(file=str(f), json=True)
+        assert cmd_push(args) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["in_sync"] is True
+        assert data["version"] == 12
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_drive_service")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -146,6 +146,43 @@ class TestUpdateStateAfterCommand:
             assert state.last_version == 20
             assert state.last_read_version == 20
 
+    def test_push_advances_read_baseline(self, tmp_path):
+        """A full-content write doubles as a read: the doc now contains
+        exactly what we sent, so the conflict baseline must advance."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(last_version=10, last_read_version=10))
+            update_state_after_command(
+                "doc1", None, command="push",
+                quiet=True, command_version=11,
+            )
+            state = load_state("doc1")
+            assert state.last_version == 11
+            assert state.last_read_version == 11
+
+    def test_write_advances_read_baseline(self, tmp_path):
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            info = self._make_change_info(current_version=10)
+            update_state_after_command(
+                "doc1", info, command="write",
+                quiet=False, command_version=11,
+            )
+            state = load_state("doc1")
+            assert state.last_version == 11
+            assert state.last_read_version == 11
+
+    def test_edit_does_not_advance_read_baseline(self, tmp_path):
+        """Partial mutations (find/replace) don't establish full-content
+        knowledge — the baseline stays at the last actual read."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(last_version=10, last_read_version=10))
+            update_state_after_command(
+                "doc1", None, command="edit",
+                quiet=True, command_version=11,
+            )
+            state = load_state("doc1")
+            assert state.last_version == 11
+            assert state.last_read_version == 10
+
     def test_quiet_does_not_advance_comment_check(self, tmp_path):
         """Decision #6: --quiet does not advance last_comment_check."""
         with patch("gdoc.state.STATE_DIR", tmp_path):

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -179,10 +179,11 @@ class TestWriteFileErrors:
 class TestWriteConflictNormal:
     """Not quiet, not force."""
 
+    @patch("gdoc.api.drive.export_doc", return_value="something else entirely")
     @patch("gdoc.api.drive.update_doc_content")
     @patch("gdoc.notify.pre_flight")
     def test_write_blocked_on_conflict(
-        self, mock_pf, mock_update_doc, tmp_path,
+        self, mock_pf, mock_update_doc, _export, tmp_path,
     ):
         f = tmp_path / "test.md"
         f.write_text("content")
@@ -197,10 +198,11 @@ class TestWriteConflictNormal:
         assert "doc changed since last read" in str(exc.value)
         mock_update_doc.assert_not_called()
 
+    @patch("gdoc.api.drive.export_doc", return_value="something else entirely")
     @patch("gdoc.api.drive.update_doc_content")
     @patch("gdoc.notify.pre_flight")
     def test_write_blocked_no_prior_read(
-        self, mock_pf, mock_update_doc, tmp_path,
+        self, mock_pf, mock_update_doc, _export, tmp_path,
     ):
         f = tmp_path / "test.md"
         f.write_text("content")
@@ -214,10 +216,11 @@ class TestWriteConflictNormal:
         assert exc.value.exit_code == 3
         mock_update_doc.assert_not_called()
 
+    @patch("gdoc.api.drive.export_doc", return_value="something else entirely")
     @patch("gdoc.api.drive.update_doc_content")
     @patch("gdoc.notify.pre_flight")
     def test_write_blocked_no_prior_read_correct_message(
-        self, mock_pf, mock_update_doc, tmp_path,
+        self, mock_pf, mock_update_doc, _export, tmp_path,
     ):
         f = tmp_path / "test.md"
         f.write_text("content")
@@ -247,10 +250,11 @@ class TestWriteConflictNormal:
         assert rc == 0
         mock_update_doc.assert_called_once()
 
+    @patch("gdoc.api.drive.export_doc", return_value="something else entirely")
     @patch("gdoc.api.drive.update_doc_content")
     @patch("gdoc.notify.pre_flight")
     def test_write_conflict_error_message(
-        self, mock_pf, mock_update_doc, tmp_path,
+        self, mock_pf, mock_update_doc, _export, tmp_path,
     ):
         f = tmp_path / "test.md"
         f.write_text("content")
@@ -264,6 +268,46 @@ class TestWriteConflictNormal:
         msg = str(exc.value)
         assert "doc changed since last read" in msg
         assert "--force" in msg
+
+
+class TestWriteInSync:
+    """Version drifted but content already matches — skip the upload."""
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 12})
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc", return_value="content")
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.notify.pre_flight")
+    def test_write_noop_when_doc_matches(
+        self, mock_pf, mock_update_doc, _export, mock_state, _ver,
+        tmp_path, capsys,
+    ):
+        f = tmp_path / "test.md"
+        f.write_text("content")
+        mock_pf.return_value = ChangeInfo(current_version=12, last_read_version=5)
+        args = _make_args(file=str(f))
+        rc = cmd_write(args)
+        assert rc == 0
+        mock_update_doc.assert_not_called()
+        assert "already in sync" in capsys.readouterr().out
+        assert mock_state.call_args.kwargs["command_version"] == 12
+        assert mock_state.call_args.kwargs["command"] == "write"
+
+    @patch("gdoc.api.drive.export_doc", return_value="content")
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_write_tab_conflict_not_rescued_by_content_match(
+        self, mock_pf, mock_insert, mock_export, tmp_path,
+    ):
+        """Tab writes never compare content — a tab body isn't the full doc."""
+        f = tmp_path / "test.md"
+        f.write_text("content")
+        mock_pf.return_value = ChangeInfo(current_version=12, last_read_version=5)
+        args = _make_args(file=str(f), tab="Notes")
+        with pytest.raises(GdocError, match="doc changed since last read"):
+            cmd_write(args)
+        mock_export.assert_not_called()
+        mock_insert.assert_not_called()
 
 
 class TestWriteConflictForce:


### PR DESCRIPTION
## Summary

Fixes the false "doc changed since last read" conflict observed when pushing after the sync hook (or any own write) already updated the doc.

- **Root cause:** conflict detection compares against `last_read_version`, but successful writes only advanced `last_version` — so the tool treated your own push as a stranger's edit. `push`/`write` (including `_sync-hook`) now advance the read baseline: a full-content write means you know exactly what the doc contains.
- **Defense in depth:** when the version check still fails for a full-doc `push`/`write`, export the doc and compare with the outgoing content. Identical → succeed as a no-op (`OK already in sync`, `in_sync: true` in JSON) and heal the baseline. Real divergence still errors with exit 3. Tab writes never use the content comparison (tab body ≠ whole-doc export).
- Version 0.10.1 + CHANGELOG.

## Test plan

- 8 new tests: push/write advance `last_read_version` (edit doesn't), no-op on matching content (with/without baseline, JSON output, state healing), blocked tests now explicitly mock differing export, tab-write conflict not rescued by content match
- Full suite: 973 passed; stub gate clean; ruff at baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)