### PR TITLE
fix: address Codex review findings from #23/#24 (0.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] — 2026-06-09
+
+### Fixed
+- **Tab writes no longer claim full-doc knowledge.** 0.10.1's baseline
+  advance applied to `write --tab` too, so a forced tab write after unseen
+  remote changes let the next full-doc `push`/`write` skip conflict
+  detection and overwrite them. The baseline now advances only for actual
+  full-content writes (`push`, full-doc `write`, the sync hook).
+  (Codex review on #24.)
+- **Replacing credential files now enforces 0600.** `os.open`'s mode only
+  applies on creation, so `gdoc auth --setup-url` over an existing
+  world-readable `credentials.json` kept it world-readable. Credential and
+  token files are now written to a fresh 0600 temp file and atomically
+  swapped in. (Codex review on #23.)
+
 ## [0.10.1] — 2026-06-09
 
 ### Fixed

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/gdoc/auth.py
+++ b/gdoc/auth.py
@@ -121,10 +121,7 @@ def _fetch_client_credentials(url: str) -> None:
             "(expected an 'installed' section with a client_id)."
         )
 
-    CREDS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(CREDS_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(raw.decode("utf-8"))
+    _write_private(CREDS_PATH, raw.decode("utf-8"))
     print(f"OK client credentials saved to {CREDS_PATH}", file=sys.stderr)
 
 
@@ -223,14 +220,31 @@ def _load_token(token_path: Path | None = None) -> Credentials | None:
         return None
 
 
+def _write_private(path: Path, content: str) -> None:
+    """Write a secret file with 0600 permissions, replacing any existing file.
+
+    os.open's mode only applies on creation, so writing in place would leave
+    a pre-existing world-readable file world-readable. Write a fresh 0600
+    temp file in the same directory and atomically swap it in instead.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.unlink(missing_ok=True)
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
 def _save_token(creds: Credentials, token_path: Path | None = None) -> None:
     """Save credentials to token.json with restricted permissions."""
     if token_path is None:
         token_path = get_token_path()
-    token_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(creds.to_json())
+    _write_private(token_path, creds.to_json())
 
 
 def list_accounts() -> list[str]:

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1098,6 +1098,7 @@ def _finish_noop_write(
     update_state_after_command(
         doc_id, change_info, command=command,
         quiet=quiet, command_version=command_version,
+        full_doc_write=True,
     )
     return 0
 
@@ -1252,6 +1253,7 @@ def cmd_write(args) -> int:
     update_state_after_command(
         doc_id, change_info, command="write",
         quiet=quiet, command_version=command_version,
+        full_doc_write=not tab_name,
     )
 
     return 0
@@ -1390,6 +1392,7 @@ def cmd_push(args) -> int:
     update_state_after_command(
         doc_id, change_info, command="push",
         quiet=quiet, command_version=command_version,
+        full_doc_write=True,
     )
 
     return 0
@@ -1455,6 +1458,7 @@ def cmd_sync_hook(args) -> int:
         update_state_after_command(
             doc_id, None, command="push",
             quiet=True, command_version=command_version,
+            full_doc_write=True,
         )
 
     except Exception:

--- a/gdoc/state.py
+++ b/gdoc/state.py
@@ -62,6 +62,7 @@ def update_state_after_command(
     quiet: bool = False,
     command_version: int | None = None,
     comment_state_patch: dict | None = None,
+    full_doc_write: bool = False,
 ) -> None:
     """Update per-doc state after a successful command.
 
@@ -73,6 +74,8 @@ def update_state_after_command(
         command_version: Version from command's own API response (for info command).
         comment_state_patch: Optional dict with targeted comment state mutations.
             Keys: "add_comment_id", "add_resolved_id", "remove_resolved_id".
+        full_doc_write: True when the command replaced the entire document
+            content, so the write doubles as a read of the whole doc.
     """
     from datetime import datetime, timezone
 
@@ -111,7 +114,9 @@ def update_state_after_command(
         # A successful full-content write doubles as a read: the doc now
         # contains exactly what we sent, so advance the conflict baseline.
         # Without this, a later push false-conflicts against our own write.
-        if command in ("push", "write"):
+        # Partial writes (tab-scoped, find/replace) must NOT advance it —
+        # the rest of the doc may hold changes the writer never saw.
+        if full_doc_write:
             state.last_read_version = command_version
 
     # Apply comment mutation patch (both quiet and non-quiet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.10.1"
+version = "0.10.2"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -263,6 +263,28 @@ class TestClientConfigSources:
         assert fake_creds.exists()
         assert oct(os.stat(fake_creds).st_mode & 0o777) == "0o600"
 
+    def test_setup_url_fixes_loose_permissions_on_overwrite(
+        self, tmp_path, monkeypatch,
+    ):
+        """O_CREAT's mode is ignored for existing files — replacing a
+        world-readable credentials.json must still end up 0600."""
+        mock_flow = _mock_flow()
+        fake_creds = tmp_path / "credentials.json"
+        fake_creds.write_text('{"installed": {"client_id": "old"}}')
+        os.chmod(fake_creds, 0o644)
+
+        with (
+            _flow_patches(tmp_path, mock_flow),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeResponse(CLIENT_FILE_JSON.encode()),
+            ),
+        ):
+            authenticate(setup_url="https://internal.example.com/gdoc.json")
+
+        assert oct(os.stat(fake_creds).st_mode & 0o777) == "0o600"
+        assert "abc.apps.googleusercontent.com" in fake_creds.read_text()
+
     def test_setup_url_rejects_non_client_json(self, tmp_path):
         with (
             patch("gdoc.auth.CREDS_PATH", tmp_path / "credentials.json"),
@@ -508,6 +530,18 @@ class TestSaveToken:
 
         assert fake_token.exists()
         assert oct(os.stat(fake_token).st_mode & 0o777) == "0o600"
+
+    def test_overwrite_fixes_loose_permissions(self, tmp_path):
+        fake_token = tmp_path / "token.json"
+        fake_token.write_text('{"token": "old"}')
+        os.chmod(fake_token, 0o644)
+        mock_creds = MagicMock()
+        mock_creds.to_json.return_value = '{"token": "new"}'
+
+        _save_token(mock_creds, fake_token)
+
+        assert oct(os.stat(fake_token).st_mode & 0o777) == "0o600"
+        assert fake_token.read_text() == '{"token": "new"}'
 
     def test_saves_atomically_with_restricted_permissions(self, tmp_path):
         """Token file is created with 0o600 from the start (no chmod race)."""

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -173,6 +173,7 @@ class TestPushInSync:
         assert "already in sync" in capsys.readouterr().out
         assert mock_state.call_args.kwargs["command_version"] == 12
         assert mock_state.call_args.kwargs["command"] == "push"
+        assert mock_state.call_args.kwargs["full_doc_write"] is True
 
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 12})
     @patch("gdoc.state.update_state_after_command")
@@ -299,7 +300,7 @@ class TestPushAwareness:
         cmd_push(args)
         mock_update.assert_called_once_with(
             "abc123", change_info, command="push",
-            quiet=False, command_version=42,
+            quiet=False, command_version=42, full_doc_write=True,
         )
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -153,7 +153,7 @@ class TestUpdateStateAfterCommand:
             save_state("doc1", DocState(last_version=10, last_read_version=10))
             update_state_after_command(
                 "doc1", None, command="push",
-                quiet=True, command_version=11,
+                quiet=True, command_version=11, full_doc_write=True,
             )
             state = load_state("doc1")
             assert state.last_version == 11
@@ -164,11 +164,24 @@ class TestUpdateStateAfterCommand:
             info = self._make_change_info(current_version=10)
             update_state_after_command(
                 "doc1", info, command="write",
-                quiet=False, command_version=11,
+                quiet=False, command_version=11, full_doc_write=True,
             )
             state = load_state("doc1")
             assert state.last_version == 11
             assert state.last_read_version == 11
+
+    def test_tab_write_does_not_advance_read_baseline(self, tmp_path):
+        """A tab-scoped write replaces one tab only — the rest of the doc
+        may hold unseen changes, so the conflict baseline must not move."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(last_version=10, last_read_version=5))
+            update_state_after_command(
+                "doc1", None, command="write",
+                quiet=True, command_version=11, full_doc_write=False,
+            )
+            state = load_state("doc1")
+            assert state.last_version == 11
+            assert state.last_read_version == 5
 
     def test_edit_does_not_advance_read_baseline(self, tmp_path):
         """Partial mutations (find/replace) don't establish full-content

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -75,7 +75,7 @@ class TestSyncHookBasic:
             cmd_sync_hook(args)
         mock_update.assert_called_once_with(
             "abc123", None, command="push",
-            quiet=True, command_version=42,
+            quiet=True, command_version=42, full_doc_write=True,
         )
 
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -552,7 +552,7 @@ class TestWriteAwareness:
         cmd_write(args)
         mock_update.assert_called_once_with(
             "abc123", change_info, command="write",
-            quiet=False, command_version=42,
+            quiet=False, command_version=42, full_doc_write=True,
         )
 
     @patch("gdoc.state.update_state_after_command")
@@ -599,7 +599,7 @@ class TestWriteAwareness:
         cmd_write(args)
         mock_update.assert_called_once_with(
             "abc123", None, command="write",
-            quiet=True, command_version=42,
+            quiet=True, command_version=42, full_doc_write=True,
         )
 
 
@@ -752,6 +752,28 @@ class TestWriteCollapseSafety:
 
 class TestWriteTabScoped:
     """--tab NAME writes only to that tab via Docs API."""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_forced_tab_write_does_not_claim_full_read(
+        self, mock_pf, mock_insert, _ver, mock_state, tmp_path,
+    ):
+        """A forced tab write bypasses the conflict check and touches one
+        tab — it must not advance the whole-doc read baseline."""
+        f = tmp_path / "doc.md"
+        f.write_text("body")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=5,
+        )
+        mock_insert.return_value = {
+            "tab_id": "t.a", "tab_title": "A", "insert_index": 1,
+        }
+        args = _make_args(file=str(f), tab="A", force=True)
+        rc = cmd_write(args)
+        assert rc == 0
+        assert mock_state.call_args.kwargs["full_doc_write"] is False
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Fixes both P2 findings from the Codex reviews on #23 and #24.

- **Tab writes no longer claim full-doc knowledge** (#24 review): the 0.10.1 baseline advance keyed off `command in ("push", "write")`, but `cmd_write` uses `command="write"` for tab writes too — so `write --tab --force` after unseen remote changes healed the baseline and let the next full-doc `push`/`write` silently overwrite them. `update_state_after_command` now takes an explicit `full_doc_write` flag, set only by `push`, full-doc `write`, the in-sync no-op path, and the sync hook.
- **Credential overwrites enforce 0600** (#23 review): `os.open(..., O_CREAT, 0o600)` ignores the mode for existing files, so `gdoc auth --setup-url` over a world-readable `credentials.json` left it 0644. New `_write_private` helper writes a fresh 0600 temp file and atomically `os.replace`s it over the target; used by both `_fetch_client_credentials` and `_save_token` (which had the same latent issue).

## Test plan

- 4 new tests: forced tab write doesn't advance the baseline (state + CLI level), setup-url overwrite of a 0644 credentials.json ends 0600, token re-save fixes loose permissions
- Updated exact-match call assertions for the new kwarg
- Full suite: 977 passed; stub gate clean; ruff at baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)