### PR TITLE
feat: revision history and revision diffs (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] — 2026-06-11
+
+### Added
+- **`gdoc revisions DOC`** (alias `history`) — list the milestone
+  revisions the Drive API retains for a document (Google's rich
+  "Version history" has no public API; Drive milestones are the
+  reconstructable subset). Human table, `--json`, and `--plain` modes;
+  `--limit N`; `[keep]` marker for pinned revisions.
+- **`gdoc cat/pull --revision REV`** — export or download a past
+  revision. REV selector grammar shared with `diff`: bare id,
+  `latest`/`head`, `prev`, `head~N` (by list position — ids are
+  sparse), `@ISO` (last revision at/before a timestamp).
+  `pull --revision` writes `source:`/`revision:` frontmatter instead
+  of `gdoc:` so a stale revision can't be pushed back by accident,
+  and neither command advances the read baseline used by
+  write-conflict checks.
+- **`gdoc diff DOC --rev A..B | --rev REV | --since ISO`** — diff two
+  revisions (or a revision against latest) with a readable
+  **coalescing word-diff**: shared scraps shorter than `--min-common`
+  chars (default 24) are absorbed so a rewritten sentence renders as
+  one removed chunk + one added chunk, not word salad. Colored
+  word-diff on a TTY, plain `[-…-]`/`{+…+}` text when piped, `--json`
+  for a stable documented diff model, and `--format html --out F`
+  for a styled review artifact (GitHub-style colors, collapsed
+  unchanged runs, `--context N`). Existing `diff DOC FILE` behavior
+  is unchanged.
+- **`gdoc diff --with-comments`** — pull the doc's comment threads and
+  anchor each to the diff hunk containing its quoted text (changed
+  hunks preferred); threads whose anchor isn't visible render in an
+  "Other comment threads" appendix. Color-coded by author in html.
+- Richer artifacts (docx, PDF, …) are deliberately not built in —
+  external scripts render them from the `--json` diff model.
+
+### Changed
+- A pruned or unknown revision produces a clear exit-3 error pointing
+  at `gdoc revisions` (Drive prunes non-pinned revisions over time).
+- `comments.list` now also requests reply `createdTime` (used by the
+  diff comment rendering).
+- `requests` is now a declared dependency (it was already pulled in
+  transitively); revision exports use it directly via
+  `google.auth.transport.requests`.
+- `push` on a `pull --revision` file explains that revision pulls are
+  not pushable, instead of "no gdoc frontmatter found".
+- Frontmatter values are flattened to one line on write, so a doc
+  title containing a newline can't inject frontmatter keys.
+
 ## [0.10.2] — 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ gdoc cat 1aBcDeFg...
 | `new TITLE` | Create a blank document (`--folder` to specify location, `--file` to import markdown with images) |
 | `cp DOC TITLE` | Duplicate a document |
 
+### Revisions & diffs
+
+| Command | Description |
+|---------|-------------|
+| `revisions DOC` | List retained revisions — id, modified time, author, `[keep]` marker (`--limit N`; alias: `history`) |
+| `cat --revision REV DOC` | Export a past revision to stdout |
+| `pull --revision REV DOC FILE` | Download a past revision (gets `source:`/`revision:` frontmatter, not `gdoc:`, so it can't be pushed back by accident) |
+| `diff DOC FILE` | Compare the current doc against a local file (unified diff) |
+| `diff DOC --rev A..B` | Word-diff two revisions (`--rev A` compares A against latest) |
+| `diff DOC --since ISO` | What changed since a timestamp (last revision at/before it vs latest) |
+| `diff DOC --rev A..B --format html` | Write a styled diff artifact (`--out PATH`, `--with-comments` to anchor comment threads) |
+
 ### Comments
 
 | Command | Description |
@@ -309,6 +321,39 @@ the Sheets API, so no re-authentication is needed.
 ```
 
 Comments whose anchor text has been deleted, is too short, or is ambiguous are grouped in an `[UNANCHORED]` section at the end.
+
+## Revision history & diffs
+
+Google Docs' "Version history" UI has no public API, but the Drive API exposes **milestone revisions** for native Docs, and each one is exportable. Two caveats baked into the tooling: revision ids are **sparse** (1, 3, 7, 20, …), and non-pinned revisions are **pruned by Google over time** — so `gdoc revisions` is the starting point, and a pruned revision produces a clear error pointing back to it.
+
+```bash
+# List retained revisions (oldest first; [keep] = pinned forever)
+gdoc revisions DOC_ID
+
+# What changed in the most recent edit?
+gdoc diff DOC_ID --rev prev
+
+# What changed since I last read it?
+gdoc diff DOC_ID --since 2026-06-10T19:00:00Z
+
+# Compare two specific revisions, chunkier word-diff
+gdoc diff DOC_ID --rev 69..190 --min-common 30
+
+# Styled artifact with the doc's comment threads anchored inline
+gdoc diff DOC_ID --rev 69..190 --format html --with-comments --out review.html
+
+# Read or download a past revision
+gdoc cat DOC_ID --revision head~2
+gdoc pull DOC_ID old-draft.md --revision @2026-06-01
+```
+
+**REV selectors** (shared by `cat`, `pull`, and `diff`): a bare revision id (`190`), `latest`/`head`, `prev`, `head~N` (N back from latest by list position), or `@ISO` (last revision at/before the timestamp; naive timestamps are local time).
+
+Revision diffs print a colored word-diff to a TTY (plain text when piped; `--format` overrides). Rewritten sentences render as one contiguous removed/added chunk rather than word salad — shared scraps shorter than `--min-common` characters (default 24) are absorbed into the change. `--context N` controls how many unchanged blocks are kept around each change; the rest collapse to `⋯ N unchanged ⋯` (headings always stay). `--json` emits the documented diff model (`doc`/`old`/`new`/`hunks`, each hunk a list of `equal|del|ins` runs, plus `comments` with their anchored hunk index when `--with-comments` is set) wrapped with top-level `ok` and `identical` keys; combined with `--format html` it instead prints a JSON write confirmation (`path`, `format`, `changed`, `identical`). Exit code follows `diff DOC FILE`: 1 when the revisions differ, 0 when identical.
+
+The diff model is display-oriented, not a faithful character diff: export escaping and whitespace are normalized, images become `⟦diagram⟧` placeholders, ordered-list renumbering alone doesn't register as a change, and coalescing relabels short unchanged spans as part of the surrounding change (pass `--min-common 0` for the uncoalesced word diff). The engine also parses Google's current markdown-export conventions (one line per paragraph, `![][imageN]` references) — like revision pruning, this is undocumented Google behavior that may change.
+
+HTML output has no extra dependencies. Richer artifacts (docx, PDF, …) are deliberately not built in: `--json` emits the full diff model (including comment anchoring and list markers), and an external script or the calling agent renders it however it likes.
 
 ## Tabs
 
@@ -446,6 +491,8 @@ gdoc edit DOC "old" "new"  # ERR: command not allowed: edit
 | 1 | API or unexpected error |
 | 2 | Authentication error (run `gdoc auth`) |
 | 3 | Usage or validation error |
+
+Exception: `gdoc diff` follows `diff(1)` semantics — exit 1 means the contents differ, 0 means identical.
 
 Errors always print `ERR: <message>` to stderr, even in `--json` mode.
 

--- a/gdoc.md
+++ b/gdoc.md
@@ -39,6 +39,15 @@ gdoc info DOC_ID                             # Title, owner, last modified, word
 gdoc share DOC_ID EMAIL [--role reader|writer|commenter]
 gdoc new "Document Title" [--folder FOLDER_ID]  # Create blank doc
 gdoc cp DOC_ID "Copy Title"                  # Duplicate a doc
+
+gdoc revisions DOC_ID                        # List retained revisions (alias: history)
+gdoc cat DOC_ID --revision REV               # Export a past revision
+gdoc pull DOC_ID FILE --revision REV         # Download a past revision (not pushable)
+gdoc diff DOC_ID --rev prev                  # Word-diff the most recent edit
+gdoc diff DOC_ID --rev 69..190               # Word-diff two revisions
+gdoc diff DOC_ID --since 2026-06-10T19:00Z   # What changed since a timestamp
+gdoc diff DOC_ID --rev A..B --format html --with-comments --out review.html
+# REV selectors: id | latest | head | prev | head~N | @ISO
 ```
 
 ### `cat --comments` (Annotated View)
@@ -332,6 +341,7 @@ ERR: multiple matches (3 found). Use --all to replace all occurrences.
 ```
 
 Exit codes: 0=success, 1=API error, 2=auth error, 3=usage error
+(`diff` is the exception: exit 1 means the contents differ, like `diff(1)`)
 
 ## Dependencies
 
@@ -339,6 +349,7 @@ Exit codes: 0=success, 1=API error, 2=auth error, 3=usage error
 google-api-python-client    # Drive + Docs API
 google-auth-oauthlib        # OAuth2 flow
 google-auth-httplib2        # HTTP transport
+requests                    # revision exportLinks downloads
 ```
 
 No other dependencies. Intentionally minimal.

--- a/gdoc.md
+++ b/gdoc.md
@@ -345,7 +345,7 @@ Exit codes: 0=success, 1=API error, 2=auth error, 3=usage error
 
 ## Dependencies
 
-```
+```text
 google-api-python-client    # Drive + Docs API
 google-auth-oauthlib        # OAuth2 flow
 google-auth-httplib2        # HTTP transport

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/gdoc/api/comments.py
+++ b/gdoc/api/comments.py
@@ -49,14 +49,16 @@ def list_comments(
             comment_fields = (
                 "id, content, author(displayName, emailAddress), "
                 "resolved, createdTime, modifiedTime, "
-                "replies(author(displayName, emailAddress), modifiedTime, content, action)"
+                "replies(author(displayName, emailAddress), createdTime, "
+                "modifiedTime, content, action)"
             )
             if include_anchor:
                 comment_fields = (
                     "id, content, author(displayName, emailAddress), "
                     "resolved, createdTime, modifiedTime, "
                     "quotedFileContent(value), "
-                    "replies(author(displayName, emailAddress), modifiedTime, content, action)"
+                    "replies(author(displayName, emailAddress), createdTime, "
+                    "modifiedTime, content, action)"
                 )
             fields = f"nextPageToken, comments({comment_fields})"
 

--- a/gdoc/api/revisions.py
+++ b/gdoc/api/revisions.py
@@ -115,7 +115,7 @@ def export_revision(
             export_links = result.get("exportLinks", {})
         except HttpError as e:
             if int(e.resp.status) == 404:
-                raise pruned_error(revision_id)
+                raise pruned_error(revision_id) from e
             _translate_http_error(e, file_id)
 
     url = export_links.get(mime_type)

--- a/gdoc/api/revisions.py
+++ b/gdoc/api/revisions.py
@@ -1,0 +1,150 @@
+"""Drive API revisions wrappers (milestone revision history).
+
+Google Docs' rich "Version history" UI has no public API, but the Drive
+``revisions`` collection returns milestone revisions for native Docs,
+and each milestone is exportable via authenticated ``exportLinks``.
+Revision ids are sparse and non-``keepForever`` revisions are pruned by
+Google over time (~weeks).
+"""
+
+import sys
+from functools import lru_cache
+
+from googleapiclient.errors import HttpError
+
+from gdoc.api import get_drive_service
+from gdoc.revdiff import pruned_error
+from gdoc.util import AuthError, GdocError
+
+_REVISION_FIELDS = (
+    "id, modifiedTime, keepForever, "
+    "lastModifyingUser(displayName, emailAddress), exportLinks"
+)
+
+_EXPORT_TIMEOUT = 30  # seconds
+
+
+def _translate_http_error(e: HttpError, file_id: str) -> None:
+    """Translate HttpError for revisions operations."""
+    status = int(e.resp.status)
+    if status == 401:
+        raise AuthError("Authentication expired. Run `gdoc auth`.")
+    if status == 403:
+        raise GdocError(f"Permission denied: {file_id}")
+    if status == 404:
+        raise GdocError(f"Document not found: {file_id}")
+    raise GdocError(f"API error ({status}): {e.reason}")
+
+
+@lru_cache(maxsize=1)
+def _get_session():
+    """One authorized HTTP session per process (exportLinks downloads)."""
+    from google.auth.transport.requests import AuthorizedSession
+
+    from gdoc.auth import get_credentials
+
+    return AuthorizedSession(get_credentials())
+
+
+def list_revisions(file_id: str) -> list[dict]:
+    """List retained revisions for a file, oldest first, auto-paginating.
+
+    Returns revision dicts with id, modifiedTime, keepForever,
+    lastModifyingUser, and exportLinks.
+    """
+    try:
+        service = get_drive_service()
+        revisions: list[dict] = []
+        page_token = None
+
+        while True:
+            response = (
+                service.revisions()
+                .list(
+                    fileId=file_id,
+                    pageSize=1000,
+                    fields=f"nextPageToken, revisions({_REVISION_FIELDS})",
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            revisions.extend(response.get("revisions", []))
+            page_token = response.get("nextPageToken")
+            if page_token is None:
+                break
+
+        # Drive doesn't document an ordering guarantee; the selector
+        # grammar (latest/prev/head~N/@ISO) depends on oldest-first.
+        revisions.sort(key=lambda r: r.get("modifiedTime", ""))
+        return revisions
+    except HttpError as e:
+        _translate_http_error(e, file_id)
+
+
+def export_revision(
+    file_id: str,
+    revision_id: str,
+    mime_type: str = "text/markdown",
+    export_links: dict | None = None,
+) -> str:
+    """Export one revision's content via its exportLinks.
+
+    The Drive API has no export endpoint for revisions of native Docs;
+    each revision instead carries authenticated exportLinks URLs. Falls
+    back to text/plain when the requested mime type has no link.
+
+    Args:
+        file_id: The document ID.
+        revision_id: The revision ID to export.
+        mime_type: Preferred export format.
+        export_links: exportLinks dict from a prior revisions.list call;
+            when omitted, fetched via revisions.get.
+    """
+    if export_links is None:
+        try:
+            service = get_drive_service()
+            result = (
+                service.revisions()
+                .get(
+                    fileId=file_id,
+                    revisionId=revision_id,
+                    fields="exportLinks",
+                )
+                .execute()
+            )
+            export_links = result.get("exportLinks", {})
+        except HttpError as e:
+            if int(e.resp.status) == 404:
+                raise pruned_error(revision_id)
+            _translate_http_error(e, file_id)
+
+    url = export_links.get(mime_type)
+    if not url:
+        url = export_links.get("text/plain")
+        if url and mime_type != "text/plain":
+            print(
+                f"WARN: revision {revision_id} has no {mime_type} "
+                "export; falling back to text/plain",
+                file=sys.stderr,
+            )
+    if not url:
+        raise GdocError(
+            f"revision {revision_id} has no {mime_type} export link"
+        )
+
+    response = _get_session().get(url, timeout=_EXPORT_TIMEOUT)
+    if response.status_code == 404:
+        raise pruned_error(revision_id)
+    if response.status_code == 401:
+        raise AuthError("Authentication expired. Run `gdoc auth`.")
+    if response.status_code == 403:
+        # Not an expired token: the session auto-refreshes, so a 403
+        # here means export/download is denied for this file.
+        raise GdocError(f"Permission denied: {file_id}")
+    if response.status_code != 200:
+        raise GdocError(
+            f"export failed for revision {revision_id} "
+            f"(HTTP {response.status_code})"
+        )
+    response.encoding = "utf-8"
+    return response.text

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 from gdoc import __version__
+from gdoc.revdiff import DEFAULT_CONTEXT, DEFAULT_MIN_COMMON
 from gdoc.util import SPREADSHEET_MIME, AuthError, GdocError
 
 
@@ -105,6 +106,10 @@ def _cat_sheet(args, doc_id: str, change_info) -> int:
     """Spreadsheet branch of `gdoc cat`: print cell values."""
     if getattr(args, "comments", False):
         raise GdocError("--comments is not supported for spreadsheets", exit_code=3)
+    if getattr(args, "revision", None):
+        raise GdocError(
+            "--revision is not supported for spreadsheets", exit_code=3,
+        )
 
     quiet = getattr(args, "quiet", False)
     tab = getattr(args, "tab", None)
@@ -176,6 +181,81 @@ def _cat_sheet(args, doc_id: str, change_info) -> int:
     return 0
 
 
+def _format_local_time(iso: str) -> str:
+    """Format an RFC3339 UTC timestamp as local 'YYYY-MM-DD HH:MM'."""
+    from datetime import datetime
+
+    try:
+        parsed = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return iso
+    return parsed.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+def _resolve_revision(doc_id: str, selector: str) -> dict:
+    """Resolve a REV selector to a revision dict (one revisions.list call)."""
+    from gdoc.api.revisions import list_revisions
+    from gdoc.revdiff import resolve_selector
+
+    return resolve_selector(list_revisions(doc_id), selector)
+
+
+def cmd_revisions(args) -> int:
+    """Handler for `gdoc revisions`."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    limit = getattr(args, "limit", 0)
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+
+    from gdoc.api.revisions import list_revisions
+    revisions = list_revisions(doc_id)
+    if limit and limit > 0:
+        revisions = revisions[-limit:]
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    if mode == "json":
+        items = [
+            {
+                "id": r.get("id"),
+                "modifiedTime": r.get("modifiedTime", ""),
+                "lastModifyingUser": r.get("lastModifyingUser", {}),
+                "keepForever": r.get("keepForever", False),
+                "exportLinks": r.get("exportLinks", {}),
+            }
+            for r in revisions
+        ]
+        print(format_json(revisions=items))
+    elif mode == "plain":
+        for r in revisions:
+            author = (r.get("lastModifyingUser") or {}).get("displayName", "")
+            keep = "true" if r.get("keepForever") else "false"
+            print(f"{r.get('id')}\t{r.get('modifiedTime', '')}\t{author}\t{keep}")
+    elif not revisions:
+        print("No revisions retained.")
+    else:
+        for r in revisions:
+            author = (r.get("lastModifyingUser") or {}).get("displayName", "?")
+            if mode == "verbose":
+                when = r.get("modifiedTime", "")
+            else:
+                when = _format_local_time(r.get("modifiedTime", ""))
+            keep = "  [keep]" if r.get("keepForever") else ""
+            print(f"{r.get('id', '?'):>6}  {when}  {author}{keep}")
+        if mode == "verbose":
+            print(f"\n({len(revisions)} revisions, oldest first; "
+                  "non-pinned revisions are pruned by Google over time)")
+
+    from gdoc.state import update_state_after_command
+    update_state_after_command(
+        doc_id, change_info, command="revisions", quiet=quiet,
+    )
+
+    return 0
+
+
 def cmd_cat(args) -> int:
     """Handler for `gdoc cat`."""
     doc_id = _resolve_doc_id(args.doc)
@@ -196,6 +276,14 @@ def cmd_cat(args) -> int:
     max_bytes = getattr(args, "max_bytes", 0)
     no_images = getattr(args, "no_images", False)
 
+    revision = getattr(args, "revision", None)
+    if revision and (tab or all_tabs or getattr(args, "comments", False)):
+        raise GdocError(
+            "--revision cannot be combined with "
+            "--tab/--all-tabs/--comments",
+            exit_code=3,
+        )
+
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
 
@@ -204,6 +292,38 @@ def cmd_cat(args) -> int:
 
     if getattr(args, "range", None):
         raise GdocError("--range is only supported for spreadsheets", exit_code=3)
+
+    if revision:
+        from gdoc.api.revisions import export_revision
+
+        rev = _resolve_revision(doc_id, revision)
+        mime = (
+            "text/plain" if getattr(args, "plain", False)
+            else "text/markdown"
+        )
+        content = export_revision(
+            doc_id, rev["id"], mime_type=mime,
+            export_links=rev.get("exportLinks"),
+        )
+        if no_images:
+            from gdoc.mdimport import strip_images
+            content = strip_images(content)
+        content = _truncate_bytes(content, max_bytes)
+
+        from gdoc.format import format_json, get_output_mode
+        if get_output_mode(args) == "json":
+            print(format_json(revision=rev["id"], content=content))
+        else:
+            print(content, end="")
+
+        # A past revision is not the current content: record the
+        # interaction without advancing the read baseline that the
+        # write-conflict check relies on.
+        from gdoc.state import update_state_after_command
+        update_state_after_command(
+            doc_id, change_info, command="cat-revision", quiet=quiet,
+        )
+        return 0
 
     if tab or all_tabs:
         from gdoc.api.docs import get_document_tabs, get_tab_text
@@ -1264,6 +1384,7 @@ def cmd_pull(args) -> int:
     doc_id = _resolve_doc_id(args.doc)
     quiet = getattr(args, "quiet", False)
     file_path = args.file
+    revision = getattr(args, "revision", None)
 
     # Pre-flight awareness check
     from gdoc.notify import pre_flight
@@ -1271,17 +1392,34 @@ def cmd_pull(args) -> int:
     change_info = pre_flight(doc_id, quiet=quiet)
     _require_doc(doc_id, change_info)
 
-    # Export doc as markdown
+    # Export doc (or one past revision) as markdown
     from gdoc.api.drive import export_doc, get_file_info
 
-    markdown = export_doc(doc_id, mime_type="text/markdown")
+    rev = None
+    if revision:
+        from gdoc.api.revisions import export_revision
+
+        rev = _resolve_revision(doc_id, revision)
+        markdown = export_revision(
+            doc_id, rev["id"], mime_type="text/markdown",
+            export_links=rev.get("exportLinks"),
+        )
+    else:
+        markdown = export_doc(doc_id, mime_type="text/markdown")
     metadata = get_file_info(doc_id)
     title = metadata.get("name", "")
 
-    # Add frontmatter and write to local file
+    # Add frontmatter and write to local file. Revision pulls
+    # deliberately omit the `gdoc:` key — push and the sync hooks key
+    # off it, and silently pushing a stale revision over the live doc
+    # is a footgun.
     from gdoc.frontmatter import add_frontmatter
 
-    content = add_frontmatter(markdown, {"gdoc": doc_id, "title": title})
+    if rev is not None:
+        front = {"source": doc_id, "revision": rev["id"], "title": title}
+    else:
+        front = {"gdoc": doc_id, "title": title}
+    content = add_frontmatter(markdown, front)
 
     try:
         with open(file_path, "w") as f:
@@ -1292,27 +1430,40 @@ def cmd_pull(args) -> int:
     # Output
     from gdoc.format import get_output_mode, format_json
 
+    rev_label = f" @ rev {rev['id']}" if rev is not None else ""
     mode = get_output_mode(args)
     if mode == "json":
-        print(format_json(pulled=True, title=title, file=file_path))
+        if rev is not None:
+            print(format_json(
+                pulled=True, title=title, file=file_path,
+                revision=rev["id"],
+            ))
+        else:
+            print(format_json(pulled=True, title=title, file=file_path))
     elif mode == "plain":
         print(f"path\t{file_path}")
+        if rev is not None:
+            print(f"revision\t{rev['id']}")
     elif mode == "verbose":
-        print(f'Pulled: "{title}"')
+        print(f'Pulled: "{title}"{rev_label}')
         print(f"File: {file_path}")
         print(f"Doc ID: {doc_id}")
     else:
-        print(f'OK pulled "{title}" -> {file_path}')
+        print(f'OK pulled "{title}"{rev_label} -> {file_path}')
 
-    # Update state (pull is a read command)
+    # Update state (pull is a read command; a revision pull is not a
+    # read of the current content, so it must not advance the read
+    # baseline used by write-conflict checks)
     command_version = metadata.get("version")
     if command_version is not None:
         command_version = int(command_version)
     from gdoc.state import update_state_after_command
 
     update_state_after_command(
-        doc_id, change_info, command="pull",
-        quiet=quiet, command_version=command_version,
+        doc_id, change_info,
+        command="pull" if rev is None else "pull-revision",
+        quiet=quiet,
+        command_version=command_version if rev is None else None,
     )
 
     return 0
@@ -1341,6 +1492,15 @@ def cmd_push(args) -> int:
 
     metadata, body = parse_frontmatter(content)
     if "gdoc" not in metadata:
+        # pull --revision writes both keys; requiring both avoids
+        # false positives on unrelated files with a `source:` key
+        if "revision" in metadata and "source" in metadata:
+            raise GdocError(
+                "this file was pulled from a past revision and is not "
+                "pushable (it would overwrite the live doc with stale "
+                "content). Use 'gdoc pull' for an editable copy.",
+                exit_code=3,
+            )
         raise GdocError(
             "no gdoc frontmatter found. Use 'gdoc pull' first.",
             exit_code=3,
@@ -1543,13 +1703,223 @@ def cmd_pull_hook(args) -> int:
     return 0
 
 
+def _resolve_diff_format(args) -> str:
+    """Resolve the effective renderer for a revision diff."""
+    import sys
+
+    from gdoc.format import get_output_mode
+
+    fmt = getattr(args, "format", "auto")
+    out = getattr(args, "out", None)
+    mode = get_output_mode(args)
+
+    if fmt == "auto" and out:
+        if out.endswith(".html"):
+            fmt = "html"
+        else:
+            raise GdocError(
+                f"cannot infer format from {out!r} (expected .html); "
+                "pass --format",
+                exit_code=3,
+            )
+    # --json composes with the html artifact (JSON write confirmation
+    # on stdout) but not with the terminal formats
+    if mode == "json" and fmt in ("color", "plain"):
+        raise GdocError(
+            f"--json and --format {fmt} are mutually exclusive",
+            exit_code=3,
+        )
+    if mode == "plain" and fmt == "color":
+        raise GdocError(
+            "--plain and --format color are mutually exclusive",
+            exit_code=3,
+        )
+    if out and fmt != "html":
+        raise GdocError(
+            "--out requires --format html "
+            "(redirect stdout for text formats)",
+            exit_code=3,
+        )
+    if fmt == "auto":
+        if mode == "json":
+            return "json"
+        if mode == "plain":
+            return "plain"
+        return "color" if sys.stdout.isatty() else "plain"
+    return fmt
+
+
+def _diff_revisions(args, doc_id: str) -> int:
+    """Revision-vs-revision diff (`gdoc diff --rev` / `--since`)."""
+    quiet = getattr(args, "quiet", False)
+    since = getattr(args, "since", None)
+    min_common = getattr(args, "min_common", DEFAULT_MIN_COMMON)
+    context = getattr(args, "context", DEFAULT_CONTEXT)
+    with_comments = getattr(args, "with_comments", False)
+
+    fmt = _resolve_diff_format(args)
+    if with_comments and fmt in ("color", "plain"):
+        raise GdocError(
+            "--with-comments requires --format html or json "
+            "(the terminal renderer does not show comments)",
+            exit_code=3,
+        )
+
+    from gdoc.revdiff import (
+        build_diff_model,
+        hunk_changed,
+        parse_rev_range,
+        parse_timestamp,
+        resolve_at_timestamp,
+        resolve_selector,
+    )
+
+    # Validate selector syntax before any API call
+    if since:
+        parse_timestamp(since)
+        old_sel = new_sel = None
+    else:
+        old_sel, new_sel = parse_rev_range(args.rev)
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+
+    from gdoc.api.revisions import export_revision, list_revisions
+
+    revisions = list_revisions(doc_id)
+    if since:
+        old_rev = resolve_at_timestamp(revisions, since)
+        new_rev = resolve_selector(revisions, "latest")
+    else:
+        old_rev = resolve_selector(revisions, old_sel)
+        new_rev = resolve_selector(revisions, new_sel)
+
+    from gdoc.api.drive import get_file_info
+    metadata = get_file_info(doc_id)
+    doc_name = metadata.get("name", doc_id)
+
+    old_md = export_revision(
+        doc_id, old_rev["id"], export_links=old_rev.get("exportLinks"),
+    )
+    new_md = export_revision(
+        doc_id, new_rev["id"], export_links=new_rev.get("exportLinks"),
+    )
+
+    model = build_diff_model(
+        doc_id, doc_name, old_rev, new_rev, old_md, new_md,
+        min_common=min_common,
+    )
+
+    if with_comments:
+        from gdoc.api.comments import list_comments
+        from gdoc.revdiff import attach_comments
+
+        comments = list_comments(doc_id, include_anchor=True)
+        model["comments"] = attach_comments(model["hunks"], comments)
+
+    changed = sum(1 for h in model["hunks"] if hunk_changed(h))
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+
+    if fmt == "json":
+        print(format_json(identical=changed == 0, **model))
+    elif fmt == "html":
+        out_path = getattr(args, "out", None) or "gdoc-diff.html"
+        from gdoc.diffrender import render_html
+        try:
+            with open(out_path, "w") as f:
+                f.write(render_html(model, context=context))
+        except OSError as e:
+            raise GdocError(f"cannot write file: {e}", exit_code=3)
+
+        inline = None
+        anchored = ""
+        if "comments" in model:
+            inline = sum(
+                1 for c in model["comments"] if c["hunk"] is not None
+            )
+            anchored = f", {inline}/{len(model['comments'])} comments anchored"
+        if mode == "json":
+            confirmation = {
+                "path": out_path,
+                "format": fmt,
+                "changed": changed,
+                "identical": changed == 0,
+            }
+            if inline is not None:
+                confirmation["comments"] = len(model["comments"])
+                confirmation["comments_anchored"] = inline
+            print(format_json(**confirmation))
+        elif mode == "plain":
+            print(f"path\t{out_path}")
+            print(f"changed\t{changed}")
+        elif mode == "verbose":
+            print(f"Wrote: {out_path}")
+            print(f"Revisions: {old_rev['id']} -> {new_rev['id']}")
+            print(f"Changed hunks: {changed}{anchored}")
+        else:
+            print(f"OK wrote {out_path} ({changed} changed hunks{anchored})")
+    elif changed == 0:
+        print(f"OK identical (rev {old_rev['id']} -> rev {new_rev['id']})")
+    else:
+        from gdoc.diffrender import render_terminal
+        print(
+            render_terminal(model, color=fmt == "color", context=context),
+            end="",
+        )
+
+    # Update state (version already fetched via get_file_info above)
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(
+        doc_id, change_info, command="diff", quiet=quiet,
+        command_version=metadata.get("version"),
+    )
+
+    return 1 if changed else 0
+
+
 def cmd_diff(args) -> int:
     """Handler for `gdoc diff`."""
     import difflib
     import os
 
     doc_id = _resolve_doc_id(args.doc)
-    file_path = args.file
+    file_path = getattr(args, "file", None)
+    rev = getattr(args, "rev", None)
+    since = getattr(args, "since", None)
+
+    if rev and since:
+        raise GdocError(
+            "--rev and --since are mutually exclusive", exit_code=3,
+        )
+    if file_path and (rev or since):
+        raise GdocError(
+            "FILE and --rev/--since are mutually exclusive (a file diff "
+            "always compares against the current document)",
+            exit_code=3,
+        )
+    if rev or since:
+        return _diff_revisions(args, doc_id)
+    if not file_path:
+        raise GdocError(
+            "nothing to compare: pass a local FILE, or --rev/--since "
+            "to diff revisions",
+            exit_code=3,
+        )
+    if (
+        getattr(args, "format", "auto") != "auto"
+        or getattr(args, "out", None)
+        or getattr(args, "with_comments", False)
+    ):
+        raise GdocError(
+            "--format/--out/--with-comments apply to revision diffs "
+            "(--rev/--since), not file diffs",
+            exit_code=3,
+        )
+
     quiet = getattr(args, "quiet", False)
     use_plain = getattr(args, "plain", False)
 
@@ -2445,9 +2815,35 @@ def build_parser() -> GdocArgumentParser:
         help="Strip image references from output",
     )
     cat_p.add_argument(
+        "--revision", metavar="REV",
+        help="Export a past revision (id, latest, head, prev, head~N, "
+             "or @ISO; see `gdoc revisions`)",
+    )
+    cat_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     cat_p.set_defaults(func=cmd_cat)
+
+    # revisions
+    revisions_p = sub.add_parser(
+        "revisions", parents=[output_parent], aliases=["history"],
+        help="List retained revisions (milestones) of a doc",
+        description=(
+            "List the milestone revisions the Drive API retains for a "
+            "document, oldest first. Revision ids are sparse, and "
+            "non-pinned revisions are pruned by Google over time. "
+            "Revision ids feed `cat/pull --revision` and `diff --rev`."
+        ),
+    )
+    revisions_p.add_argument("doc", help="Document ID or URL")
+    revisions_p.add_argument(
+        "--limit", type=int, default=0, metavar="N",
+        help="Show only the N most recent revisions",
+    )
+    revisions_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    revisions_p.set_defaults(func=cmd_revisions)
 
     # tabs
     tabs_p = sub.add_parser(
@@ -2574,9 +2970,59 @@ def build_parser() -> GdocArgumentParser:
     edit_p.set_defaults(func=cmd_edit)
 
     # diff
-    diff_p = sub.add_parser("diff", parents=[output_parent], help="Compare doc with local file")
+    diff_p = sub.add_parser(
+        "diff", parents=[output_parent],
+        help="Compare doc with a local file, or between revisions",
+        description=(
+            "With FILE, compare the current document against a local "
+            "file (unified diff). With --rev or --since, compare two "
+            "retained revisions with a readable coalesced word-diff. "
+            "REV selectors: a revision id, latest/head, prev, head~N "
+            "(by list position), or @ISO (last revision at/before the "
+            "timestamp)."
+        ),
+    )
     diff_p.add_argument("doc", help="Document ID or URL")
-    diff_p.add_argument("file", help="Local file to compare against")
+    diff_p.add_argument(
+        "file", nargs="?",
+        help="Local file to compare against (current doc vs file)",
+    )
+    diff_p.add_argument(
+        "--rev", metavar="REV[..REV]",
+        help="Diff revisions: A..B compares two; a single selector "
+             "compares it against the latest",
+    )
+    diff_p.add_argument(
+        "--since", metavar="ISO",
+        help="Diff the last revision at/before this timestamp against "
+             "the latest (what changed since I last read it)",
+    )
+    diff_p.add_argument(
+        "--format",
+        choices=["auto", "color", "plain", "json", "html"],
+        default="auto",
+        help="Revision-diff renderer (default: color on a TTY, else "
+             "plain; html writes a styled artifact)",
+    )
+    diff_p.add_argument(
+        "--out", metavar="PATH",
+        help="Output path for --format html (default: gdoc-diff.html)",
+    )
+    diff_p.add_argument(
+        "--with-comments", action="store_true",
+        help="Anchor the doc's comment threads into html/json "
+             "revision diffs",
+    )
+    diff_p.add_argument(
+        "--min-common", type=int, default=DEFAULT_MIN_COMMON, metavar="N",
+        help="Coalescing threshold for word-diff chunks "
+             f"(higher = chunkier; default {DEFAULT_MIN_COMMON})",
+    )
+    diff_p.add_argument(
+        "--context", type=int, default=DEFAULT_CONTEXT, metavar="N",
+        help="Unchanged blocks kept around each change "
+             f"(default {DEFAULT_CONTEXT})",
+    )
     diff_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
@@ -2646,6 +3092,12 @@ def build_parser() -> GdocArgumentParser:
     pull_p = sub.add_parser("pull", parents=[output_parent], help="Download doc as local markdown")
     pull_p.add_argument("doc", help="Document ID or URL")
     pull_p.add_argument("file", help="Local file to write")
+    pull_p.add_argument(
+        "--revision", metavar="REV",
+        help="Download a past revision (id, latest, head, prev, head~N, "
+             "or @ISO); the file gets `source:`/`revision:` frontmatter "
+             "instead of `gdoc:` so it cannot be pushed back by accident",
+    )
     pull_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1832,7 +1832,7 @@ def _diff_revisions(args, doc_id: str) -> int:
             with open(out_path, "w") as f:
                 f.write(render_html(model, context=context))
         except OSError as e:
-            raise GdocError(f"cannot write file: {e}", exit_code=3)
+            raise GdocError(f"cannot write file: {e}", exit_code=3) from e
 
         inline = None
         anchored = ""

--- a/gdoc/diffrender.py
+++ b/gdoc/diffrender.py
@@ -1,0 +1,293 @@
+"""Terminal (color/plain) and HTML renderers for the revision-diff model.
+
+Richer artifacts (docx, PDF, ...) are deliberately out of scope:
+external scripts build them from the `gdoc diff --json` model.
+"""
+
+import html as html_mod
+from collections.abc import Iterator
+
+from gdoc.revdiff import DEFAULT_CONTEXT, hunk_changed
+
+_RESET = "\x1b[0m"
+_DIM = "\x1b[2m"
+_GREEN = "\x1b[32m"
+_RED_STRIKE = "\x1b[31;9m"
+
+
+def select_visible(
+    hunks: list[dict],
+    context: int = DEFAULT_CONTEXT,
+    comment_hunks: frozenset | set = frozenset(),
+) -> list[bool]:
+    """Which hunks to render: changed, commented, headings, ±context."""
+    keep = [
+        hunk_changed(h)
+        or h["block_type"] == "heading"
+        or i in comment_hunks
+        for i, h in enumerate(hunks)
+    ]
+    for i, h in enumerate(hunks):
+        if hunk_changed(h):
+            for d in range(-context, context + 1):
+                if 0 <= i + d < len(hunks):
+                    keep[i + d] = True
+    return keep
+
+
+def iter_visible(
+    hunks: list[dict],
+    context: int = DEFAULT_CONTEXT,
+    comment_hunks: frozenset | set = frozenset(),
+) -> Iterator[tuple[str, int]]:
+    """Yield ("gap", count) / ("hunk", index) events, collapsing
+    consecutive hidden hunks into one gap."""
+    keep = select_visible(hunks, context, comment_hunks=comment_hunks)
+    gap = 0
+    for i in range(len(hunks)):
+        if not keep[i]:
+            gap += 1
+            continue
+        if gap:
+            yield "gap", gap
+            gap = 0
+        yield "hunk", i
+    if gap:
+        yield "gap", gap
+
+
+def split_comments(comments: list[dict]) -> tuple[dict, list[dict]]:
+    """Group model comments by anchored hunk index; rest go to appendix."""
+    by_hunk: dict[int, list[dict]] = {}
+    appendix: list[dict] = []
+    for c in comments:
+        if c.get("hunk") is None:
+            appendix.append(c)
+        else:
+            by_hunk.setdefault(c["hunk"], []).append(c)
+    return by_hunk, appendix
+
+
+def short_time(iso: str) -> str:
+    """Trim an RFC3339 UTC timestamp to 'YYYY-MM-DD HH:MMZ'."""
+    return iso[:16].replace("T", " ") + "Z" if iso else "?"
+
+
+_QUOTED_MAX = 90
+
+
+def clip_quoted(text: str) -> str:
+    """Truncate a comment's quoted snippet for display."""
+    return text[:_QUOTED_MAX] + "…" if len(text) > _QUOTED_MAX else text
+
+
+# ---------------------------------------------------------------- terminal
+
+def _block_prefix(hunk: dict) -> str:
+    if hunk["block_type"] == "heading":
+        return "#" * hunk.get("level", 2) + " "
+    if hunk["block_type"] == "listitem":
+        return hunk.get("marker", "•") + " "
+    return ""
+
+
+def _term_run(run: dict, color: bool) -> str:
+    if run["op"] == "ins":
+        if color:
+            return f"{_GREEN}{run['text']}{_RESET}"
+        return "{+" + run["text"] + "+}"
+    if run["op"] == "del":
+        if color:
+            return f"{_RED_STRIKE}{run['text']}{_RESET}"
+        return "[-" + run["text"] + "-]"
+    return run["text"]
+
+
+def render_terminal(
+    model: dict, color: bool, context: int = DEFAULT_CONTEXT,
+) -> str:
+    """Render the diff model as terminal text (ANSI word-diff or plain)."""
+    old, new = model["old"], model["new"]
+    header = (
+        f"{model['doc']['name']}: "
+        f"rev {old['id']} ({short_time(old['modifiedTime'])}) -> "
+        f"rev {new['id']} ({short_time(new['modifiedTime'])})"
+    )
+    lines = [f"{_DIM}{header}{_RESET}" if color else header, ""]
+
+    hunks = model["hunks"]
+    for event, value in iter_visible(hunks, context):
+        if event == "gap":
+            label = f"⋯ {value} unchanged ⋯"
+            lines.append(f"{_DIM}{label}{_RESET}" if color else label)
+            continue
+        hunk = hunks[value]
+        body = "".join(_term_run(r, color) for r in hunk["runs"])
+        line = _block_prefix(hunk) + body
+        if color and hunk["kind"] == "equal":
+            line = f"{_DIM}{line}{_RESET}"
+        lines.append(line)
+
+    return "\n".join(lines) + "\n"
+
+
+# -------------------------------------------------------------------- html
+
+_AUTHOR_BARS = [
+    "#d4a72c", "#54aeff", "#8250df", "#fb8500", "#2da44e", "#cf222e",
+]
+
+_HTML_STYLE = """\
+body { font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI",
+       Helvetica, Arial, sans-serif; color: #24292f; max-width: 760px;
+       margin: 2rem auto; padding: 0 1rem; }
+h1.title { margin-bottom: 0.2rem; color: #0b2b52; }
+.meta { color: #57606a; margin-bottom: 0.3rem; }
+.meta .old { color: #8b141b; } .meta .new { color: #0a5a24; }
+.legend { color: #57606a; font-size: 13px; border-bottom: 1px solid #d0d7de;
+          padding-bottom: 0.8rem; margin-bottom: 1rem; }
+ins { background: #ccffd8; color: #0a5a24; text-decoration: none; }
+del { background: #ffd7d5; color: #8b141b; text-decoration: line-through; }
+h2.h, h3.h, h4.h { color: #0b2b52; margin: 1.1em 0 0.3em; }
+.h.ins-blk { color: #0a5a24; } .h.del-blk { color: #8b141b; }
+.blk { margin: 6px 0; }
+.blk.ctx { color: #57606a; }
+.blk.ins-blk { border-left: 3px solid #2da44e; padding-left: 9px; }
+.blk.del-blk { border-left: 3px solid #cf222e; padding-left: 9px; }
+.blk.rep { border-left: 3px solid #0969da; padding-left: 9px; }
+.collapse { text-align: center; color: #8c959d; font-style: italic;
+            font-size: 13px; margin: 10px 0; }
+.cmt { background: #fff8c5; border-left: 4px solid #d4a72c; border-radius: 3px;
+       padding: 8px 12px; margin: 8px 0 8px 16px; font-size: 13.5px; }
+.cmt.resolved { opacity: 0.65; }
+.cmt .head { font-weight: 600; }
+.cmt .head .when, .cmt .head .tag { color: #57606a; font-weight: 400;
+                                    font-size: 12.5px; }
+.cmt .on { color: #57606a; font-style: italic; font-size: 12.5px; }
+.cmt .reply { margin-left: 1.2em; margin-top: 2px; }
+.appendix { border-top: 1px solid #d0d7de; margin-top: 1.5rem;
+            padding-top: 0.5rem; }
+"""
+
+
+def _html_runs(runs: list[dict]) -> str:
+    parts = []
+    for r in runs:
+        text = html_mod.escape(r["text"])
+        if r["op"] == "ins":
+            parts.append(f"<ins>{text}</ins>")
+        elif r["op"] == "del":
+            parts.append(f"<del>{text}</del>")
+        else:
+            parts.append(text)
+    return "".join(parts)
+
+
+_KIND_CLASS = {
+    "equal": "ctx", "insert": "ins-blk", "delete": "del-blk",
+    "replace": "rep",
+}
+
+
+def _html_hunk(hunk: dict) -> str:
+    body = _html_runs(hunk["runs"])
+    kind_class = _KIND_CLASS[hunk["kind"]]
+    if hunk["block_type"] == "heading":
+        tag = f"h{min(hunk.get('level', 2) + 1, 4)}"
+        return f'<{tag} class="h {kind_class}">{body}</{tag}>'
+    if hunk["block_type"] == "listitem":
+        marker = html_mod.escape(hunk.get("marker", "•"))
+        body = f"{marker}&nbsp;&nbsp;" + body
+    return f'<div class="blk {kind_class}">{body}</div>'
+
+
+def _html_comment(c: dict, bar: str) -> str:
+    classes = "cmt resolved" if c.get("resolved") else "cmt"
+    head = (
+        f'💬 {html_mod.escape(c["author"])} '
+        f'<span class="when">· {html_mod.escape(short_time(c["createdTime"]))}'
+        "</span>"
+    )
+    if c.get("resolved"):
+        head += ' <span class="tag">(resolved)</span>'
+    parts = [
+        f'<div class="{classes}" style="border-left-color:{bar}">',
+        f'<div class="head">{head}</div>',
+    ]
+    if c.get("quoted"):
+        parts.append(
+            '<div class="on">on: '
+            f"“{html_mod.escape(clip_quoted(c['quoted']))}”</div>"
+        )
+    parts.append(f"<div>{html_mod.escape(c['content'])}</div>")
+    for r in c.get("replies", []):
+        parts.append(
+            f'<div class="reply">↳ <b>{html_mod.escape(r["author"])}</b>: '
+            f'{html_mod.escape(r["content"])}</div>'
+        )
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def render_html(model: dict, context: int = DEFAULT_CONTEXT) -> str:
+    """Render the diff model as a self-contained styled HTML document."""
+    hunks = model["hunks"]
+    comments = model.get("comments", [])
+    by_hunk, appendix = split_comments(comments)
+
+    author_bars: dict[str, str] = {}
+
+    def bar(author: str) -> str:
+        if author not in author_bars:
+            author_bars[author] = _AUTHOR_BARS[
+                len(author_bars) % len(_AUTHOR_BARS)
+            ]
+        return author_bars[author]
+
+    name = html_mod.escape(model["doc"]["name"])
+    old, new = model["old"], model["new"]
+    legend = (
+        "<ins>added</ins> &nbsp; <del>removed</del> &nbsp;·&nbsp; "
+        "blue bar = reworded"
+    )
+    if comments:
+        legend += " &nbsp;·&nbsp; 💬 comment threads (color-coded by author)"
+
+    body: list[str] = [
+        f'<h1 class="title">{name} — revision diff</h1>',
+        '<div class="meta">'
+        f'<span class="old">rev {html_mod.escape(str(old["id"]))} '
+        f"({html_mod.escape(short_time(old['modifiedTime']))})</span>"
+        " → "
+        f'<span class="new">rev {html_mod.escape(str(new["id"]))} '
+        f"({html_mod.escape(short_time(new['modifiedTime']))})</span>"
+        "</div>",
+        f'<div class="legend">{legend}</div>',
+    ]
+
+    for event, value in iter_visible(
+        hunks, context, comment_hunks=set(by_hunk),
+    ):
+        if event == "gap":
+            body.append(
+                f'<div class="collapse">⋯ {value} unchanged ⋯</div>'
+            )
+            continue
+        body.append(_html_hunk(hunks[value]))
+        for c in by_hunk.get(value, []):
+            body.append(_html_comment(c, bar(c["author"])))
+
+    if appendix:
+        body.append('<div class="appendix">')
+        body.append("<h2>Other comment threads</h2>")
+        for c in appendix:
+            body.append(_html_comment(c, bar(c["author"])))
+        body.append("</div>")
+
+    return (
+        "<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n"
+        f"<title>{name} — revision diff</title>\n"
+        f"<style>\n{_HTML_STYLE}</style>\n</head>\n<body>\n"
+        + "\n".join(body)
+        + "\n</body>\n</html>\n"
+    )

--- a/gdoc/frontmatter.py
+++ b/gdoc/frontmatter.py
@@ -52,9 +52,15 @@ def add_frontmatter(body: str, metadata: dict) -> str:
 
     Returns:
         Content with frontmatter prepended.
+
+    Values are flattened to a single line: a line break in a value
+    (e.g. a doc title) would otherwise inject arbitrary frontmatter
+    keys. splitlines() covers the same separator set parse_frontmatter
+    splits on (\\n, \\r, \\x0b, \\u2028, ...), unlike a [\\r\\n] regex.
     """
     lines = ["---"]
     for key, value in metadata.items():
+        value = " ".join(str(value).splitlines())
         lines.append(f"{key}: {value}")
     lines.append("---")
     lines.append("")

--- a/gdoc/mdimport.py
+++ b/gdoc/mdimport.py
@@ -8,6 +8,12 @@ from dataclasses import dataclass
 
 _IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 
+# Reference-style images as emitted by the Drive markdown export:
+# `![][imageN]` refs plus `[imageN]: <data:image/...>` definitions.
+# Single source for this convention — gdoc.revdiff imports both.
+IMAGE_REF_RE = re.compile(r"!\[\]\[image\d+\]")
+IMAGE_DEF_RE = re.compile(r"^[ \t]*\[image\d+\][ \t]*:.*$", re.MULTILINE)
+
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 
 _MIME_TYPES = {
@@ -106,7 +112,13 @@ def extract_images(
 
 
 def strip_images(content: str) -> str:
-    """Remove image references and collapse excess blank lines."""
+    """Remove image references and collapse excess blank lines.
+
+    Handles both inline ``![alt](path)`` images and the reference
+    style the Drive markdown export emits.
+    """
     result = _IMAGE_RE.sub("", content)
+    result = IMAGE_REF_RE.sub("", result)
+    result = IMAGE_DEF_RE.sub("", result)
     result = re.sub(r"\n{3,}", "\n\n", result)
     return result

--- a/gdoc/revdiff.py
+++ b/gdoc/revdiff.py
@@ -1,0 +1,541 @@
+"""Revision diff engine: REV selectors, block alignment, coalescing word-diff.
+
+One diff model, many renderers (gdoc.diffrender for terminal/HTML;
+richer artifacts like docx are built by external scripts from the
+`--json` output). The model is the documented `gdoc diff --json`
+schema::
+
+    {
+      "doc": {"id": "...", "name": "..."},
+      "old": {"id": "69",  "modifiedTime": "..."},
+      "new": {"id": "190", "modifiedTime": "..."},
+      "hunks": [
+        {"kind": "equal|insert|delete|replace",
+         "block_type": "heading|paragraph|listitem",
+         "level": 2,                      # headings only
+         "marker": "2.",                  # list items only ("•" for bullets)
+         "runs": [{"op": "equal|del|ins", "text": "..."}]}
+      ],
+      "comments": [                       # only with --with-comments
+        {"id": "...", "author": "...", "createdTime": "...",
+         "resolved": false, "content": "...", "quoted": "...",
+         "hunk": 3,                       # anchored hunk index, or null
+         "replies": [{"author": "...", "content": "...",
+                      "createdTime": "..."}]}
+      ]
+    }
+
+The CLI's ``--json`` output wraps this model with top-level ``ok`` and
+``identical`` keys. The model is display-oriented, not a faithful
+character diff: ``clean_text`` normalizes export escaping/whitespace
+and replaces images with placeholders, and coalescing (``min_common``)
+absorbs short unchanged spans into the surrounding change.
+"""
+
+import difflib
+import html
+import re
+from datetime import datetime
+
+from gdoc.mdimport import IMAGE_DEF_RE, IMAGE_REF_RE
+from gdoc.util import GdocError
+
+DEFAULT_MIN_COMMON = 24
+DEFAULT_CONTEXT = 2
+
+_HEADING_MARK = r"#{1,6}"
+_BULLET_MARK = r"\\?[*\-]"
+_ORDERED_MARK = r"\d+[.)\\]+"
+_HEADING = re.compile(rf"^({_HEADING_MARK})\s")
+_LISTITEM = re.compile(rf"^\s*({_BULLET_MARK}|{_ORDERED_MARK})\s")
+_TOKEN = re.compile(r"\s+|\S+")
+_HEAD_N = re.compile(r"^(?:head|latest)~(\d+)$")
+
+
+# ---------------------------------------------------------------- selectors
+
+def parse_rev_range(rev: str) -> tuple[str, str]:
+    """Parse a --rev value into (old_selector, new_selector).
+
+    "A..B" compares two revisions; a single selector "A" compares it
+    against the latest.
+    """
+    if ".." in rev:
+        old_sel, _, new_sel = rev.partition("..")
+        if not old_sel or not new_sel:
+            raise GdocError(
+                f"invalid revision range: {rev!r} (use A..B)", exit_code=3,
+            )
+        return old_sel, new_sel
+    return rev, "latest"
+
+
+def resolve_selector(revisions: list[dict], selector: str) -> dict:
+    """Resolve a REV selector against the retained-revisions list.
+
+    Grammar: bare id | latest | head | prev | head~N | @ISO.
+    head~N counts by list position — revision ids are sparse, so id
+    arithmetic is never valid.
+    """
+    if not revisions:
+        raise GdocError(
+            "no revisions retained for this document", exit_code=3,
+        )
+    s = selector.strip()
+    lowered = s.lower()
+    if lowered in ("latest", "head"):
+        return revisions[-1]
+    if lowered == "prev":
+        return _nth_before_latest(revisions, 1, label="prev")
+    match = _HEAD_N.match(lowered)
+    if match:
+        return _nth_before_latest(revisions, int(match.group(1)))
+    if s.startswith("@"):
+        return resolve_at_timestamp(revisions, s[1:])
+    for rev in revisions:
+        if rev.get("id") == s:
+            return rev
+    raise pruned_error(s)
+
+
+def pruned_error(revision_id: str) -> GdocError:
+    """The shared not-found/pruned error (also raised by the API layer)."""
+    return GdocError(
+        f"revision not found: {revision_id} (it may have been pruned — "
+        "Google drops non-pinned revisions over time). "
+        "Run `gdoc revisions DOC` to see retained revisions.",
+        exit_code=3,
+    )
+
+
+def _nth_before_latest(
+    revisions: list[dict], n: int, label: str | None = None,
+) -> dict:
+    index = len(revisions) - 1 - n
+    if index < 0:
+        raise GdocError(
+            f"{label or f'head~{n}'} is out of range (only "
+            f"{len(revisions)} "
+            f"revision{'s' if len(revisions) != 1 else ''} retained). "
+            "Run `gdoc revisions DOC`.",
+            exit_code=3,
+        )
+    return revisions[index]
+
+
+def parse_timestamp(value: str) -> datetime:
+    """Parse a user-supplied ISO timestamp.
+
+    Accepts dates ("2026-06-10") and datetimes with or without an
+    offset; naive values are interpreted as local time.
+    """
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as e:
+        raise GdocError(
+            f"invalid timestamp: {value!r} (use ISO format, e.g. "
+            "2026-06-10T19:00:00Z or 2026-06-10)",
+            exit_code=3,
+        ) from e
+    if parsed.tzinfo is None:
+        parsed = parsed.astimezone()
+    return parsed
+
+
+def _revision_time(rev: dict) -> datetime:
+    return datetime.fromisoformat(
+        rev.get("modifiedTime", "").replace("Z", "+00:00")
+    )
+
+
+def resolve_at_timestamp(revisions: list[dict], value: str) -> dict:
+    """Resolve to the last revision at/before a timestamp (--since, @ISO)."""
+    if not revisions:
+        raise GdocError(
+            "no revisions retained for this document", exit_code=3,
+        )
+    target = parse_timestamp(value)
+    prior = [r for r in revisions if _revision_time(r) <= target]
+    if not prior:
+        earliest = revisions[0].get("modifiedTime", "?")
+        raise GdocError(
+            f"no revision at/before {value} (earliest retained is "
+            f"{earliest}). Run `gdoc revisions DOC`.",
+            exit_code=3,
+        )
+    return prior[-1]
+
+
+# ------------------------------------------------------------ text cleanup
+
+def clean_text(s: str) -> str:
+    """Clean one exported-markdown block for display.
+
+    The markdown export escapes punctuation (``\\>``, ``\\=``, sometimes
+    double-escaped): de-escape in a loop, drop a leading blockquote
+    marker, replace image refs with a placeholder, and collapse spaces.
+    """
+    s = html.unescape(s)
+    s = IMAGE_REF_RE.sub("⟦diagram⟧", s)
+    for _ in range(3):  # loop handles double-escapes
+        unescaped = re.sub(r"\\([^\w\s])", r"\1", s)
+        if unescaped == s:
+            break
+        s = unescaped
+    s = re.sub(r"^>\s*", "", s)
+    s = s.replace("\u00a0", " ")  # nbsp
+    return re.sub(r"[ \t]+", " ", s).strip()
+
+
+def _norm(s: str) -> str:
+    """Normalize text for matching (block alignment, comment anchoring)."""
+    return re.sub(r"\s+", " ", html.unescape(s)).strip().lower()
+
+
+def _align_key(block: str) -> str:
+    """Key for pairing blocks across revisions.
+
+    Cleans before normalizing so escape-only noise between exports
+    doesn't break pairing; the paired blocks' *final* equal-vs-replace
+    kind is decided from their cleaned display text in `_make_hunk`.
+    """
+    return _norm(clean_text(block))
+
+
+def load_blocks(text: str) -> list[str]:
+    """Split exported markdown into non-blank blocks.
+
+    The export emits one long line per paragraph. Drops blank lines,
+    ``[imageN]: ...`` definitions, and stray base64 ``data:image``
+    blob lines (prose that merely mentions data:image is kept).
+    """
+    blocks = []
+    for raw in text.splitlines():
+        if IMAGE_DEF_RE.match(raw) or raw.lstrip().startswith(
+            ("data:image", "<data:image"),
+        ):
+            continue
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        blocks.append(stripped)
+    return blocks
+
+
+def classify_block(block: str) -> str:
+    """Classify a raw markdown block: heading, listitem, or paragraph."""
+    if _HEADING.match(block):
+        return "heading"
+    if _LISTITEM.match(block):
+        return "listitem"
+    return "paragraph"
+
+
+def heading_level(block: str) -> int:
+    match = _HEADING.match(block)
+    return len(match.group(1)) if match else 2
+
+
+def strip_marker(block: str) -> str:
+    """Strip the leading markdown marker (#, bullet, or number)."""
+    block = re.sub(rf"^{_HEADING_MARK}\s+", "", block)
+    block = re.sub(rf"^\s*{_BULLET_MARK}\s+", "", block)
+    block = re.sub(rf"^\s*{_ORDERED_MARK}\s+", "", block)
+    return block
+
+
+def _list_marker(block: str) -> str:
+    """Display marker for a list item: the real ordinal, or •."""
+    match = re.match(rf"^\s*({_BULLET_MARK}|{_ORDERED_MARK})\s", block)
+    if match and match.group(1)[0].isdigit():
+        return clean_text(match.group(1))
+    return "•"
+
+
+def _block_structure(block: str) -> tuple:
+    """Structure key for same-text equality: type, level, list shape.
+
+    Distinguishes heading levels and bullet vs ordered lists, but not
+    the ordinal of an ordered item, so renumbering reads as equal.
+    (List nesting depth can't be tracked here: load_blocks strips
+    leading whitespace.)
+    """
+    block_type = classify_block(block)
+    if block_type == "heading":
+        return ("heading", heading_level(block))
+    if block_type == "listitem":
+        match = re.match(
+            rf"^\s*({_BULLET_MARK}|{_ORDERED_MARK})\s", block,
+        )
+        kind = (
+            "ordered" if match and match.group(1)[0].isdigit()
+            else "bullet"
+        )
+        return ("listitem", kind)
+    return ("paragraph",)
+
+
+# -------------------------------------------------------------- word diff
+
+def word_diff_runs(
+    old: str, new: str, min_common: int = DEFAULT_MIN_COMMON,
+) -> list[dict]:
+    """Word-level diff with island coalescing.
+
+    Plain word-level difflib clings to scraps ("the", "—") inside
+    rewritten sentences and produces unreadable salad. Shared runs
+    shorter than `min_common` stripped chars, flanked by changes on
+    both sides, are absorbed into the change; consecutive changed
+    segments then merge into one contiguous del + ins pair.
+    """
+    a = _TOKEN.findall(old)
+    b = _TOKEN.findall(new)
+    segments = [
+        [op, "".join(a[i1:i2]), "".join(b[j1:j2])]
+        for op, i1, i2, j1, j2 in difflib.SequenceMatcher(
+            a=a, b=b, autojunk=False,
+        ).get_opcodes()
+    ]
+    # Interior equal runs are flanked by changes on both sides by
+    # construction: get_opcodes never emits adjacent equal ops.
+    for k in range(1, len(segments) - 1):
+        if (
+            segments[k][0] == "equal"
+            and len(segments[k][1].strip()) < min_common
+        ):
+            segments[k][0] = "replace"
+
+    runs: list[dict] = []
+    i = 0
+    while i < len(segments):
+        if segments[i][0] == "equal":
+            runs.append({"op": "equal", "text": segments[i][1]})
+            i += 1
+            continue
+        deleted, inserted = [], []
+        while i < len(segments) and segments[i][0] != "equal":
+            op, old_text, new_text = segments[i]
+            if op in ("delete", "replace"):
+                deleted.append(old_text)
+            if op in ("insert", "replace"):
+                inserted.append(new_text)
+            i += 1
+        deleted_text = "".join(deleted)
+        inserted_text = "".join(inserted)
+        if deleted_text.strip():
+            runs.append({"op": "del", "text": deleted_text})
+        if inserted_text.strip():
+            runs.append({"op": "ins", "text": inserted_text})
+    return runs
+
+
+# ------------------------------------------------------------- diff model
+
+def _make_hunk(
+    kind: str,
+    old_block: str | None,
+    new_block: str | None,
+    min_common: int,
+) -> dict:
+    src = new_block if new_block is not None else old_block
+    block_type = classify_block(src)
+    old_text = (
+        clean_text(strip_marker(old_block)) if old_block is not None else ""
+    )
+    new_text = (
+        clean_text(strip_marker(new_block)) if new_block is not None else ""
+    )
+    hunk: dict = {"kind": kind, "block_type": block_type}
+    if block_type == "heading":
+        hunk["level"] = heading_level(src)
+    elif block_type == "listitem":
+        hunk["marker"] = _list_marker(src)
+    if kind == "equal":
+        hunk["runs"] = [{"op": "equal", "text": new_text}]
+    elif kind == "insert":
+        hunk["runs"] = [{"op": "ins", "text": new_text}]
+    elif kind == "delete":
+        hunk["runs"] = [{"op": "del", "text": old_text}]
+    else:
+        hunk["runs"] = word_diff_runs(old_text, new_text, min_common)
+    return hunk
+
+
+def _pair_hunks(old_block: str, new_block: str, min_common: int) -> list[dict]:
+    """Hunks for an aligned old/new block pair.
+
+    Alignment pairs blocks loosely (case-insensitive), so a pair can
+    arrive looking equal or changed either way; the final kind depends
+    on what a reader actually sees — the cleaned text plus the block
+    structure. A marker-only change (heading level, paragraph→bullet)
+    becomes delete+insert: a replace hunk would carry only equal runs
+    and render with no visible difference, and this way the old marker
+    is shown too. Ordered-list renumbering still reads as equal.
+    """
+    old_text = clean_text(strip_marker(old_block))
+    new_text = clean_text(strip_marker(new_block))
+    if old_text != new_text:
+        return [_make_hunk("replace", old_block, new_block, min_common)]
+    if _block_structure(old_block) == _block_structure(new_block):
+        return [_make_hunk("equal", old_block, new_block, min_common)]
+    return [
+        _make_hunk("delete", old_block, None, min_common),
+        _make_hunk("insert", None, new_block, min_common),
+    ]
+
+
+def build_hunks(
+    old_md: str, new_md: str, min_common: int = DEFAULT_MIN_COMMON,
+) -> list[dict]:
+    """Align blocks of two markdown exports and emit the hunk list."""
+    old_blocks = load_blocks(old_md)
+    new_blocks = load_blocks(new_md)
+    matcher = difflib.SequenceMatcher(
+        a=[_align_key(b) for b in old_blocks],
+        b=[_align_key(b) for b in new_blocks],
+        autojunk=False,
+    )
+    hunks: list[dict] = []
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == "equal":
+            for k in range(i2 - i1):
+                hunks.extend(_pair_hunks(
+                    old_blocks[i1 + k], new_blocks[j1 + k], min_common,
+                ))
+        elif op == "delete":
+            for k in range(i1, i2):
+                hunks.append(_make_hunk(
+                    "delete", old_blocks[k], None, min_common,
+                ))
+        elif op == "insert":
+            for k in range(j1, j2):
+                hunks.append(_make_hunk(
+                    "insert", None, new_blocks[k], min_common,
+                ))
+        else:
+            # replace: pair blocks positionally; extras become del/ins
+            old_chunk = old_blocks[i1:i2]
+            new_chunk = new_blocks[j1:j2]
+            for k in range(max(len(old_chunk), len(new_chunk))):
+                o = old_chunk[k] if k < len(old_chunk) else None
+                n = new_chunk[k] if k < len(new_chunk) else None
+                if o is not None and n is not None:
+                    hunks.extend(_pair_hunks(o, n, min_common))
+                elif o is not None:
+                    hunks.append(_make_hunk("delete", o, None, min_common))
+                else:
+                    hunks.append(_make_hunk("insert", None, n, min_common))
+    return hunks
+
+
+def hunk_changed(hunk: dict) -> bool:
+    return hunk["kind"] != "equal"
+
+
+def hunk_side_text(hunk: dict, side: str) -> str:
+    """Concatenate a hunk's old or new side text from its runs."""
+    ops = ("equal", "del") if side == "old" else ("equal", "ins")
+    return "".join(r["text"] for r in hunk["runs"] if r["op"] in ops)
+
+
+def build_diff_model(
+    doc_id: str,
+    doc_name: str,
+    old_rev: dict,
+    new_rev: dict,
+    old_md: str,
+    new_md: str,
+    min_common: int = DEFAULT_MIN_COMMON,
+) -> dict:
+    """Assemble the full diff model (sans comments)."""
+    return {
+        "doc": {"id": doc_id, "name": doc_name},
+        "old": {
+            "id": old_rev.get("id"),
+            "modifiedTime": old_rev.get("modifiedTime", ""),
+        },
+        "new": {
+            "id": new_rev.get("id"),
+            "modifiedTime": new_rev.get("modifiedTime", ""),
+        },
+        "hunks": build_hunks(old_md, new_md, min_common),
+    }
+
+
+# --------------------------------------------------------------- comments
+
+_ANCHOR_STOPWORDS = {"this"}
+_ANCHOR_KEY_LEN = 45
+_ANCHOR_MIN_LEN = 4
+
+
+def attach_comments(hunks: list[dict], comments: list[dict]) -> list[dict]:
+    """Anchor comment threads to hunks by quoted-snippet matching.
+
+    Best-effort: the API gives only the quoted snippet, not a position.
+    Prefers a *changed* hunk containing the snippet over the first
+    match (so a short anchor lands on the section under discussion,
+    not the first stray occurrence). Unmatched threads get hunk=None
+    and render as an appendix — they are never dropped.
+    """
+    # Sides matched separately: concatenating old + new would let a
+    # key false-match across the artificial junction of a replace hunk.
+    match_texts = [
+        (_norm(hunk_side_text(h, "old")), _norm(hunk_side_text(h, "new")))
+        for h in hunks
+    ]
+    model_comments = []
+    for c in sorted(comments, key=lambda c: c.get("createdTime", "")):
+        quoted = (c.get("quotedFileContent") or {}).get("value", "")
+        anchor = _norm(quoted)
+        key = anchor[:_ANCHOR_KEY_LEN]
+        target = None
+        if (
+            key
+            and len(anchor) >= _ANCHOR_MIN_LEN
+            and anchor not in _ANCHOR_STOPWORDS
+        ):
+            # Preference ladder: a changed hunk whose *new* side holds
+            # the anchor (the current content under discussion), then a
+            # changed hunk matching only its old side (quoted text that
+            # was deleted), then the first match anywhere. Matters for
+            # split delete+insert pairs, which share the same text.
+            old_changed = None
+            first_match = None
+            for idx, (old_side, new_side) in enumerate(match_texts):
+                in_new = key in new_side
+                if not in_new and key not in old_side:
+                    continue
+                if first_match is None:
+                    first_match = idx
+                if hunk_changed(hunks[idx]):
+                    if in_new:
+                        target = idx
+                        break
+                    if old_changed is None:
+                        old_changed = idx
+            if target is None:
+                target = (
+                    old_changed if old_changed is not None else first_match
+                )
+        replies = [
+            {
+                "author": (r.get("author") or {}).get("displayName", "?"),
+                "content": r.get("content", ""),
+                "createdTime": r.get("createdTime")
+                or r.get("modifiedTime", ""),
+            }
+            for r in c.get("replies", [])
+            if r.get("content")  # skip action-only replies
+        ]
+        model_comments.append({
+            "id": c.get("id", ""),
+            "author": (c.get("author") or {}).get("displayName", "?"),
+            "createdTime": c.get("createdTime", ""),
+            "resolved": c.get("resolved", False),
+            "content": clean_text(c.get("content", "")),
+            "quoted": clean_text(quoted),
+            "replies": replies,
+            "hunk": target,
+        })
+    return model_comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.10.2"
+version = "0.11.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [
     "google-api-python-client>=2.150.0",
     "google-auth-oauthlib>=1.2.1",
     "google-auth-httplib2>=0.2.0",
+    # Used directly via google.auth.transport.requests for revision
+    # exportLinks downloads; previously only a transitive dependency.
+    "requests>=2.28",
 ]
 
 [project.scripts]

--- a/tests/test_api_revisions.py
+++ b/tests/test_api_revisions.py
@@ -1,0 +1,84 @@
+"""Tests for the revisions API wrapper (exportLinks download path)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gdoc.api.revisions import _EXPORT_TIMEOUT, export_revision, list_revisions
+from gdoc.util import AuthError, GdocError
+
+LINKS = {
+    "text/markdown": "https://example.test/x.md",
+    "text/plain": "https://example.test/x.txt",
+}
+
+
+def _response(status=200, text="body"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+@patch("gdoc.api.revisions._get_session")
+class TestExportRevision:
+    def test_downloads_with_timeout(self, mock_session):
+        mock_session.return_value.get.return_value = _response()
+        content = export_revision("doc", "5", export_links=LINKS)
+        assert content == "body"
+        call = mock_session.return_value.get.call_args
+        assert call.args == (LINKS["text/markdown"],)
+        assert call.kwargs["timeout"] == _EXPORT_TIMEOUT
+
+    def test_403_is_permission_denied_not_auth(self, mock_session):
+        # The session auto-refreshes tokens, so a 403 means the export
+        # is denied, not that auth expired.
+        mock_session.return_value.get.return_value = _response(403)
+        with pytest.raises(GdocError, match="Permission denied") as exc_info:
+            export_revision("doc", "5", export_links=LINKS)
+        assert exc_info.value.exit_code == 1
+        assert not isinstance(exc_info.value, AuthError)
+
+    def test_401_is_auth_error(self, mock_session):
+        mock_session.return_value.get.return_value = _response(401)
+        with pytest.raises(AuthError):
+            export_revision("doc", "5", export_links=LINKS)
+
+    def test_404_is_pruned_error(self, mock_session):
+        mock_session.return_value.get.return_value = _response(404)
+        with pytest.raises(GdocError, match="pruned") as exc_info:
+            export_revision("doc", "5", export_links=LINKS)
+        assert exc_info.value.exit_code == 3
+
+    def test_plain_fallback_warns_on_stderr(self, mock_session, capsys):
+        mock_session.return_value.get.return_value = _response()
+        export_revision(
+            "doc", "5",
+            export_links={"text/plain": "https://example.test/x.txt"},
+        )
+        assert "falling back to text/plain" in capsys.readouterr().err
+
+    def test_no_warning_when_markdown_available(self, mock_session, capsys):
+        mock_session.return_value.get.return_value = _response()
+        export_revision("doc", "5", export_links=LINKS)
+        assert capsys.readouterr().err == ""
+
+
+@patch("gdoc.api.revisions.get_drive_service")
+class TestListRevisions:
+    def test_sorts_by_modified_time(self, mock_service):
+        # Drive documents no ordering guarantee; the selector grammar
+        # depends on oldest-first.
+        execute = (
+            mock_service.return_value.revisions.return_value
+            .list.return_value.execute
+        )
+        execute.return_value = {
+            "revisions": [
+                {"id": "9", "modifiedTime": "2026-06-10T00:00:00.000Z"},
+                {"id": "2", "modifiedTime": "2026-06-01T00:00:00.000Z"},
+                {"id": "5", "modifiedTime": "2026-06-05T00:00:00.000Z"},
+            ],
+        }
+        revisions = list_revisions("doc")
+        assert [r["id"] for r in revisions] == ["2", "5", "9"]

--- a/tests/test_cat_revision.py
+++ b/tests/test_cat_revision.py
@@ -1,0 +1,180 @@
+"""Tests for `gdoc cat --revision` and `gdoc pull --revision`."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gdoc.cli import cmd_cat, cmd_pull
+from gdoc.util import GdocError
+
+REVS = [
+    {
+        "id": "1", "modifiedTime": "2026-06-01T10:00:00.000Z",
+        "exportLinks": {"text/markdown": "https://example.test/1.md",
+                        "text/plain": "https://example.test/1.txt"},
+    },
+    {
+        "id": "20", "modifiedTime": "2026-06-08T10:00:00.000Z",
+        "exportLinks": {"text/markdown": "https://example.test/20.md",
+                        "text/plain": "https://example.test/20.txt"},
+    },
+    {
+        "id": "66", "modifiedTime": "2026-06-10T10:00:00.000Z",
+        "exportLinks": {"text/markdown": "https://example.test/66.md",
+                        "text/plain": "https://example.test/66.txt"},
+    },
+]
+
+
+def _cat_args(**overrides):
+    defaults = {
+        "command": "cat",
+        "doc": "abc123",
+        "comments": False,
+        "all": False,
+        "tab": None,
+        "all_tabs": False,
+        "max_bytes": 0,
+        "no_images": False,
+        "revision": None,
+        "plain": False,
+        "json": False,
+        "verbose": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _pull_args(**overrides):
+    defaults = {
+        "command": "pull",
+        "doc": "abc123",
+        "file": "/tmp/out.md",
+        "revision": None,
+        "plain": False,
+        "json": False,
+        "verbose": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _doc_mime(doc_mime):
+    """Keep spreadsheet detection on the Docs path for this module."""
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.revisions.export_revision", return_value="old content\n")
+@patch("gdoc.api.revisions.list_revisions", return_value=list(REVS))
+@patch("gdoc.notify.pre_flight", return_value=None)
+class TestCatRevision:
+    def test_exports_resolved_revision(
+        self, _pf, _list, mock_export, _update, capsys,
+    ):
+        rc = cmd_cat(_cat_args(revision="prev"))
+        assert rc == 0
+        assert capsys.readouterr().out == "old content\n"
+        mock_export.assert_called_once_with(
+            "abc123", "20", mime_type="text/markdown",
+            export_links=REVS[1]["exportLinks"],
+        )
+
+    def test_plain_uses_text_mime(self, _pf, _list, mock_export, _update):
+        cmd_cat(_cat_args(revision="66", plain=True))
+        assert mock_export.call_args.kwargs["mime_type"] == "text/plain"
+
+    def test_json_includes_revision_id(
+        self, _pf, _list, _export, _update, capsys,
+    ):
+        cmd_cat(_cat_args(revision="latest", json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["revision"] == "66"
+        assert data["content"] == "old content\n"
+
+    def test_state_does_not_advance_read_baseline(
+        self, _pf, _list, _export, mock_update,
+    ):
+        cmd_cat(_cat_args(revision="1"))
+        # command name must not be a read command (cat/info/pull), or
+        # update_state_after_command would advance last_read_version
+        assert mock_update.call_args.kwargs.get("command") == "cat-revision"
+
+    def test_revision_with_comments_rejected(
+        self, _pf, _list, _export, _update,
+    ):
+        with pytest.raises(GdocError, match="cannot be combined") as exc_info:
+            cmd_cat(_cat_args(revision="1", comments=True))
+        assert exc_info.value.exit_code == 3
+
+    def test_revision_with_tab_rejected(self, _pf, _list, _export, _update):
+        with pytest.raises(GdocError, match="cannot be combined") as exc_info:
+            cmd_cat(_cat_args(revision="1", tab="Notes"))
+        assert exc_info.value.exit_code == 3
+
+    def test_unknown_revision_errors(self, _pf, _list, _export, _update):
+        with pytest.raises(GdocError, match="revision not found") as exc_info:
+            cmd_cat(_cat_args(revision="999"))
+        assert exc_info.value.exit_code == 3
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch(
+    "gdoc.api.drive.get_file_info",
+    return_value={"name": "My Doc", "version": 42},
+)
+@patch("gdoc.api.revisions.export_revision", return_value="old body\n")
+@patch("gdoc.api.revisions.list_revisions", return_value=list(REVS))
+@patch("gdoc.notify.pre_flight", return_value=None)
+class TestPullRevision:
+    def test_writes_file_with_revision_frontmatter(
+        self, _pf, _list, _export, _info, _update, capsys, tmp_path,
+    ):
+        out = tmp_path / "old.md"
+        rc = cmd_pull(_pull_args(file=str(out), revision="head~1"))
+        assert rc == 0
+        content = out.read_text()
+        assert content.startswith("---\n")
+        assert "source: abc123" in content
+        assert "revision: 20" in content
+        assert "old body" in content
+        # No gdoc: key — push and the sync hooks must not pick this up
+        assert "\ngdoc:" not in content
+        assert "@ rev 20" in capsys.readouterr().out
+
+    def test_json_output(
+        self, _pf, _list, _export, _info, _update, capsys, tmp_path,
+    ):
+        out = tmp_path / "old.md"
+        cmd_pull(_pull_args(file=str(out), revision="latest", json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data["pulled"] is True
+        assert data["revision"] == "66"
+
+    def test_state_does_not_advance_read_baseline(
+        self, _pf, _list, _export, _info, mock_update, tmp_path,
+    ):
+        out = tmp_path / "old.md"
+        cmd_pull(_pull_args(file=str(out), revision="1"))
+        assert mock_update.call_args.kwargs.get("command") == "pull-revision"
+        assert mock_update.call_args.kwargs.get("command_version") is None
+
+    def test_default_pull_unchanged(
+        self, _pf, _list, mock_export, _info, mock_update, tmp_path,
+    ):
+        with patch(
+            "gdoc.api.drive.export_doc", return_value="current body\n",
+        ) as mock_doc_export:
+            out = tmp_path / "cur.md"
+            rc = cmd_pull(_pull_args(file=str(out)))
+            assert rc == 0
+            mock_doc_export.assert_called_once()
+        mock_export.assert_not_called()
+        content = out.read_text()
+        assert "gdoc: abc123" in content
+        assert mock_update.call_args.kwargs.get("command") == "pull"

--- a/tests/test_diff_rev_cmd.py
+++ b/tests/test_diff_rev_cmd.py
@@ -1,0 +1,281 @@
+"""Tests for the revision paths of `gdoc diff` (--rev / --since)."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gdoc.cli import cmd_diff
+from gdoc.util import GdocError
+
+REVS = [
+    {
+        "id": "1", "modifiedTime": "2026-06-01T10:00:00.000Z",
+        "exportLinks": {"text/markdown": "https://example.test/1.md"},
+    },
+    {
+        "id": "20", "modifiedTime": "2026-06-08T10:00:00.000Z",
+        "exportLinks": {"text/markdown": "https://example.test/20.md"},
+    },
+    {
+        "id": "66", "modifiedTime": "2026-06-10T10:00:00.000Z",
+        "exportLinks": {"text/markdown": "https://example.test/66.md"},
+    },
+]
+
+CONTENT = {
+    "1": "# Title\n\nThe original opening paragraph with several words.\n",
+    "20": "# Title\n\nThe revised opening paragraph with several words.\n",
+    "66": "# Title\n\nThe final opening paragraph with several words.\n",
+}
+
+
+def _export(doc_id, revision_id, mime_type="text/markdown",
+            export_links=None):
+    return CONTENT[revision_id]
+
+
+def _make_args(**overrides):
+    defaults = {
+        "command": "diff",
+        "doc": "abc123",
+        "file": None,
+        "rev": None,
+        "since": None,
+        "format": "auto",
+        "out": None,
+        "with_comments": False,
+        "min_common": 24,
+        "context": 2,
+        "plain": False,
+        "json": False,
+        "verbose": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _patches(func):
+    """Stack the standard mocks for revision-diff handler tests.
+
+    The first-applied patch is innermost, so mock args arrive in this
+    order: (pre_flight, list_revisions, export_revision, get_file_info,
+    update_state).
+    """
+    func = patch("gdoc.notify.pre_flight", return_value=None)(func)
+    func = patch(
+        "gdoc.api.revisions.list_revisions", return_value=list(REVS),
+    )(func)
+    func = patch(
+        "gdoc.api.revisions.export_revision", side_effect=_export,
+    )(func)
+    func = patch(
+        "gdoc.api.drive.get_file_info",
+        return_value={"name": "My Doc", "version": 42},
+    )(func)
+    func = patch("gdoc.state.update_state_after_command")(func)
+    return func
+
+
+class TestRevSelection:
+    @_patches
+    def test_rev_range_json_model(
+        self, _pf, _list, _export, _info, _update, capsys,
+    ):
+        rc = cmd_diff(_make_args(rev="1..20", json=True))
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["identical"] is False
+        assert data["doc"] == {"id": "abc123", "name": "My Doc"}
+        assert data["old"]["id"] == "1"
+        assert data["new"]["id"] == "20"
+        kinds = [h["kind"] for h in data["hunks"]]
+        assert "replace" in kinds
+        replace = next(h for h in data["hunks"] if h["kind"] == "replace")
+        assert {r["op"] for r in replace["runs"]} >= {"del", "ins"}
+        assert "comments" not in data
+
+    @_patches
+    def test_single_rev_diffs_against_latest(
+        self, _pf, _list, mock_export, _info, _update, capsys,
+    ):
+        rc = cmd_diff(_make_args(rev="1", json=True))
+        assert rc == 1
+        exported = [c.args[1] for c in mock_export.call_args_list]
+        assert exported == ["1", "66"]
+
+    @_patches
+    def test_since_resolves_old_revision(
+        self, _pf, _list, mock_export, _info, _update, capsys,
+    ):
+        rc = cmd_diff(_make_args(since="2026-06-09T00:00:00Z", json=True))
+        assert rc == 1
+        exported = [c.args[1] for c in mock_export.call_args_list]
+        assert exported == ["20", "66"]
+
+    @_patches
+    def test_identical_revisions_return_zero(
+        self, _pf, _list, _export, _info, _update, capsys,
+    ):
+        rc = cmd_diff(_make_args(rev="66..66"))
+        assert rc == 0
+        assert "OK identical" in capsys.readouterr().out
+
+
+class TestRevOutput:
+    @_patches
+    def test_plain_terminal_output(
+        self, _pf, _list, _export, _info, _update, capsys,
+    ):
+        rc = cmd_diff(_make_args(rev="1..20", format="plain"))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "[-original-]" in out
+        assert "{+revised+}" in out
+        assert "\x1b[" not in out
+
+    @_patches
+    def test_color_terminal_output(
+        self, _pf, _list, _export, _info, _update, capsys,
+    ):
+        rc = cmd_diff(_make_args(rev="1..20", format="color"))
+        assert rc == 1
+        assert "\x1b[32m" in capsys.readouterr().out
+
+    @_patches
+    def test_html_artifact(
+        self, _pf, _list, _export, _info, _update, capsys, tmp_path,
+    ):
+        out_path = tmp_path / "diff.html"
+        rc = cmd_diff(_make_args(rev="1..20", out=str(out_path)))
+        assert rc == 1
+        html = out_path.read_text()
+        assert "<ins>" in html
+        assert "My Doc" in html
+        assert f"OK wrote {out_path}" in capsys.readouterr().out
+
+    @_patches
+    def test_with_comments_in_json(
+        self, _pf, _list, _export, _info, _update, capsys,
+    ):
+        comments = [{
+            "id": "c1", "author": {"displayName": "Alice"},
+            "createdTime": "2026-06-09T00:00:00Z", "resolved": False,
+            "content": "note",
+            "quotedFileContent": {"value": "opening paragraph"},
+            "replies": [],
+        }]
+        with patch(
+            "gdoc.api.comments.list_comments", return_value=comments,
+        ) as mock_comments:
+            rc = cmd_diff(_make_args(rev="1..20", json=True,
+                                     with_comments=True))
+            assert rc == 1
+            mock_comments.assert_called_once_with(
+                "abc123", include_anchor=True,
+            )
+        data = json.loads(capsys.readouterr().out)
+        assert len(data["comments"]) == 1
+        assert data["comments"][0]["author"] == "Alice"
+        assert data["comments"][0]["hunk"] is not None
+
+    @_patches
+    def test_state_updated_with_version(
+        self, _pf, _list, _export, _info, mock_update, capsys,
+    ):
+        # The version comes from get_file_info's metadata — no extra
+        # get_file_version round trip.
+        cmd_diff(_make_args(rev="1..20", json=True))
+        mock_update.assert_called_once_with(
+            "abc123", None, command="diff", quiet=False,
+            command_version=42,
+        )
+
+    @_patches
+    def test_json_confirmation_for_artifact(
+        self, _pf, _list, _export, _info, _update, capsys, tmp_path,
+    ):
+        # --json with an artifact write prints a machine confirmation
+        out_path = tmp_path / "diff.html"
+        rc = cmd_diff(_make_args(rev="1..20", json=True, out=str(out_path)))
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["path"] == str(out_path)
+        assert data["format"] == "html"
+        assert data["changed"] >= 1
+        assert data["identical"] is False
+        assert out_path.exists()
+
+    @_patches
+    def test_artifact_write_error_exits_3(
+        self, _pf, _list, _export, _info, _update, tmp_path,
+    ):
+        out_path = tmp_path / "no-such-dir" / "diff.html"
+        with pytest.raises(GdocError, match="cannot write file") as exc_info:
+            cmd_diff(_make_args(rev="1..20", out=str(out_path)))
+        assert exc_info.value.exit_code == 3
+
+
+class TestRevValidation:
+    def test_rev_and_since_conflict(self):
+        with pytest.raises(GdocError, match="mutually exclusive") as exc_info:
+            cmd_diff(_make_args(rev="1..20", since="2026-06-09"))
+        assert exc_info.value.exit_code == 3
+
+    def test_file_and_rev_conflict(self):
+        with pytest.raises(GdocError, match="mutually exclusive") as exc_info:
+            cmd_diff(_make_args(file="/tmp/x.md", rev="1..20"))
+        assert exc_info.value.exit_code == 3
+
+    def test_no_file_no_rev(self):
+        with pytest.raises(GdocError, match="nothing to compare") as exc_info:
+            cmd_diff(_make_args())
+        assert exc_info.value.exit_code == 3
+
+    def test_format_with_file_diff_rejected(self):
+        with pytest.raises(GdocError, match="revision diffs") as exc_info:
+            cmd_diff(_make_args(file="/tmp/x.md", format="html"))
+        assert exc_info.value.exit_code == 3
+
+    def test_out_with_unknown_extension(self):
+        with pytest.raises(GdocError, match="cannot infer format") as exc_info:
+            cmd_diff(_make_args(rev="1..20", out="diff.pdf"))
+        assert exc_info.value.exit_code == 3
+
+    def test_out_with_terminal_format(self):
+        with pytest.raises(GdocError, match="--out requires") as exc_info:
+            cmd_diff(_make_args(rev="1..20", format="color", out="x.html"))
+        assert exc_info.value.exit_code == 3
+
+    def test_json_flag_with_terminal_format(self):
+        with pytest.raises(GdocError, match="mutually exclusive") as exc_info:
+            cmd_diff(_make_args(rev="1..20", json=True, format="color"))
+        assert exc_info.value.exit_code == 3
+
+    def test_plain_flag_with_color_format(self):
+        with pytest.raises(GdocError, match="mutually exclusive") as exc_info:
+            cmd_diff(_make_args(rev="1..20", plain=True, format="color"))
+        assert exc_info.value.exit_code == 3
+
+    def test_with_comments_requires_rich_format(self):
+        with pytest.raises(
+            GdocError, match="--with-comments requires",
+        ) as exc_info:
+            cmd_diff(_make_args(rev="1..20", format="plain",
+                                with_comments=True))
+        assert exc_info.value.exit_code == 3
+
+    def test_invalid_range_fails_before_api_calls(self):
+        # No mocks: selector syntax must be validated before pre-flight
+        with pytest.raises(GdocError, match="invalid revision range") as exc_info:
+            cmd_diff(_make_args(rev="1..", json=True))
+        assert exc_info.value.exit_code == 3
+
+    def test_invalid_since_fails_before_api_calls(self):
+        with pytest.raises(GdocError, match="invalid timestamp") as exc_info:
+            cmd_diff(_make_args(since="not-a-date"))
+        assert exc_info.value.exit_code == 3

--- a/tests/test_diffrender.py
+++ b/tests/test_diffrender.py
@@ -1,0 +1,153 @@
+"""Tests for the terminal and HTML revision-diff renderers."""
+
+from gdoc.diffrender import (
+    render_html,
+    render_terminal,
+    select_visible,
+    split_comments,
+)
+from gdoc.revdiff import attach_comments, build_diff_model, build_hunks
+
+OLD_REV = {"id": "69", "modifiedTime": "2026-06-01T10:00:00.000Z"}
+NEW_REV = {"id": "190", "modifiedTime": "2026-06-10T19:23:00.000Z"}
+
+
+def _model(old_md, new_md, comments=None):
+    model = build_diff_model(
+        "doc1", "Test Doc", OLD_REV, NEW_REV, old_md, new_md,
+    )
+    if comments is not None:
+        model["comments"] = attach_comments(model["hunks"], comments)
+    return model
+
+
+def _paragraphs(n, prefix="Unchanged paragraph"):
+    return "\n\n".join(f"{prefix} number {i}." for i in range(n)) + "\n"
+
+
+class TestSelectVisible:
+    def test_context_window_around_change(self):
+        old = _paragraphs(7)
+        new = old.replace("number 3.", "number three, fully rewritten.")
+        hunks = build_hunks(old, new)
+        keep = select_visible(hunks, context=1)
+        assert keep == [False, False, True, True, True, False, False]
+
+    def test_headings_always_kept(self):
+        old = "# Section\n\n" + _paragraphs(7)
+        new = old.replace("number 6.", "number six, fully rewritten.")
+        hunks = build_hunks(old, new)
+        keep = select_visible(hunks, context=1)
+        assert keep[0] is True  # heading far from the change
+
+    def test_commented_hunks_kept(self):
+        hunks = build_hunks(_paragraphs(7), _paragraphs(7))
+        keep = select_visible(hunks, context=0, comment_hunks={4})
+        assert keep[4] is True
+        assert keep[1] is False
+
+
+class TestSplitComments:
+    def test_split(self):
+        by_hunk, appendix = split_comments([
+            {"id": "a", "hunk": 2}, {"id": "b", "hunk": None},
+            {"id": "c", "hunk": 2},
+        ])
+        assert [c["id"] for c in by_hunk[2]] == ["a", "c"]
+        assert [c["id"] for c in appendix] == ["b"]
+
+
+class TestRenderTerminal:
+    def test_plain_uses_word_diff_markers(self):
+        old = "The plan is to ship the feature next week to customers.\n"
+        new = "The plan is to deliver the product next month to customers.\n"
+        out = render_terminal(_model(old, new), color=False)
+        assert "[-" in out and "-]" in out
+        assert "{+" in out and "+}" in out
+        assert "\x1b[" not in out
+
+    def test_plain_collapses_unchanged(self):
+        old = _paragraphs(9)
+        new = old.replace("number 0.", "number zero, fully rewritten.")
+        out = render_terminal(_model(old, new), color=False, context=1)
+        assert "unchanged ⋯" in out
+
+    def test_color_uses_ansi(self):
+        old = "Alpha original sentence with plenty of words.\n"
+        new = "Alpha rewritten sentence with plenty of words.\n"
+        out = render_terminal(_model(old, new), color=True)
+        assert "\x1b[32m" in out  # green insert
+        assert "\x1b[31;9m" in out  # red strikethrough delete
+
+    def test_header_names_revisions(self):
+        out = render_terminal(_model("a b c\n", "a b d\n"), color=False)
+        assert "rev 69" in out and "rev 190" in out
+        assert "Test Doc" in out
+
+    def test_heading_prefix_preserved(self):
+        out = render_terminal(
+            _model("## Section title here\n", "## Section title here\n"),
+            color=False,
+        )
+        assert "## Section title here" in out
+
+    def test_list_markers_shown(self):
+        # Ordered items keep their ordinal; a bullet→numbered switch
+        # shows both forms
+        out = render_terminal(
+            _model(
+                "- The same item text here.\n",
+                "1\\. The same item text here.\n",
+            ),
+            color=False,
+        )
+        assert "• [-The same item text here.-]" in out
+        assert "1. {+The same item text here.+}" in out
+
+
+class TestRenderHtml:
+    def test_ins_del_tags(self):
+        old = "The plan is to ship the feature next week to customers.\n"
+        new = "The plan is to deliver the product next month to customers.\n"
+        html = render_html(_model(old, new))
+        assert "<ins>" in html and "<del>" in html
+
+    def test_escapes_content(self):
+        html = render_html(_model(
+            "Safe paragraph.\n", "<script>alert(1)</script> injected.\n",
+        ))
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_comments_inline_and_appendix(self):
+        old = "Stable opening paragraph.\n\nThe rollout plan needs work.\n"
+        new = "Stable opening paragraph.\n\nThe rollout plan is finished.\n"
+        comments = [
+            {
+                "id": "c1", "author": {"displayName": "Alice"},
+                "createdTime": "2026-06-09T00:00:00Z", "resolved": False,
+                "content": "Looks good now",
+                "quotedFileContent": {"value": "rollout plan"},
+                "replies": [{
+                    "author": {"displayName": "Bob"},
+                    "content": "Agreed", "createdTime": "2026-06-09T01:00:00Z",
+                }],
+            },
+            {
+                "id": "c2", "author": {"displayName": "Carol"},
+                "createdTime": "2026-06-09T02:00:00Z", "resolved": True,
+                "content": "Anchored to vanished text",
+                "quotedFileContent": {"value": "completely absent anchor"},
+                "replies": [],
+            },
+        ]
+        html = render_html(_model(old, new, comments))
+        assert "Alice" in html and "Agreed" in html
+        assert "Other comment threads" in html
+        assert "Carol" in html
+        assert "(resolved)" in html
+
+    def test_self_contained_document(self):
+        html = render_html(_model("a b c\n", "a b c\n"))
+        assert html.startswith("<!doctype html>")
+        assert "<style>" in html

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,5 +1,7 @@
 """Tests for the frontmatter parser."""
 
+import pytest
+
 from gdoc.frontmatter import add_frontmatter, parse_frontmatter
 
 
@@ -108,6 +110,29 @@ class TestAddFrontmatter:
     def test_empty_metadata(self):
         result = add_frontmatter("Body", {})
         assert result == "---\n---\nBody"
+
+    def test_newlines_in_values_flattened(self):
+        # A newline in a value (e.g. a doc title) must not be able to
+        # inject extra frontmatter keys like `gdoc:`.
+        result = add_frontmatter(
+            "Body", {"title": "Line one\ngdoc: evil-id"},
+        )
+        metadata, _ = parse_frontmatter(result)
+        assert "gdoc" not in metadata
+        assert metadata["title"] == "Line one gdoc: evil-id"
+
+    @pytest.mark.parametrize(
+        "sep",
+        ["\n", "\r\n", "\r", "\x0b", "\x0c", "\x85", "\u2028", "\u2029"],
+    )
+    def test_every_line_separator_flattened(self, sep):
+        # parse_frontmatter uses splitlines(), so every separator it
+        # honors must be neutralized on write, not just \r and \n
+        result = add_frontmatter(
+            "Body", {"title": f"Line one{sep}gdoc: evil-id"},
+        )
+        metadata, _ = parse_frontmatter(result)
+        assert "gdoc" not in metadata
 
     def test_roundtrip(self):
         original_body = "# Document\n\nContent here.\n"

--- a/tests/test_mdimport.py
+++ b/tests/test_mdimport.py
@@ -1,8 +1,5 @@
 """Tests for markdown image extraction."""
 
-import os
-from unittest.mock import patch
-
 import pytest
 
 from gdoc.mdimport import extract_images, strip_images
@@ -135,3 +132,17 @@ class TestStripImages:
         url = "https://lh7-us.googleusercontent.com/docs/ABC123_very_long_token_here"
         content = f"Before\n\n![screenshot]({url})\n\nAfter"
         assert strip_images(content) == "Before\n\nAfter"
+
+    def test_strips_reference_style_refs_and_defs(self):
+        # The Drive markdown export emits reference-style images
+        content = (
+            "Intro ![][image1] text\n"
+            "\n"
+            "[image1]: <data:image/png;base64,AAAA>\n"
+            "\n"
+            "After\n"
+        )
+        result = strip_images(content)
+        assert "![][image1]" not in result
+        assert "[image1]:" not in result
+        assert "Intro" in result and "After" in result

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -327,6 +327,16 @@ class TestPushErrors:
             cmd_push(args)
         assert exc.value.exit_code == 3
 
+    def test_revision_pull_file_rejected_specifically(self, tmp_path):
+        f = tmp_path / "old.md"
+        f.write_text(
+            "---\nsource: abc123\nrevision: 20\ntitle: Foo\n---\nBody"
+        )
+        args = _make_args(file=str(f))
+        with pytest.raises(GdocError, match="past revision") as exc:
+            cmd_push(args)
+        assert exc.value.exit_code == 3
+
     def test_invalid_doc_id_in_frontmatter(self, tmp_path):
         f = tmp_path / "test.md"
         f.write_text("---\ngdoc: !!invalid!!\n---\nBody")

--- a/tests/test_revdiff.py
+++ b/tests/test_revdiff.py
@@ -1,0 +1,381 @@
+"""Tests for the revision-diff engine and REV selector grammar."""
+
+import pytest
+
+from gdoc.revdiff import (
+    attach_comments,
+    build_hunks,
+    classify_block,
+    clean_text,
+    heading_level,
+    load_blocks,
+    parse_rev_range,
+    resolve_at_timestamp,
+    resolve_selector,
+    strip_marker,
+    word_diff_runs,
+)
+from gdoc.util import GdocError
+
+# Sparse ids on purpose: selectors must count by list position,
+# never by id arithmetic.
+REVS = [
+    {"id": "1", "modifiedTime": "2026-06-01T10:00:00.000Z"},
+    {"id": "3", "modifiedTime": "2026-06-03T10:00:00.000Z"},
+    {"id": "7", "modifiedTime": "2026-06-05T10:00:00.000Z"},
+    {"id": "20", "modifiedTime": "2026-06-08T10:00:00.000Z"},
+    {"id": "66", "modifiedTime": "2026-06-10T10:00:00.000Z"},
+]
+
+
+class TestSelectors:
+    def test_bare_id(self):
+        assert resolve_selector(REVS, "7")["id"] == "7"
+
+    @pytest.mark.parametrize("sel", ["latest", "head", "HEAD", "Latest"])
+    def test_latest_aliases(self, sel):
+        assert resolve_selector(REVS, sel)["id"] == "66"
+
+    def test_prev(self):
+        assert resolve_selector(REVS, "prev")["id"] == "20"
+
+    def test_prev_out_of_range_names_prev(self):
+        single = [{"id": "5", "modifiedTime": "2026-06-01T10:00:00.000Z"}]
+        with pytest.raises(GdocError, match="prev is out of range"):
+            resolve_selector(single, "prev")
+
+    def test_head_n_counts_by_position_not_id(self):
+        assert resolve_selector(REVS, "head~2")["id"] == "7"
+        assert resolve_selector(REVS, "latest~4")["id"] == "1"
+
+    def test_head_n_out_of_range(self):
+        with pytest.raises(GdocError, match="out of range") as exc_info:
+            resolve_selector(REVS, "head~5")
+        assert exc_info.value.exit_code == 3
+
+    def test_unknown_id_points_at_revisions(self):
+        with pytest.raises(GdocError, match="gdoc revisions") as exc_info:
+            resolve_selector(REVS, "999")
+        assert exc_info.value.exit_code == 3
+
+    def test_empty_revision_list(self):
+        with pytest.raises(GdocError, match="no revisions") as exc_info:
+            resolve_selector([], "latest")
+        assert exc_info.value.exit_code == 3
+
+    def test_at_timestamp_inclusive_boundary(self):
+        assert resolve_selector(REVS, "@2026-06-05T10:00:00Z")["id"] == "7"
+
+    def test_at_timestamp_between_revisions(self):
+        assert resolve_selector(REVS, "@2026-06-06T00:00:00Z")["id"] == "7"
+
+    def test_at_date_only(self):
+        # Naive dates are local time; 2026-06-04 falls between revs 3
+        # and 7 in every timezone.
+        assert resolve_selector(REVS, "@2026-06-04")["id"] == "3"
+
+    def test_at_before_earliest(self):
+        with pytest.raises(GdocError, match="no revision at/before") as exc_info:
+            resolve_selector(REVS, "@2026-05-01T00:00:00Z")
+        assert exc_info.value.exit_code == 3
+
+    def test_at_invalid_timestamp(self):
+        with pytest.raises(GdocError, match="invalid timestamp") as exc_info:
+            resolve_selector(REVS, "@yesterday")
+        assert exc_info.value.exit_code == 3
+
+    def test_since_uses_same_resolver(self):
+        assert resolve_at_timestamp(REVS, "2026-06-09T00:00:00Z")["id"] == "20"
+
+
+class TestRevRange:
+    def test_range(self):
+        assert parse_rev_range("1..3") == ("1", "3")
+
+    def test_range_with_selectors(self):
+        assert parse_rev_range("head~1..head") == ("head~1", "head")
+
+    def test_single_defaults_to_latest(self):
+        assert parse_rev_range("7") == ("7", "latest")
+
+    @pytest.mark.parametrize("bad", ["..3", "1..", ".."])
+    def test_half_open_range_rejected(self, bad):
+        with pytest.raises(GdocError, match="invalid revision range") as exc_info:
+            parse_rev_range(bad)
+        assert exc_info.value.exit_code == 3
+
+
+class TestCleanText:
+    def test_de_escapes_punctuation(self):
+        assert clean_text(r"\#5 and \~tilde\~ and \=eq") == "#5 and ~tilde~ and =eq"
+
+    def test_de_escapes_double_escapes(self):
+        assert clean_text(r"\\> nested") == "nested"
+
+    def test_strips_leading_blockquote(self):
+        assert clean_text("> quoted text") == "quoted text"
+
+    def test_unescapes_html_entities(self):
+        assert clean_text("a &amp; b") == "a & b"
+
+    def test_replaces_image_refs_with_placeholder(self):
+        assert clean_text("before ![][image3] after") == "before ⟦diagram⟧ after"
+
+    def test_collapses_whitespace_and_nbsp(self):
+        assert clean_text("a  b\t\tc") == "a b c"
+
+
+class TestLoadBlocks:
+    def test_drops_blanks_and_image_noise(self):
+        text = (
+            "# Title\n"
+            "\n"
+            "A paragraph.\n"
+            "\n"
+            "[image1]: <data:image/png;base64,AAAA>\n"
+            "data:image/png;base64,BBBB\n"
+            "Last.\n"
+        )
+        assert load_blocks(text) == ["# Title", "A paragraph.", "Last."]
+
+    def test_prose_mentioning_data_image_is_kept(self):
+        text = "A paragraph about data:image URIs in HTML.\n"
+        assert load_blocks(text) == [
+            "A paragraph about data:image URIs in HTML.",
+        ]
+
+
+class TestBlockClassification:
+    def test_heading(self):
+        assert classify_block("## Head") == "heading"
+        assert heading_level("### Deep") == 3
+        assert strip_marker("## Head") == "Head"
+
+    @pytest.mark.parametrize(
+        "block", ["- item", "* item", r"\- item", "1. item", "2) item"],
+    )
+    def test_listitem(self, block):
+        assert classify_block(block) == "listitem"
+        assert strip_marker(block) == "item"
+
+    def test_paragraph(self):
+        assert classify_block("Just text.") == "paragraph"
+
+
+OLD_SENTENCE = "We should ship the feature next week because the team is ready."
+NEW_SENTENCE = (
+    "We could possibly deliver the product next month since the group "
+    "seems ready."
+)
+
+
+class TestWordDiffCoalescing:
+    def test_rewritten_sentence_is_one_chunk_not_salad(self):
+        runs = word_diff_runs(OLD_SENTENCE, NEW_SENTENCE, min_common=24)
+        assert sum(1 for r in runs if r["op"] == "del") == 1
+        assert sum(1 for r in runs if r["op"] == "ins") == 1
+
+    def test_min_common_zero_keeps_shared_scraps(self):
+        runs = word_diff_runs(OLD_SENTENCE, NEW_SENTENCE, min_common=0)
+        assert sum(1 for r in runs if r["op"] == "del") > 1
+
+    def test_flanking_equal_runs_survive(self):
+        runs = word_diff_runs(OLD_SENTENCE, NEW_SENTENCE, min_common=24)
+        assert runs[0] == {"op": "equal", "text": "We "}
+        assert runs[-1]["op"] == "equal"
+        assert "ready." in runs[-1]["text"]
+
+    def test_identical_text_is_single_equal_run(self):
+        runs = word_diff_runs("same text", "same text")
+        assert runs == [{"op": "equal", "text": "same text"}]
+
+
+class TestBuildHunks:
+    def test_kinds(self):
+        old = "# Title\n\nKeep me.\n\nDelete me entirely.\n"
+        new = (
+            "# Title\n\nKeep me.\n\n"
+            "Brand new paragraph instead, fully different.\n\n"
+            "Appended paragraph.\n"
+        )
+        hunks = build_hunks(old, new)
+        assert [h["kind"] for h in hunks] == [
+            "equal", "equal", "replace", "insert",
+        ]
+
+    def test_heading_level_recorded(self):
+        hunks = build_hunks("## Old heading text here\n", "## New heading text here\n")
+        assert hunks[0]["block_type"] == "heading"
+        assert hunks[0]["level"] == 2
+
+    def test_replace_extras_become_delete(self):
+        old = "First old paragraph with words.\n\nSecond old paragraph with words.\n"
+        new = "Completely rewritten single paragraph.\n"
+        hunks = build_hunks(old, new)
+        assert [h["kind"] for h in hunks] == ["replace", "delete"]
+
+    def test_runs_use_cleaned_text(self):
+        hunks = build_hunks("\\# not a heading\n", "")
+        assert hunks[0]["kind"] == "delete"
+        assert hunks[0]["block_type"] == "paragraph"
+        assert hunks[0]["runs"][0]["text"] == "# not a heading"
+
+    def test_case_only_change_is_a_real_diff(self):
+        # Alignment is case-insensitive, but the final kind must come
+        # from the text a reader actually sees.
+        hunks = build_hunks(
+            "Hello World, this sentence stays put.\n",
+            "hello world, this sentence stays put.\n",
+        )
+        assert [h["kind"] for h in hunks] == ["replace"]
+
+    def test_escape_only_difference_is_equal(self):
+        hunks = build_hunks(
+            "A sentence \\- with escaped punctuation.\n",
+            "A sentence - with escaped punctuation.\n",
+        )
+        assert [h["kind"] for h in hunks] == ["equal"]
+
+    def test_heading_level_change_is_a_diff(self):
+        # delete+insert, not replace: a replace hunk here would carry
+        # only equal runs and render invisibly, and the old marker
+        # would never be shown
+        hunks = build_hunks(
+            "## Same heading text here\n", "### Same heading text here\n",
+        )
+        assert [h["kind"] for h in hunks] == ["delete", "insert"]
+        assert [h["level"] for h in hunks] == [2, 3]
+
+    def test_paragraph_to_bullet_is_a_diff(self):
+        hunks = build_hunks(
+            "The same sentence either way.\n",
+            "- The same sentence either way.\n",
+        )
+        assert [h["kind"] for h in hunks] == ["delete", "insert"]
+        assert [h["block_type"] for h in hunks] == ["paragraph", "listitem"]
+
+    def test_ordered_list_renumbering_stays_equal(self):
+        hunks = build_hunks(
+            "2\\. The same item text here.\n",
+            "3\\. The same item text here.\n",
+        )
+        assert [h["kind"] for h in hunks] == ["equal"]
+
+    def test_bullet_to_ordered_is_a_diff(self):
+        hunks = build_hunks(
+            "- The same item text here.\n",
+            "1\\. The same item text here.\n",
+        )
+        assert [h["kind"] for h in hunks] == ["delete", "insert"]
+        # markers carried so renderers can show what changed
+        assert [h["marker"] for h in hunks] == ["•", "1."]
+
+    def test_listitem_marker_recorded(self):
+        hunks = build_hunks(
+            "2\\. An ordered item with text.\n\n"
+            "- A bulleted item with text.\n",
+            "",
+        )
+        assert [h.get("marker") for h in hunks] == ["2.", "•"]
+
+
+def _comment(cid, quoted, content="note", author="Alice",
+             created="2026-06-09T00:00:00Z"):
+    return {
+        "id": cid,
+        "author": {"displayName": author},
+        "createdTime": created,
+        "resolved": False,
+        "content": content,
+        "quotedFileContent": {"value": quoted},
+        "replies": [],
+    }
+
+
+class TestAttachComments:
+    def test_prefers_changed_hunk_over_first_match(self):
+        old = (
+            "Mention of Conor in the stable intro paragraph here.\n\n"
+            "Conor will handle the rollout plan.\n"
+        )
+        new = (
+            "Mention of Conor in the stable intro paragraph here.\n\n"
+            "Conor will handle the rollout plan and the budget.\n"
+        )
+        hunks = build_hunks(old, new)
+        [comment] = attach_comments(hunks, [_comment("c1", "Conor")])
+        assert comment["hunk"] == 1
+        assert hunks[1]["kind"] == "replace"
+
+    def test_first_match_when_nothing_changed_matches(self):
+        text = "Alpha text.\n\nBeta text.\n"
+        hunks = build_hunks(text, text)
+        [comment] = attach_comments(hunks, [_comment("c1", "Beta")])
+        assert comment["hunk"] == 1
+
+    def test_unmatched_goes_to_appendix(self):
+        hunks = build_hunks("Some text.\n", "Some text.\n")
+        [comment] = attach_comments(hunks, [_comment("c1", "no such anchor")])
+        assert comment["hunk"] is None
+
+    def test_split_marker_pair_anchors_to_current_side(self):
+        # A marker-only change is a delete+insert pair with identical
+        # text; the comment belongs on the current (insert) side
+        hunks = build_hunks(
+            "## Same heading text here\n", "### Same heading text here\n",
+        )
+        [comment] = attach_comments(
+            hunks, [_comment("c1", "Same heading text here")],
+        )
+        assert hunks[comment["hunk"]]["kind"] == "insert"
+
+    def test_deleted_text_anchors_to_delete_hunk(self):
+        old = "Stable paragraph one.\n\nGone forever sentence here.\n"
+        new = "Stable paragraph one.\n"
+        hunks = build_hunks(old, new)
+        [comment] = attach_comments(
+            hunks, [_comment("c1", "Gone forever sentence")],
+        )
+        assert hunks[comment["hunk"]]["kind"] == "delete"
+
+    def test_no_match_across_replace_junction(self):
+        # The anchor spans the end of the old side and the start of the
+        # new side; neither side alone contains it.
+        hunk = {
+            "kind": "replace", "block_type": "paragraph",
+            "runs": [
+                {"op": "del", "text": "the draft ends with alpha"},
+                {"op": "ins", "text": "beta begins the new text"},
+            ],
+        }
+        [comment] = attach_comments([hunk], [_comment("c1", "alpha beta")])
+        assert comment["hunk"] is None
+
+    def test_short_anchor_not_matched(self):
+        hunks = build_hunks("It is ok here.\n", "It is ok here.\n")
+        [comment] = attach_comments(hunks, [_comment("c1", "ok")])
+        assert comment["hunk"] is None
+
+    def test_stopword_anchor_not_matched(self):
+        hunks = build_hunks("this is fine.\n", "this is fine.\n")
+        [comment] = attach_comments(hunks, [_comment("c1", "this")])
+        assert comment["hunk"] is None
+
+    def test_action_only_replies_dropped(self):
+        hunks = build_hunks("Anchor text here.\n", "Anchor text here.\n")
+        raw = _comment("c1", "Anchor text")
+        raw["replies"] = [
+            {"author": {"displayName": "Bob"}, "content": "", "action": "resolve"},
+            {"author": {"displayName": "Eve"}, "content": "real reply",
+             "createdTime": "2026-06-09T01:00:00Z"},
+        ]
+        [comment] = attach_comments(hunks, [raw])
+        assert [r["author"] for r in comment["replies"]] == ["Eve"]
+
+    def test_sorted_by_created_time(self):
+        hunks = build_hunks("Anchor text here.\n", "Anchor text here.\n")
+        comments = attach_comments(hunks, [
+            _comment("newer", "Anchor", created="2026-06-10T00:00:00Z"),
+            _comment("older", "Anchor", created="2026-06-01T00:00:00Z"),
+        ])
+        assert [c["id"] for c in comments] == ["older", "newer"]

--- a/tests/test_revdiff.py
+++ b/tests/test_revdiff.py
@@ -122,7 +122,7 @@ class TestCleanText:
         assert clean_text("before ![][image3] after") == "before ⟦diagram⟧ after"
 
     def test_collapses_whitespace_and_nbsp(self):
-        assert clean_text("a  b\t\tc") == "a b c"
+        assert clean_text("a\u00a0 b\t\tc") == "a b c"
 
 
 class TestLoadBlocks:

--- a/tests/test_revisions_cmd.py
+++ b/tests/test_revisions_cmd.py
@@ -1,0 +1,109 @@
+"""Tests for the `gdoc revisions` command handler."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gdoc.cli import cmd_revisions
+
+REVS = [
+    {
+        "id": "1", "modifiedTime": "2026-06-01T10:00:00.000Z",
+        "lastModifyingUser": {"displayName": "Alice"},
+        "keepForever": False,
+        "exportLinks": {"text/markdown": "https://example.test/1"},
+    },
+    {
+        "id": "7", "modifiedTime": "2026-06-05T10:00:00.000Z",
+        "lastModifyingUser": {"displayName": "Bob"},
+        "keepForever": True,
+        "exportLinks": {"text/markdown": "https://example.test/7"},
+    },
+    {
+        "id": "66", "modifiedTime": "2026-06-10T10:00:00.000Z",
+        "lastModifyingUser": {"displayName": "Alice"},
+        "keepForever": False,
+        "exportLinks": {"text/markdown": "https://example.test/66"},
+    },
+]
+
+
+def _make_args(**overrides):
+    defaults = {
+        "command": "revisions",
+        "doc": "abc123",
+        "limit": 0,
+        "plain": False,
+        "json": False,
+        "verbose": False,
+        "quiet": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.revisions.list_revisions", return_value=list(REVS))
+@patch("gdoc.notify.pre_flight", return_value=None)
+class TestRevisionsOutput:
+    def test_terse_table(self, _pf, _list, _update, capsys):
+        rc = cmd_revisions(_make_args())
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = out.strip().splitlines()
+        assert len(lines) == 3
+        assert "Alice" in lines[0]
+        assert "[keep]" in lines[1]
+        assert "[keep]" not in lines[0]
+
+    def test_json(self, _pf, _list, _update, capsys):
+        rc = cmd_revisions(_make_args(json=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert [r["id"] for r in data["revisions"]] == ["1", "7", "66"]
+        assert data["revisions"][1]["keepForever"] is True
+        assert data["revisions"][0]["lastModifyingUser"]["displayName"] == "Alice"
+        assert "exportLinks" in data["revisions"][0]
+
+    def test_plain_tsv(self, _pf, _list, _update, capsys):
+        rc = cmd_revisions(_make_args(plain=True))
+        assert rc == 0
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert lines[0] == "1\t2026-06-01T10:00:00.000Z\tAlice\tfalse"
+        assert lines[1] == "7\t2026-06-05T10:00:00.000Z\tBob\ttrue"
+
+    def test_limit_keeps_most_recent(self, _pf, _list, _update, capsys):
+        rc = cmd_revisions(_make_args(json=True, limit=2))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert [r["id"] for r in data["revisions"]] == ["7", "66"]
+
+    def test_verbose_shows_full_timestamps(self, _pf, _list, _update, capsys):
+        rc = cmd_revisions(_make_args(verbose=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "2026-06-05T10:00:00.000Z" in out
+        assert "(3 revisions" in out
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.revisions.list_revisions", return_value=[])
+@patch("gdoc.notify.pre_flight", return_value=None)
+class TestRevisionsEmpty:
+    def test_terse_empty(self, _pf, _list, _update, capsys):
+        rc = cmd_revisions(_make_args())
+        assert rc == 0
+        assert "No revisions retained." in capsys.readouterr().out
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.revisions.list_revisions", return_value=list(REVS))
+@patch("gdoc.notify.pre_flight", return_value=None)
+class TestRevisionsAwareness:
+    def test_preflight_and_state(self, mock_pf, _list, mock_update, capsys):
+        cmd_revisions(_make_args(quiet=True))
+        mock_pf.assert_called_once_with("abc123", quiet=True)
+        mock_update.assert_called_once_with(
+            "abc123", None, command="revisions", quiet=True,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -269,12 +269,13 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.10.2"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -291,6 +292,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = ">=1.2.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14" },
+    { name = "requests", specifier = ">=2.28" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Google Docs' rich Version history UI has no public API, but the Drive
`revisions` collection exposes exportable milestone revisions — this
surfaces them in gdoc's existing idiom.

## New surface

- **`gdoc revisions DOC`** (alias `history`) — list retained milestone
  revisions in terse/json/plain modes, `--limit N`, `[keep]` marker for
  pinned revisions. Revision ids are sparse and non-pinned revisions are
  pruned by Google over time; pruned/unknown revisions produce a clear
  exit-3 error pointing back here.
- **`gdoc cat/pull --revision REV`** — export or download a past
  revision. Shared REV grammar: bare id, `latest`/`head`, `prev`,
  `head~N` (by list position, never id arithmetic), `@ISO` (last
  revision at/before the timestamp; naive timestamps are local time).
- **`gdoc diff DOC --rev A..B | --rev REV | --since ISO`** — coalescing
  word-diff between revisions: shared runs shorter than `--min-common`
  chars (default 24) are absorbed so a rewritten sentence renders as one
  removed + one added chunk, not word salad. Colored on a TTY,
  `[-…-]`/`{+…+}` plain text when piped, `--json` emits a documented
  diff model, `--format html --out F` writes a styled self-contained
  artifact (collapsed unchanged runs, `--context N`, real list markers).
  Exit code follows `diff(1)`: 1 when the revisions differ, 0 when
  identical. Marker-only edits (heading level, bullet↔numbered) render
  as delete+insert so the change is visible; ordered-list renumbering
  alone reads as equal.
- **`--with-comments`** — anchors the doc's comment threads to the hunk
  containing their quoted text (changed-hunk preference, current-side
  preference); unmatched threads render in an appendix, never dropped.
- Richer artifacts (docx, PDF, …) are deliberately not built in:
  external scripts render them from the `--json` diff model.

## Safety decisions

- `pull --revision` writes `source:`/`revision:` frontmatter instead of
  `gdoc:`, so `push` and the sync hooks can't silently overwrite the
  live doc with a stale revision — and `push` explains this on such
  files. Frontmatter values are flattened to one line so a doc title
  containing a line break can't inject frontmatter keys.
- `cat/pull --revision` record the interaction without advancing
  `last_read_version`, so reading an old revision can't unlock a
  `write` over unseen current changes.
- Spreadsheets are rejected on the new doc-only paths.

## Architecture & notes

- One diff engine, multiple renderers: `gdoc/revdiff.py` (selectors +
  engine, pure stdlib) feeds `gdoc/diffrender.py` (terminal +
  self-contained HTML, no new deps). `gdoc/api/revisions.py` wraps
  `revisions.list`/exportLinks downloads (`requests` is now a declared
  dependency). Existing `diff DOC FILE` behavior is unchanged.
- `cat --no-images` now also strips the reference-style `![][imageN]`
  images and base64 definitions the Drive export actually emits
  (previously only inline `![alt](url)` images were removed).
- Version 0.11.0. Full suite: 1112 tests passing.

## Test plan

- New tests cover the REV grammar (sparse-id `head~N`, `@ISO` boundaries,
  timezone handling), coalescing behavior at varying `--min-common`,
  marker-only change rendering, comment anchoring (changed-hunk and
  current-side preference, appendix fallback), export error mapping
  (401/403/404, timeout, text/plain fallback warning), frontmatter
  injection hardening, and CLI validation for every flag combination.
  Full suite: 1112 passing.
- Verified live against real Google Docs: revision listing, `--rev prev`
  and `--since` diffs, html artifacts with anchored comment threads,
  identical-revision exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * List, export, and pull document revisions from version history.
  * Generate diffs between revisions with word-level highlighting.
  * Create HTML diff artifacts with anchored comment threads.
  * Support revision selection via timestamps and relative syntax.

* **Changed**
  * Improved error handling and messaging for unknown/pruned revisions.
  * Frontmatter values flattened to prevent accidental newline injection.
  * Enhanced markdown image reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->