### PR TITLE
chore: sync uv.lock to 0.10.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
One-line lockfile sync missed in #24 (version 0.10.0 → 0.10.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)