### PR TITLE
Per-tab markdown: fix bold/italic & escapes, expand supported subset (0.11.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 build/
 .pytest_cache/
 .DS_Store
+
+# swarm-loop-review run artifacts (not committed)
+.swarm-loop-review/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] — 2026-06-13
+
+### Fixed
+- **Per-tab markdown writes preserve bold/italic.** `write --tab` /
+  `insert --tab` emitted `updateTextStyle` before `updateParagraphStyle`;
+  applying a `namedStyleType` re-resolves a run's direct character
+  formatting and cleared the just-set bold/italic (links survived a
+  named-style reset, so only bold/italic broke). Paragraph-style and bullet
+  requests are now emitted before text styles, so character formatting
+  wins. Whole-doc `write` (Drive's importer) was unaffected.
+- **Per-tab markdown writes honor backslash escapes.** `_parse_inline` had
+  no escape pass, so `\*x\*` kept the backslash *and* still rendered italic.
+  Escapes are now resolved first (CommonMark ASCII-punctuation set): the
+  escaping backslash is stripped and the escaped character can no longer
+  open or close an inline span, so `\*`, `\[`, etc. produce literal text.
+
 ## [0.10.2] — 2026-06-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.3] — 2026-06-13
+## [0.11.0] — 2026-06-13
+
+### Added
+- **Per-tab markdown writes now render a much larger subset.** `write --tab` /
+  `insert --tab` (the hand-built Docs API path, not Drive's importer) now
+  support: nested emphasis (`**bold _italic_**`), strikethrough (`~~x~~`),
+  blockquotes (indented), horizontal rules, fenced code blocks (monospace),
+  nested bullet/numbered lists (indented), and inline formatting inside table
+  cells. See `gdoc.md` for the supported set and known gaps (images render as
+  `!` + link; nested-list glyphs don't cycle by depth).
 
 ### Fixed
 - **Per-tab markdown writes preserve bold/italic.** `write --tab` /
@@ -16,9 +25,14 @@ All notable changes to `gdoc` are documented here. This project follows
   wins. Whole-doc `write` (Drive's importer) was unaffected.
 - **Per-tab markdown writes honor backslash escapes.** `_parse_inline` had
   no escape pass, so `\*x\*` kept the backslash *and* still rendered italic.
-  Escapes are now resolved first (CommonMark ASCII-punctuation set): the
-  escaping backslash is stripped and the escaped character can no longer
-  open or close an inline span, so `\*`, `\[`, etc. produce literal text.
+  Escapes now follow CommonMark: the escaping backslash is stripped and the
+  escaped character can no longer open or close an inline span, so `\*`,
+  `\[`, etc. produce literal text. Code spans stay literal (a regex like
+  `` `\d+\.\d+` `` keeps its backslashes).
+- **Ordered lists number continuously.** Bullets are created top-to-bottom so
+  Docs attaches each item to the list above it (`1, 2, 3`, not three `1`s).
+- **Horizontal rules survive at end of input.** The trailing-newline trim no
+  longer collapses a final horizontal rule.
 
 ## [0.10.2] — 2026-06-09
 

--- a/gdoc.md
+++ b/gdoc.md
@@ -277,7 +277,7 @@ The `write` command does a full overwrite. Strategy:
 
 **Caveat**: This is a full overwrite — it replaces the entire doc body. For surgical edits, use `edit`.
 
-**Note on `--tab` writes**: writing into a specific tab (`write --tab` / `insert --tab`) does not use Drive's importer — it hand-builds Docs API requests from a markdown *subset* (headings, bold/italic, code, links, top-level bullets/numbers, tables). Unsupported syntax (nested lists, blockquotes, strikethrough, images, fenced blocks) passes through as literal text. Backslash escapes follow CommonMark (a `\` before ASCII punctuation is dropped, e.g. `\*` → `*`, `50\%` → `50%`), matching the importer.
+**Note on `--tab` writes**: writing into a specific tab (`write --tab` / `insert --tab`) does not use Drive's importer — it hand-builds Docs API requests from a markdown *subset*: headings, bold/italic/bold-italic, strikethrough, inline code, links, nested emphasis, bullet/numbered lists (incl. nesting), blockquotes, horizontal rules, fenced code blocks, and tables (with inline formatting inside cells). Known gaps vs Drive's importer: images render as `!` + a link (not embedded); nested lists render as indented bullets (the glyph does not cycle disc→circle→square by depth). Anything else unrecognized passes through as literal text. Backslash escapes follow CommonMark (a `\` before ASCII punctuation is dropped, e.g. `\*` → `*`, `50\%` → `50%`), matching the importer.
 
 ### Comments (Drive API v3)
 

--- a/gdoc.md
+++ b/gdoc.md
@@ -277,6 +277,8 @@ The `write` command does a full overwrite. Strategy:
 
 **Caveat**: This is a full overwrite — it replaces the entire doc body. For surgical edits, use `edit`.
 
+**Note on `--tab` writes**: writing into a specific tab (`write --tab` / `insert --tab`) does not use Drive's importer — it hand-builds Docs API requests from a markdown *subset* (headings, bold/italic, code, links, top-level bullets/numbers, tables). Unsupported syntax (nested lists, blockquotes, strikethrough, images, fenced blocks) passes through as literal text. Backslash escapes follow CommonMark (a `\` before ASCII punctuation is dropped, e.g. `\*` → `*`, `50\%` → `50%`), matching the importer.
+
 ### Comments (Drive API v3)
 
 | Command | API Call | Notes |

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.10.3"
+__version__ = "0.11.0"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -544,7 +544,7 @@ def _insert_table(
             return
 
         # Parse each cell's markdown to plain text + inline styles, once.
-        from gdoc.mdparse import StyleRange, _parse_inline, _text_style_fields
+        from gdoc.mdparse import StyleRange, parse_inline, text_style_fields
 
         parsed_cells: dict[tuple[int, int], tuple[str, list]] = {}
         for r_idx, row in enumerate(cell_indices):
@@ -553,7 +553,7 @@ def _insert_table(
                 if r_idx < len(table.rows) and c_idx < len(table.rows[r_idx]):
                     raw = table.rows[r_idx][c_idx]
                 parsed_cells[(r_idx, c_idx)] = (
-                    _parse_inline(raw) if raw else ("", [])
+                    parse_inline(raw) if raw else ("", [])
                 )
 
         # Step 3: Insert cell plain text (reverse order, so the original cell
@@ -600,7 +600,7 @@ def _insert_table(
                         "updateTextStyle": {
                             "range": style_range,
                             "textStyle": s.style,
-                            "fields": _text_style_fields(s.style),
+                            "fields": text_style_fields(s.style),
                         }
                     })
                 shift += len(plain)
@@ -902,6 +902,26 @@ def _tab_body_range(body: dict) -> tuple[int, int]:
     return (1, last_end - 1)
 
 
+def _strip_trailing_newline_unless_hr(parsed) -> None:
+    """Drop the trailing \\n parse_markdown appends — the existing paragraph at
+    the insertion point already owns one, so without this every write leaves an
+    extra blank line. Skipped when the last paragraph is a horizontal rule (an
+    intentionally-empty paragraph whose border is lost if its only character is
+    removed). Mutates ``parsed`` in place.
+    """
+    old_len = len(parsed.plain_text)
+    last_is_hr = any(
+        s.type == "paragraph_style" and s.end == old_len
+        and "borderBottom" in s.style
+        for s in parsed.styles
+    )
+    if parsed.plain_text.endswith("\n") and not last_is_hr:
+        parsed.plain_text = parsed.plain_text[:-1]
+        for s in parsed.styles:
+            if s.end == old_len:
+                s.end = old_len - 1
+
+
 def insert_markdown_into_tab(
     doc_id: str,
     tab_name: str,
@@ -946,21 +966,7 @@ def insert_markdown_into_tab(
 
     parsed = parse_markdown(markdown)
 
-    # Strip trailing \n \u2014 the existing paragraph already owns one. Without
-    # this, every insert leaves an extra blank line behind. But skip the strip
-    # when the last paragraph is a horizontal rule (an intentionally-empty
-    # paragraph whose border is lost if its only character is removed).
-    old_len = len(parsed.plain_text)
-    last_is_hr = any(
-        s.type == "paragraph_style" and s.end == old_len
-        and "borderBottom" in s.style
-        for s in parsed.styles
-    )
-    if parsed.plain_text.endswith("\n") and not last_is_hr:
-        parsed.plain_text = parsed.plain_text[:-1]
-        for s in parsed.styles:
-            if s.end == old_len:
-                s.end = old_len - 1
+    _strip_trailing_newline_unless_hr(parsed)
 
     requests: list[dict] = []
 
@@ -1035,21 +1041,7 @@ def replace_formatted(
 
     parsed = parse_markdown(new_markdown)
 
-    # Strip trailing \n \u2014 the existing paragraph in the document already has
-    # one.  Without this, every replacement inserts an extra paragraph break.
-    # But skip the strip when the last paragraph is a horizontal rule (an
-    # intentionally-empty paragraph whose border is lost if stripped).
-    old_len = len(parsed.plain_text)
-    last_is_hr = any(
-        s.type == "paragraph_style" and s.end == old_len
-        and "borderBottom" in s.style
-        for s in parsed.styles
-    )
-    if parsed.plain_text.endswith("\n") and not last_is_hr:
-        parsed.plain_text = parsed.plain_text[:-1]
-        for s in parsed.styles:
-            if s.end == old_len:
-                s.end = old_len - 1
+    _strip_trailing_newline_unless_hr(parsed)
 
     # Sort matches by startIndex descending (last-to-first)
     sorted_matches = sorted(

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -543,52 +543,67 @@ def _insert_table(
         if not cell_indices:
             return
 
-        # Step 3: Insert text into cells (reverse order)
+        # Parse each cell's markdown to plain text + inline styles, once.
+        from gdoc.mdparse import StyleRange, _parse_inline, _text_style_fields
+
+        parsed_cells: dict[tuple[int, int], tuple[str, list]] = {}
+        for r_idx, row in enumerate(cell_indices):
+            for c_idx in range(len(row)):
+                raw = ""
+                if r_idx < len(table.rows) and c_idx < len(table.rows[r_idx]):
+                    raw = table.rows[r_idx][c_idx]
+                parsed_cells[(r_idx, c_idx)] = (
+                    _parse_inline(raw) if raw else ("", [])
+                )
+
+        # Step 3: Insert cell plain text (reverse order, so the original cell
+        # indices stay valid — inserting at a higher index never shifts a
+        # lower one).
         text_requests: list[dict] = []
         for r_idx in range(len(cell_indices) - 1, -1, -1):
             row = cell_indices[r_idx]
             for c_idx in range(len(row) - 1, -1, -1):
-                cell_text = ""
-                if r_idx < len(table.rows):
-                    row_data = table.rows[r_idx]
-                    if c_idx < len(row_data):
-                        cell_text = row_data[c_idx]
-                if cell_text:
+                plain, _ = parsed_cells[(r_idx, c_idx)]
+                if plain:
                     cell_location = {"index": row[c_idx]}
                     if tab_id:
                         cell_location["tabId"] = tab_id
                     text_requests.append({
                         "insertText": {
                             "location": cell_location,
-                            "text": cell_text,
+                            "text": plain,
                         }
                     })
 
-        # Bold the header row (row 0). Indices must account for
-        # shifts from earlier columns' insertions (processed right-to-
-        # left, so col 0's insert shifts col 1+).
-        if cell_indices and table.rows:
-            row = cell_indices[0]
-            shift = 0
+        # Apply inline styles (plus bold for the whole header row) in forward
+        # index order. Each cell's final position is its original index plus the
+        # total length of all earlier (lower-index) cells already inserted.
+        shift = 0
+        for r_idx in range(len(cell_indices)):
+            row = cell_indices[r_idx]
             for c_idx in range(len(row)):
-                cell_text = ""
-                if c_idx < len(table.rows[0]):
-                    cell_text = table.rows[0][c_idx]
-                if cell_text:
-                    bold_range = {
-                        "startIndex": row[c_idx] + shift,
-                        "endIndex": row[c_idx] + shift + len(cell_text),
+                plain, cell_styles = parsed_cells[(r_idx, c_idx)]
+                cell_styles = list(cell_styles)
+                if r_idx == 0 and plain:
+                    cell_styles.append(StyleRange(
+                        0, len(plain), {"bold": True}, "text_style",
+                    ))
+                base = row[c_idx] + shift
+                for s in cell_styles:
+                    style_range = {
+                        "startIndex": base + s.start,
+                        "endIndex": base + s.end,
                     }
                     if tab_id:
-                        bold_range["tabId"] = tab_id
+                        style_range["tabId"] = tab_id
                     text_requests.append({
                         "updateTextStyle": {
-                            "range": bold_range,
-                            "textStyle": {"bold": True},
-                            "fields": "bold",
+                            "range": style_range,
+                            "textStyle": s.style,
+                            "fields": _text_style_fields(s.style),
                         }
                     })
-                shift += len(cell_text)
+                shift += len(plain)
 
         if text_requests:
             service.documents().batchUpdate(
@@ -931,10 +946,17 @@ def insert_markdown_into_tab(
 
     parsed = parse_markdown(markdown)
 
-    # Strip trailing \n \u2014 the existing paragraph already owns one.
-    # Without this, every insert leaves an extra blank line behind.
-    if parsed.plain_text.endswith("\n"):
-        old_len = len(parsed.plain_text)
+    # Strip trailing \n \u2014 the existing paragraph already owns one. Without
+    # this, every insert leaves an extra blank line behind. But skip the strip
+    # when the last paragraph is a horizontal rule (an intentionally-empty
+    # paragraph whose border is lost if its only character is removed).
+    old_len = len(parsed.plain_text)
+    last_is_hr = any(
+        s.type == "paragraph_style" and s.end == old_len
+        and "borderBottom" in s.style
+        for s in parsed.styles
+    )
+    if parsed.plain_text.endswith("\n") and not last_is_hr:
         parsed.plain_text = parsed.plain_text[:-1]
         for s in parsed.styles:
             if s.end == old_len:
@@ -969,9 +991,12 @@ def insert_markdown_into_tab(
 
     if parsed.tables:
         for table in reversed(parsed.tables):
+            # Subtract leading list-indent tabs that createParagraphBullets
+            # removed before this table, shifting its real position left.
             _insert_table(
                 doc_id,
-                insert_index + table.plain_text_offset,
+                insert_index + table.plain_text_offset
+                - table.removed_tabs_before,
                 table,
                 tab_id=tab_id,
             )
@@ -1010,11 +1035,17 @@ def replace_formatted(
 
     parsed = parse_markdown(new_markdown)
 
-    # Strip trailing \n \u2014 the existing paragraph in the document
-    # already has one.  Without this, every replacement inserts an
-    # extra paragraph break.
-    if parsed.plain_text.endswith("\n"):
-        old_len = len(parsed.plain_text)
+    # Strip trailing \n \u2014 the existing paragraph in the document already has
+    # one.  Without this, every replacement inserts an extra paragraph break.
+    # But skip the strip when the last paragraph is a horizontal rule (an
+    # intentionally-empty paragraph whose border is lost if stripped).
+    old_len = len(parsed.plain_text)
+    last_is_hr = any(
+        s.type == "paragraph_style" and s.end == old_len
+        and "borderBottom" in s.style
+        for s in parsed.styles
+    )
+    if parsed.plain_text.endswith("\n") and not last_is_hr:
         parsed.plain_text = parsed.plain_text[:-1]
         for s in parsed.styles:
             if s.end == old_len:
@@ -1082,7 +1113,11 @@ def replace_formatted(
             sorted_matches[0]["endIndex"] - sorted_matches[0]["startIndex"]
             if sorted_matches else 0
         )
-        delta = len(parsed.plain_text) - match_len
+        # createParagraphBullets removes the nested-list indent tabs during
+        # the main batch, so each match grows the doc by the post-removal
+        # length, not len(plain_text).
+        effective_len = len(parsed.plain_text) - parsed.removed_tabs
+        delta = effective_len - match_len
         # Matches are sorted descending by startIndex; iterate in
         # that same order so higher positions are cleaned first.
         # Within one batchUpdate, deletions at higher indices
@@ -1092,7 +1127,7 @@ def replace_formatted(
             # by `delta` chars during the main replacement.
             adjusted_pos = (
                 match["startIndex"]
-                + len(parsed.plain_text)
+                + effective_len
                 + (n - 1 - j) * delta
             )
             reqs = _build_cleanup_requests(fetch_body, adjusted_pos, tab_id)
@@ -1108,7 +1143,10 @@ def replace_formatted(
             for table in reversed(parsed.tables):
                 for j, match in enumerate(sorted_matches):
                     shift = (n - 1 - j) * delta
-                    idx = match["startIndex"] + table.plain_text_offset + shift
+                    idx = (
+                        match["startIndex"] + table.plain_text_offset
+                        - table.removed_tabs_before + shift
+                    )
                     _insert_table(doc_id, idx, table, tab_id=tab_id)
 
         return len(sorted_matches)

--- a/gdoc/mdparse.py
+++ b/gdoc/mdparse.py
@@ -143,6 +143,16 @@ def _strip_escapes(s: str) -> str:
     return "".join(out)
 
 
+def parse_inline(text: str) -> tuple[str, list[StyleRange]]:
+    """Public: parse inline formatting from a single string.
+
+    For callers (e.g. table-cell rendering) that need inline parsing without
+    the block-level handling of `parse_markdown`. Returns (plain_text,
+    style_ranges) with offsets relative to plain_text.
+    """
+    return _parse_inline(text)
+
+
 def _parse_inline(text: str) -> tuple[str, list[StyleRange]]:
     """Parse inline formatting from a text string.
 
@@ -546,6 +556,11 @@ def to_docs_requests(
         removed += leading
 
     return requests
+
+
+def text_style_fields(style: dict) -> str:
+    """Public: build the updateTextStyle `fields` mask for a style dict."""
+    return _text_style_fields(style)
 
 
 def _text_style_fields(style: dict) -> str:

--- a/gdoc/mdparse.py
+++ b/gdoc/mdparse.py
@@ -24,6 +24,9 @@ class TableData:
     num_rows: int
     num_cols: int
     plain_text_offset: int  # byte offset in plain_text where placeholder sits
+    # Leading list-indent tabs inserted before this table. createParagraphBullets
+    # removes those tabs, shifting the table's real position left by this many.
+    removed_tabs_before: int = 0
 
 
 @dataclass
@@ -33,6 +36,10 @@ class ParsedMarkdown:
     plain_text: str
     styles: list[StyleRange] = field(default_factory=list)
     tables: list[TableData] = field(default_factory=list)
+    # Total leading list-indent tabs in plain_text. createParagraphBullets
+    # removes them at apply time, so the document grows by len(plain_text)
+    # minus this when the requests are applied.
+    removed_tabs: int = 0
 
 
 # Inline patterns — order matters (bold+italic before bold/italic)
@@ -42,15 +49,43 @@ _ITALIC_RE = re.compile(
     r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)"
     r"|(?<!_)_(?!_)(.+?)(?<!_)_(?!_)"
 )
+_STRIKE_RE = re.compile(r"~~(.+?)~~")
 _CODE_RE = re.compile(r"`([^`]+)`")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+# Inline patterns in precedence order. Each entry: (regex, kind). On a tie at
+# the same position, the earlier entry wins, so ***x*** beats **x**/*x*.
+_INLINE_PATTERNS = [
+    (_BOLD_ITALIC_RE, "bolditalic"),
+    (_BOLD_RE, "bold"),
+    (_ITALIC_RE, "italic"),
+    (_STRIKE_RE, "strike"),
+    (_CODE_RE, "code"),
+    (_LINK_RE, "link"),
+]
+
+# Text-style dicts applied per emphasis kind (these recurse into their inner
+# content so emphasis can nest, e.g. **bold _and italic_**).
+_STYLES_FOR_KIND = {
+    "bolditalic": [{"bold": True}, {"italic": True}],
+    "bold": [{"bold": True}],
+    "italic": [{"italic": True}],
+    "strike": [{"strikethrough": True}],
+}
+
+_CODE_FONT = {"weightedFontFamily": {"fontFamily": "Courier New"}}
 
 # Heading pattern
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
 
-# List item patterns
-_BULLET_RE = re.compile(r"^[-*]\s+(.+)$")
-_NUMBERED_RE = re.compile(r"^\d+\.\s+(.+)$")
+# List item patterns (capture leading indentation for nesting)
+_BULLET_RE = re.compile(r"^([ \t]*)[-*]\s+(.+)$")
+_NUMBERED_RE = re.compile(r"^([ \t]*)\d+\.\s+(.+)$")
+
+# Block patterns
+_BLOCKQUOTE_RE = re.compile(r"^ {0,3}>\s?(.*)$")
+_HR_RE = re.compile(r"^ {0,3}([-*_])[ ]*(?:\1[ ]*){2,}$")
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(\S*)\s*$")
 
 # Table patterns
 _TABLE_ROW_RE = re.compile(r"^\|(.+)\|$")
@@ -63,157 +98,159 @@ _ESCAPABLE = set("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 # the inline regexes. NUL never appears in real document text.
 _MASK = "\x00"
 
+# Indentation magnitude (PT) used for one level of blockquote indent.
+_QUOTE_INDENT_PT = 36
 
-def _unescape(text: str) -> tuple[str, str]:
-    """Process backslash escapes.
 
-    Returns ``(working, masked)``, two equal-length strings. ``working`` is
-    ``text`` with the escaping backslashes removed. ``masked`` is identical
-    except each escaped character is replaced by a sentinel, so the inline
-    regexes (which run against ``masked``) neither match an escaped marker
-    nor are broken by one — span text is still taken from ``working``. A
-    backslash before a non-escapable character (or at end of string) is kept
-    literally, matching CommonMark.
+def _mask_escapes(text: str) -> str:
+    """Return a same-length copy of ``text`` with each backslash-escaped
+    character blanked to a sentinel, so the inline regexes never match (or are
+    broken by) an escaped marker. The backslash itself is left in place (it
+    isn't a marker). Emitted text is sliced from the original, so the lengths
+    must stay aligned — hence blanking in place rather than removing.
     """
     if "\\" not in text:
-        return text, text
-    working: list[str] = []
-    masked: list[str] = []
+        return text
+    out = list(text)
     i = 0
     n = len(text)
     while i < n:
-        ch = text[i]
-        if ch == "\\" and i + 1 < n and text[i + 1] in _ESCAPABLE:
-            working.append(text[i + 1])
-            masked.append(_MASK)
+        if text[i] == "\\" and i + 1 < n and text[i + 1] in _ESCAPABLE:
+            out[i + 1] = _MASK
             i += 2
         else:
-            working.append(ch)
-            masked.append(ch)
             i += 1
-    return "".join(working), "".join(masked)
+    return "".join(out)
+
+
+def _strip_escapes(s: str) -> str:
+    """Drop escaping backslashes (``\\X`` -> ``X`` for escapable X), matching
+    CommonMark. NOT applied inside code spans, whose content is literal.
+    A backslash before a non-escapable character (or at end) is kept.
+    """
+    if "\\" not in s:
+        return s
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        if s[i] == "\\" and i + 1 < n and s[i + 1] in _ESCAPABLE:
+            out.append(s[i + 1])
+            i += 2
+        else:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
 
 
 def _parse_inline(text: str) -> tuple[str, list[StyleRange]]:
     """Parse inline formatting from a text string.
 
-    Returns (plain_text, style_ranges) where style_ranges have offsets
-    relative to the returned plain_text.
-
-    Backslash escapes are resolved first: the escaping backslash is removed
-    and the escaped character is prevented from acting as a markdown marker.
+    Returns (plain_text, style_ranges) with offsets relative to plain_text.
+    Emphasis spans nest recursively; backslash escapes are resolved per
+    segment (and left intact inside code spans).
     """
-    styles: list[StyleRange] = []
+    return _scan(text, _mask_escapes(text))
 
-    # Resolve escapes. The regexes run against `masked` (escaped markers
-    # blanked to a sentinel); match offsets index identically into `working`,
-    # from which we take the actual span text.
-    working, masked = _unescape(text)
 
-    def _span(m: re.Match, group: int) -> str:
-        return working[m.start(group):m.end(group)]
+def _scan(text: str, masked: str) -> tuple[str, list[StyleRange]]:
+    """Recursively parse inline formatting.
 
-    def _overlaps(start: int, end: int) -> bool:
-        """True if [start, end) overlaps an already-recorded segment."""
-        return any(s[0] <= start < s[1] or s[0] < end <= s[1]
-                   for s in segments)
-
-    # Process in passes, tracking replacements with placeholders.
-    # We process from most specific to least specific to avoid conflicts.
-
-    # We'll collect all matches first, then process them in order of
-    # their position in the original string to build the plain text.
-
-    segments: list[tuple[int, int, str, list[dict]]] = []
-    # Each segment: (orig_start, orig_end, plain_text, [style_dicts])
-
-    # Find all inline formatting matches (against `masked`; inner text taken
-    # from `working` so escaped characters appear as their literal selves).
-    # Bold+italic: ***text***
-    for m in _BOLD_ITALIC_RE.finditer(masked):
-        segments.append((
-            m.start(), m.end(), _span(m, 1),
-            [{"bold": True}, {"italic": True}],
-        ))
-
-    # Bold: **text** or __text__
-    for m in _BOLD_RE.finditer(masked):
-        group = 1 if m.group(1) is not None else 2
-        # Skip if overlaps with bold+italic
-        if _overlaps(m.start(), m.end()):
-            continue
-        segments.append((m.start(), m.end(), _span(m, group), [{"bold": True}]))
-
-    # Italic: *text* or _text_
-    for m in _ITALIC_RE.finditer(masked):
-        group = 1 if m.group(1) is not None else 2
-        if _overlaps(m.start(), m.end()):
-            continue
-        segments.append((
-            m.start(), m.end(), _span(m, group), [{"italic": True}],
-        ))
-
-    # Code: `text`
-    for m in _CODE_RE.finditer(masked):
-        if _overlaps(m.start(), m.end()):
-            continue
-        segments.append((
-            m.start(), m.end(), _span(m, 1),
-            [{"weightedFontFamily": {"fontFamily": "Courier New"}}],
-        ))
-
-    # Links: [text](url)
-    for m in _LINK_RE.finditer(masked):
-        if _overlaps(m.start(), m.end()):
-            continue
-        segments.append((
-            m.start(), m.end(), _span(m, 1),
-            [{"link": {"url": _span(m, 2)}}],
-        ))
-
-    # Sort segments by original start position
-    segments.sort(key=lambda s: s[0])
-
-    # Build plain text and style ranges
+    ``text`` is the original source; ``masked`` is the same length with escaped
+    markers blanked to a sentinel. The regexes run against ``masked``; emitted
+    text is sliced from ``text``. Escaping backslashes are stripped from normal
+    content but PRESERVED inside code spans (code is literal — CommonMark).
+    Spans recurse so emphasis can nest (e.g. ``**bold _and italic_**``).
+    Returns (plain_text, [StyleRange]) with offsets relative to plain_text.
+    """
     plain_parts: list[str] = []
-    plain_offset = 0
-    prev_end = 0
+    styles: list[StyleRange] = []
+    offset = 0
+    pos = 0
+    n = len(masked)
 
-    for orig_start, orig_end, seg_text, seg_styles in segments:
-        # Add any literal text before this segment
-        if orig_start > prev_end:
-            literal = working[prev_end:orig_start]
-            plain_parts.append(literal)
-            plain_offset += len(literal)
+    while pos < n:
+        # Search the unconsumed tail (a fresh slice), not masked[pos:] via the
+        # pos argument: a lookbehind (`(?<!\*)`) would otherwise read the
+        # just-consumed marker before `pos` and wrongly block a span that abuts
+        # it (e.g. the `*b*` in `**a***b*`). Match offsets are relative to the
+        # slice, so shift them by `pos`.
+        tail = masked[pos:]
+        best: tuple[re.Match, str] | None = None
+        for pat, kind in _INLINE_PATTERNS:
+            m = pat.search(tail)
+            if m is not None and (best is None or m.start() < best[0].start()):
+                best = (m, kind)
+        if best is None:
+            plain_parts.append(_strip_escapes(text[pos:]))
+            break
 
-        # Add the segment's plain text
-        seg_start = plain_offset
-        plain_parts.append(seg_text)
-        plain_offset += len(seg_text)
-        seg_end = plain_offset
+        m, kind = best
+        m_start = pos + m.start()
+        if m_start > pos:
+            lit = _strip_escapes(text[pos:m_start])
+            plain_parts.append(lit)
+            offset += len(lit)
 
-        # Record styles
-        for sd in seg_styles:
+        def _grp(group: int) -> tuple[int, int]:
+            return pos + m.start(group), pos + m.end(group)
+
+        seg_start = offset
+        if kind == "code":
+            # Code spans are literal — content kept verbatim (backslashes too).
+            a, b = _grp(1)
+            inner = text[a:b]
+            plain_parts.append(inner)
+            offset += len(inner)
+            styles.append(StyleRange(seg_start, offset, _CODE_FONT, "text_style"))
+        elif kind == "link":
+            a, b = _grp(1)
+            sub_plain, sub_styles = _scan(text[a:b], masked[a:b])
+            plain_parts.append(sub_plain)
+            offset += len(sub_plain)
+            for s in sub_styles:
+                styles.append(StyleRange(
+                    s.start + seg_start, s.end + seg_start, s.style, s.type,
+                ))
+            ua, ub = _grp(2)
             styles.append(StyleRange(
-                start=seg_start, end=seg_end,
-                style=sd, type="text_style",
+                seg_start, offset,
+                {"link": {"url": _strip_escapes(text[ua:ub])}}, "text_style",
             ))
+        else:
+            # bold / italic alternations capture group 1 or 2; others, group 1.
+            g = 2 if (kind in ("bold", "italic") and m.group(1) is None) else 1
+            a, b = _grp(g)
+            sub_plain, sub_styles = _scan(text[a:b], masked[a:b])
+            plain_parts.append(sub_plain)
+            offset += len(sub_plain)
+            for s in sub_styles:
+                styles.append(StyleRange(
+                    s.start + seg_start, s.end + seg_start, s.style, s.type,
+                ))
+            for sd in _STYLES_FOR_KIND[kind]:
+                styles.append(StyleRange(seg_start, offset, sd, "text_style"))
 
-        prev_end = orig_end
+        pos = pos + m.end()
 
-    # Add any remaining literal text
-    if prev_end < len(working):
-        plain_parts.append(working[prev_end:])
+    return "".join(plain_parts), styles
 
-    plain_text = "".join(plain_parts)
-    return plain_text, styles
+
+def _list_level(indent: str) -> int:
+    """Nesting level from a list item's leading whitespace.
+
+    Two columns (or one tab) per level; capped at 8 (Docs' max).
+    """
+    columns = len(indent.replace("\t", "  "))
+    return min(columns // 2, 8)
 
 
 def parse_markdown(text: str) -> ParsedMarkdown:
     """Parse markdown text into plain text + style annotations.
 
-    Handles: headings (H1-H6), bullet lists, numbered lists,
-    bold, italic, bold+italic, inline code, links.
+    Handles: headings (H1-H6), bullet/numbered lists (nested), bold, italic,
+    bold+italic, strikethrough, inline code, links, blockquotes, horizontal
+    rules, fenced code blocks, and tables.
     """
     if not text:
         return ParsedMarkdown(plain_text="")
@@ -223,33 +260,87 @@ def parse_markdown(text: str) -> ParsedMarkdown:
     all_styles: list[StyleRange] = []
     all_tables: list[TableData] = []
     offset = 0
+    removed_tabs = 0  # running count of leading list-indent tabs (see below)
+
+    def emit_paragraph(
+        content: str,
+        content_styles: list[StyleRange],
+        para_style: dict,
+        bullet_preset: str | None = None,
+        leading_tabs: int = 0,
+    ) -> None:
+        """Append one paragraph (content + newline) and its style ranges.
+
+        ``leading_tabs`` prepends tabs for list nesting; createParagraphBullets
+        counts and removes them at apply time (tracked via ``removed_tabs``).
+        """
+        nonlocal offset, removed_tabs
+        para_start = offset
+        if leading_tabs:
+            plain_parts.append("\t" * leading_tabs)
+            offset += leading_tabs
+            removed_tabs += leading_tabs
+        text_start = offset
+        plain_parts.append(content)
+        offset += len(content)
+        for s in content_styles:
+            all_styles.append(StyleRange(
+                s.start + text_start, s.end + text_start, s.style, s.type,
+            ))
+        plain_parts.append("\n")
+        offset += 1
+        all_styles.append(StyleRange(
+            para_start, offset, para_style, "paragraph_style",
+        ))
+        if bullet_preset is not None:
+            all_styles.append(StyleRange(
+                para_start, offset,
+                {"bulletPreset": bullet_preset}, "bullets",
+            ))
 
     i = 0
     while i < len(lines):
         line = lines[i]
 
-        # Table: detect header row + separator row + data rows
+        # Fenced code block: ``` (or ~~~) ... ```
+        fence_m = _FENCE_RE.match(line)
+        if fence_m:
+            fence = fence_m.group(1)
+            fence_char = fence[0]
+            i += 1
+            while i < len(lines):
+                close = _FENCE_RE.match(lines[i])
+                if close:
+                    close_fence = close.group(1)
+                    if close_fence[0] == fence_char and len(
+                        close_fence
+                    ) >= len(fence):
+                        i += 1
+                        break
+                code_line = lines[i]
+                styles = (
+                    [StyleRange(0, len(code_line), _CODE_FONT, "text_style")]
+                    if code_line else []
+                )
+                emit_paragraph(
+                    code_line, styles, {"namedStyleType": "NORMAL_TEXT"},
+                )
+                i += 1
+            continue
+
+        # Table: header row + separator row + data rows
         if (
             _TABLE_ROW_RE.match(line)
             and i + 1 < len(lines)
             and _TABLE_SEP_RE.match(lines[i + 1])
         ):
-            # Consume all table rows
             table_rows: list[list[str]] = []
-            # Header row
-            header_cells = [
-                c.strip() for c in line.strip("|").split("|")
-            ]
+            header_cells = [c.strip() for c in line.strip("|").split("|")]
             table_rows.append(header_cells)
             num_cols = len(header_cells)
             i += 2  # skip header + separator
-            # Data rows
             while i < len(lines) and _TABLE_ROW_RE.match(lines[i]):
-                cells = [
-                    c.strip()
-                    for c in lines[i].strip("|").split("|")
-                ]
-                # Pad or trim to match column count
+                cells = [c.strip() for c in lines[i].strip("|").split("|")]
                 if len(cells) < num_cols:
                     cells.extend([""] * (num_cols - len(cells)))
                 elif len(cells) > num_cols:
@@ -257,17 +348,16 @@ def parse_markdown(text: str) -> ParsedMarkdown:
                 table_rows.append(cells)
                 i += 1
 
-            # Record table with a placeholder newline
             para_start = offset
             all_tables.append(TableData(
                 rows=table_rows,
                 num_rows=len(table_rows),
                 num_cols=num_cols,
                 plain_text_offset=offset,
+                removed_tabs_before=removed_tabs,
             ))
             plain_parts.append("\n")
             offset += 1
-
             all_styles.append(StyleRange(
                 start=para_start, end=offset,
                 style={"namedStyleType": "NORMAL_TEXT"},
@@ -279,135 +369,83 @@ def parse_markdown(text: str) -> ParsedMarkdown:
         heading_m = _HEADING_RE.match(line)
         if heading_m:
             level = len(heading_m.group(1))
-            content = heading_m.group(2)
-            inline_text, inline_styles = _parse_inline(content)
-
-            para_start = offset
-            plain_parts.append(inline_text)
-            offset += len(inline_text)
-
-            # Shift inline styles
-            for s in inline_styles:
-                all_styles.append(StyleRange(
-                    start=s.start + para_start,
-                    end=s.end + para_start,
-                    style=s.style, type=s.type,
-                ))
-
-            # Add newline
-            plain_parts.append("\n")
-            offset += 1
-
-            # Record heading style for this paragraph
-            all_styles.append(StyleRange(
-                start=para_start, end=offset,
-                style={"namedStyleType": f"HEADING_{level}"},
-                type="paragraph_style",
-            ))
-
+            inline_text, inline_styles = _parse_inline(heading_m.group(2))
+            emit_paragraph(
+                inline_text, inline_styles,
+                {"namedStyleType": f"HEADING_{level}"},
+            )
             i += 1
             continue
 
-        # Bullet list item
+        # Horizontal rule (--- / *** / ___) — an empty paragraph with a
+        # bottom border (the Docs API has no direct horizontal-rule insert).
+        if _HR_RE.match(line):
+            emit_paragraph("", [], {
+                "namedStyleType": "NORMAL_TEXT",
+                "borderBottom": {
+                    "color": {"color": {"rgbColor": {
+                        "red": 0.5, "green": 0.5, "blue": 0.5,
+                    }}},
+                    "width": {"magnitude": 1, "unit": "PT"},
+                    "padding": {"magnitude": 1, "unit": "PT"},
+                    "dashStyle": "SOLID",
+                },
+            })
+            i += 1
+            continue
+
+        # Blockquote — render as an indented normal paragraph.
+        quote_m = _BLOCKQUOTE_RE.match(line)
+        if quote_m:
+            inline_text, inline_styles = _parse_inline(quote_m.group(1))
+            indent = {"magnitude": _QUOTE_INDENT_PT, "unit": "PT"}
+            emit_paragraph(inline_text, inline_styles, {
+                "namedStyleType": "NORMAL_TEXT",
+                "indentStart": indent,
+                "indentFirstLine": indent,
+            })
+            i += 1
+            continue
+
+        # Bullet list item (indent-aware)
         bullet_m = _BULLET_RE.match(line)
         if bullet_m:
-            content = bullet_m.group(1)
-            inline_text, inline_styles = _parse_inline(content)
-
-            para_start = offset
-            plain_parts.append(inline_text)
-            offset += len(inline_text)
-
-            for s in inline_styles:
-                all_styles.append(StyleRange(
-                    start=s.start + para_start,
-                    end=s.end + para_start,
-                    style=s.style, type=s.type,
-                ))
-
-            plain_parts.append("\n")
-            offset += 1
-
-            all_styles.append(StyleRange(
-                start=para_start, end=offset,
-                style={"namedStyleType": "NORMAL_TEXT"},
-                type="paragraph_style",
-            ))
-            all_styles.append(StyleRange(
-                start=para_start, end=offset,
-                style={"bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"},
-                type="bullets",
-            ))
-
+            inline_text, inline_styles = _parse_inline(bullet_m.group(2))
+            emit_paragraph(
+                inline_text, inline_styles,
+                {"namedStyleType": "NORMAL_TEXT"},
+                bullet_preset="BULLET_DISC_CIRCLE_SQUARE",
+                leading_tabs=_list_level(bullet_m.group(1)),
+            )
             i += 1
             continue
 
-        # Numbered list item
+        # Numbered list item (indent-aware)
         numbered_m = _NUMBERED_RE.match(line)
         if numbered_m:
-            content = numbered_m.group(1)
-            inline_text, inline_styles = _parse_inline(content)
-
-            para_start = offset
-            plain_parts.append(inline_text)
-            offset += len(inline_text)
-
-            for s in inline_styles:
-                all_styles.append(StyleRange(
-                    start=s.start + para_start,
-                    end=s.end + para_start,
-                    style=s.style, type=s.type,
-                ))
-
-            plain_parts.append("\n")
-            offset += 1
-
-            all_styles.append(StyleRange(
-                start=para_start, end=offset,
-                style={"namedStyleType": "NORMAL_TEXT"},
-                type="paragraph_style",
-            ))
-            all_styles.append(StyleRange(
-                start=para_start, end=offset,
-                style={"bulletPreset": "NUMBERED_DECIMAL_ALPHA_ROMAN"},
-                type="bullets",
-            ))
-
+            inline_text, inline_styles = _parse_inline(numbered_m.group(2))
+            emit_paragraph(
+                inline_text, inline_styles,
+                {"namedStyleType": "NORMAL_TEXT"},
+                bullet_preset="NUMBERED_DECIMAL_ALPHA_ROMAN",
+                leading_tabs=_list_level(numbered_m.group(1)),
+            )
             i += 1
             continue
 
-        # Normal paragraph line
+        # Normal paragraph line. Explicit NORMAL_TEXT so inserted paragraphs
+        # don't inherit the style of the paragraph at the insertion point.
         inline_text, inline_styles = _parse_inline(line)
-
-        para_start = offset
-        plain_parts.append(inline_text)
-        offset += len(inline_text)
-
-        for s in inline_styles:
-            all_styles.append(StyleRange(
-                start=s.start + para_start,
-                end=s.end + para_start,
-                style=s.style, type=s.type,
-            ))
-
-        plain_parts.append("\n")
-        offset += 1
-
-        # Explicit NORMAL_TEXT so inserted paragraphs don't inherit
-        # the style of the paragraph at the insertion point.
-        all_styles.append(StyleRange(
-            start=para_start, end=offset,
-            style={"namedStyleType": "NORMAL_TEXT"},
-            type="paragraph_style",
-        ))
-
+        emit_paragraph(
+            inline_text, inline_styles, {"namedStyleType": "NORMAL_TEXT"},
+        )
         i += 1
 
-    plain_text = "".join(plain_parts)
     return ParsedMarkdown(
-        plain_text=plain_text,
+        plain_text="".join(plain_parts),
         styles=all_styles,
         tables=all_tables,
+        removed_tabs=removed_tabs,
     )
 
 
@@ -431,7 +469,6 @@ def to_docs_requests(
 
     requests: list[dict] = []
 
-    # Helper to build location/range dicts with optional tabId
     def _location(index: int) -> dict:
         loc = {"index": index}
         if tab_id:
@@ -444,7 +481,7 @@ def to_docs_requests(
             r["tabId"] = tab_id
         return r
 
-    # 1. Insert the plain text
+    # 1. Insert the plain text.
     requests.append({
         "insertText": {
             "location": _location(insert_index),
@@ -452,56 +489,61 @@ def to_docs_requests(
         }
     })
 
-    # Paragraph-level requests (named styles, bullets) MUST be applied
-    # before character-level (text style) requests. Applying a
-    # `namedStyleType` re-resolves a run's direct character formatting and
-    # clears any bold/italic already set, so text styles must come last to
-    # win. (Links survive a named-style reset, which is why earlier the bug
-    # only manifested for bold/italic.)
-
-    # 2. Apply paragraph styles (headings, NORMAL_TEXT)
+    # 2. Paragraph styles (named styles, indents, borders). Applied before text
+    #    styles because a `namedStyleType` re-resolves a run's direct character
+    #    formatting and would clear bold/italic set afterwards.
     for sr in parsed.styles:
         if sr.type == "paragraph_style":
             requests.append({
                 "updateParagraphStyle": {
                     "range": _range(
-                        sr.start + insert_index,
-                        sr.end + insert_index,
+                        sr.start + insert_index, sr.end + insert_index,
                     ),
                     "paragraphStyle": sr.style,
-                    "fields": "namedStyleType",
+                    "fields": _paragraph_style_fields(sr.style),
                 }
             })
 
-    # 3. Apply bullet styles (after paragraph styles)
-    for sr in parsed.styles:
-        if sr.type == "bullets":
-            requests.append({
-                "createParagraphBullets": {
-                    "range": _range(
-                        sr.start + insert_index,
-                        sr.end + insert_index,
-                    ),
-                    "bulletPreset": sr.style["bulletPreset"],
-                }
-            })
-
-    # 4. Apply text styles last (bold, italic, code, link) so they are not
-    #    clobbered by the paragraph-style requests above.
+    # 3. Text styles (bold, italic, strikethrough, code, link). After paragraph
+    #    styles so they are not clobbered; before bullets so they are already
+    #    attached to their runs when bullet creation removes leading tabs.
     for sr in parsed.styles:
         if sr.type == "text_style":
-            # Build the fields mask from the style keys
-            fields = _text_style_fields(sr.style)
             requests.append({
                 "updateTextStyle": {
                     "range": _range(
-                        sr.start + insert_index,
-                        sr.end + insert_index,
+                        sr.start + insert_index, sr.end + insert_index,
                     ),
                     "textStyle": sr.style,
-                    "fields": fields,
+                    "fields": _text_style_fields(sr.style),
                 }
             })
+
+    # 4. Bullets last, in FORWARD document order. Two forces:
+    #    - createParagraphBullets counts and REMOVES the leading tabs that
+    #      encode nesting level, shifting all later indices left.
+    #    - ordered lists only number continuously (1, 2, 3) when each item is
+    #      created after the one above it — reverse order makes each item start
+    #      its own list at 1 (and can drop bullets entirely).
+    #    So process top-to-bottom and subtract the tabs that earlier items in
+    #    this same batch have already removed.
+    text = parsed.plain_text
+    removed = 0
+    bullet_ranges = [sr for sr in parsed.styles if sr.type == "bullets"]
+    for sr in sorted(bullet_ranges, key=lambda s: s.start):
+        leading = 0
+        while sr.start + leading < len(text) and text[sr.start + leading] == "\t":
+            leading += 1
+        requests.append({
+            "createParagraphBullets": {
+                "range": _range(
+                    sr.start + insert_index - removed,
+                    sr.end + insert_index - removed,
+                ),
+                "bulletPreset": sr.style["bulletPreset"],
+            }
+        })
+        removed += leading
 
     return requests
 
@@ -514,8 +556,25 @@ def _text_style_fields(style: dict) -> str:
             parts.append("bold")
         elif key == "italic":
             parts.append("italic")
+        elif key == "strikethrough":
+            parts.append("strikethrough")
         elif key == "weightedFontFamily":
             parts.append("weightedFontFamily")
         elif key == "link":
             parts.append("link")
     return ",".join(parts)
+
+
+# ParagraphStyle keys this module emits, each a valid Docs API field name.
+_PARAGRAPH_STYLE_FIELDS = frozenset({
+    "namedStyleType", "indentStart", "indentFirstLine", "borderBottom",
+})
+
+
+def _paragraph_style_fields(style: dict) -> str:
+    """Build the fields mask string for updateParagraphStyle.
+
+    Whitelisted (rather than ``",".join(style.keys())``) so an unexpected key
+    can't produce a malformed field mask — mirrors ``_text_style_fields``.
+    """
+    return ",".join(k for k in style if k in _PARAGRAPH_STYLE_FIELDS)

--- a/gdoc/mdparse.py
+++ b/gdoc/mdparse.py
@@ -56,14 +56,67 @@ _NUMBERED_RE = re.compile(r"^\d+\.\s+(.+)$")
 _TABLE_ROW_RE = re.compile(r"^\|(.+)\|$")
 _TABLE_SEP_RE = re.compile(r"^\|[\s:]*-{3,}[\s:]*(\|[\s:]*-{3,}[\s:]*)*\|$")
 
+# Characters a backslash may escape (CommonMark ASCII-punctuation set).
+_ESCAPABLE = set("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+
+# Sentinel used to mask escaped characters so they cannot match (or break)
+# the inline regexes. NUL never appears in real document text.
+_MASK = "\x00"
+
+
+def _unescape(text: str) -> tuple[str, str]:
+    """Process backslash escapes.
+
+    Returns ``(working, masked)``, two equal-length strings. ``working`` is
+    ``text`` with the escaping backslashes removed. ``masked`` is identical
+    except each escaped character is replaced by a sentinel, so the inline
+    regexes (which run against ``masked``) neither match an escaped marker
+    nor are broken by one — span text is still taken from ``working``. A
+    backslash before a non-escapable character (or at end of string) is kept
+    literally, matching CommonMark.
+    """
+    if "\\" not in text:
+        return text, text
+    working: list[str] = []
+    masked: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n and text[i + 1] in _ESCAPABLE:
+            working.append(text[i + 1])
+            masked.append(_MASK)
+            i += 2
+        else:
+            working.append(ch)
+            masked.append(ch)
+            i += 1
+    return "".join(working), "".join(masked)
+
 
 def _parse_inline(text: str) -> tuple[str, list[StyleRange]]:
     """Parse inline formatting from a text string.
 
     Returns (plain_text, style_ranges) where style_ranges have offsets
     relative to the returned plain_text.
+
+    Backslash escapes are resolved first: the escaping backslash is removed
+    and the escaped character is prevented from acting as a markdown marker.
     """
     styles: list[StyleRange] = []
+
+    # Resolve escapes. The regexes run against `masked` (escaped markers
+    # blanked to a sentinel); match offsets index identically into `working`,
+    # from which we take the actual span text.
+    working, masked = _unescape(text)
+
+    def _span(m: re.Match, group: int) -> str:
+        return working[m.start(group):m.end(group)]
+
+    def _overlaps(start: int, end: int) -> bool:
+        """True if [start, end) overlaps an already-recorded segment."""
+        return any(s[0] <= start < s[1] or s[0] < end <= s[1]
+                   for s in segments)
 
     # Process in passes, tracking replacements with placeholders.
     # We process from most specific to least specific to avoid conflicts.
@@ -74,49 +127,48 @@ def _parse_inline(text: str) -> tuple[str, list[StyleRange]]:
     segments: list[tuple[int, int, str, list[dict]]] = []
     # Each segment: (orig_start, orig_end, plain_text, [style_dicts])
 
-    # Find all inline formatting matches
+    # Find all inline formatting matches (against `masked`; inner text taken
+    # from `working` so escaped characters appear as their literal selves).
     # Bold+italic: ***text***
-    for m in _BOLD_ITALIC_RE.finditer(text):
+    for m in _BOLD_ITALIC_RE.finditer(masked):
         segments.append((
-            m.start(), m.end(), m.group(1),
+            m.start(), m.end(), _span(m, 1),
             [{"bold": True}, {"italic": True}],
         ))
 
     # Bold: **text** or __text__
-    for m in _BOLD_RE.finditer(text):
-        inner = m.group(1) or m.group(2)
+    for m in _BOLD_RE.finditer(masked):
+        group = 1 if m.group(1) is not None else 2
         # Skip if overlaps with bold+italic
-        if any(s[0] <= m.start() < s[1] or s[0] < m.end() <= s[1]
-               for s in segments):
+        if _overlaps(m.start(), m.end()):
             continue
-        segments.append((m.start(), m.end(), inner, [{"bold": True}]))
+        segments.append((m.start(), m.end(), _span(m, group), [{"bold": True}]))
 
     # Italic: *text* or _text_
-    for m in _ITALIC_RE.finditer(text):
-        inner = m.group(1) or m.group(2)
-        if any(s[0] <= m.start() < s[1] or s[0] < m.end() <= s[1]
-               for s in segments):
-            continue
-        segments.append((m.start(), m.end(), inner, [{"italic": True}]))
-
-    # Code: `text`
-    for m in _CODE_RE.finditer(text):
-        if any(s[0] <= m.start() < s[1] or s[0] < m.end() <= s[1]
-               for s in segments):
+    for m in _ITALIC_RE.finditer(masked):
+        group = 1 if m.group(1) is not None else 2
+        if _overlaps(m.start(), m.end()):
             continue
         segments.append((
-            m.start(), m.end(), m.group(1),
+            m.start(), m.end(), _span(m, group), [{"italic": True}],
+        ))
+
+    # Code: `text`
+    for m in _CODE_RE.finditer(masked):
+        if _overlaps(m.start(), m.end()):
+            continue
+        segments.append((
+            m.start(), m.end(), _span(m, 1),
             [{"weightedFontFamily": {"fontFamily": "Courier New"}}],
         ))
 
     # Links: [text](url)
-    for m in _LINK_RE.finditer(text):
-        if any(s[0] <= m.start() < s[1] or s[0] < m.end() <= s[1]
-               for s in segments):
+    for m in _LINK_RE.finditer(masked):
+        if _overlaps(m.start(), m.end()):
             continue
         segments.append((
-            m.start(), m.end(), m.group(1),
-            [{"link": {"url": m.group(2)}}],
+            m.start(), m.end(), _span(m, 1),
+            [{"link": {"url": _span(m, 2)}}],
         ))
 
     # Sort segments by original start position
@@ -130,7 +182,7 @@ def _parse_inline(text: str) -> tuple[str, list[StyleRange]]:
     for orig_start, orig_end, seg_text, seg_styles in segments:
         # Add any literal text before this segment
         if orig_start > prev_end:
-            literal = text[prev_end:orig_start]
+            literal = working[prev_end:orig_start]
             plain_parts.append(literal)
             plain_offset += len(literal)
 
@@ -150,8 +202,8 @@ def _parse_inline(text: str) -> tuple[str, list[StyleRange]]:
         prev_end = orig_end
 
     # Add any remaining literal text
-    if prev_end < len(text):
-        plain_parts.append(text[prev_end:])
+    if prev_end < len(working):
+        plain_parts.append(working[prev_end:])
 
     plain_text = "".join(plain_parts)
     return plain_text, styles
@@ -400,23 +452,14 @@ def to_docs_requests(
         }
     })
 
-    # 2. Apply text styles (bold, italic, code, link)
-    for sr in parsed.styles:
-        if sr.type == "text_style":
-            # Build the fields mask from the style keys
-            fields = _text_style_fields(sr.style)
-            requests.append({
-                "updateTextStyle": {
-                    "range": _range(
-                        sr.start + insert_index,
-                        sr.end + insert_index,
-                    ),
-                    "textStyle": sr.style,
-                    "fields": fields,
-                }
-            })
+    # Paragraph-level requests (named styles, bullets) MUST be applied
+    # before character-level (text style) requests. Applying a
+    # `namedStyleType` re-resolves a run's direct character formatting and
+    # clears any bold/italic already set, so text styles must come last to
+    # win. (Links survive a named-style reset, which is why earlier the bug
+    # only manifested for bold/italic.)
 
-    # 3. Apply paragraph styles (headings, NORMAL_TEXT)
+    # 2. Apply paragraph styles (headings, NORMAL_TEXT)
     for sr in parsed.styles:
         if sr.type == "paragraph_style":
             requests.append({
@@ -430,7 +473,7 @@ def to_docs_requests(
                 }
             })
 
-    # 4. Apply bullet styles (after paragraph styles)
+    # 3. Apply bullet styles (after paragraph styles)
     for sr in parsed.styles:
         if sr.type == "bullets":
             requests.append({
@@ -440,6 +483,23 @@ def to_docs_requests(
                         sr.end + insert_index,
                     ),
                     "bulletPreset": sr.style["bulletPreset"],
+                }
+            })
+
+    # 4. Apply text styles last (bold, italic, code, link) so they are not
+    #    clobbered by the paragraph-style requests above.
+    for sr in parsed.styles:
+        if sr.type == "text_style":
+            # Build the fields mask from the style keys
+            fields = _text_style_fields(sr.style)
+            requests.append({
+                "updateTextStyle": {
+                    "range": _range(
+                        sr.start + insert_index,
+                        sr.end + insert_index,
+                    ),
+                    "textStyle": sr.style,
+                    "fields": fields,
                 }
             })
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.10.3"
+version = "0.11.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.10.2"
+version = "0.10.3"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_mdparse.py
+++ b/tests/test_mdparse.py
@@ -311,15 +311,15 @@ class TestToDocsRequests:
     def test_bold_generates_update_text_style(self):
         parsed = parse_markdown("**bold**")
         reqs = to_docs_requests(parsed, insert_index=5)
-        # insertText + updateTextStyle + updateParagraphStyle (NORMAL_TEXT)
+        # insertText + updateParagraphStyle (NORMAL_TEXT) + updateTextStyle
         assert len(reqs) == 3
         insert = reqs[0]
         assert insert["insertText"]["text"] == "bold\n"
         assert insert["insertText"]["location"]["index"] == 5
 
-        style_req = reqs[1]
-        assert "updateTextStyle" in style_req
-        uts = style_req["updateTextStyle"]
+        style_reqs = [r for r in reqs if "updateTextStyle" in r]
+        assert len(style_reqs) == 1
+        uts = style_reqs[0]["updateTextStyle"]
         assert uts["range"]["startIndex"] == 5
         assert uts["range"]["endIndex"] == 9
         assert uts["textStyle"] == {"bold": True}
@@ -376,7 +376,7 @@ class TestToDocsRequests:
         reqs = to_docs_requests(parsed, insert_index=100)
         insert = reqs[0]
         assert insert["insertText"]["location"]["index"] == 100
-        style = reqs[1]["updateTextStyle"]
+        style = [r for r in reqs if "updateTextStyle" in r][0]["updateTextStyle"]
         assert style["range"]["startIndex"] == 100
         assert style["range"]["endIndex"] == 104
 
@@ -386,7 +386,12 @@ class TestToDocsRequests:
         assert reqs == []
 
     def test_request_ordering(self):
-        """Insert first, text styles, paragraph styles, bullets."""
+        """Insert first, then paragraph styles, then bullets, then text styles.
+
+        Text styles must come last: applying a ``namedStyleType`` (paragraph
+        style) re-resolves a run's direct character formatting, so bold/italic
+        applied before it would be clobbered. See the per-tab formatting bug.
+        """
         parsed = parse_markdown("# **Bold** heading\n- item")
         reqs = to_docs_requests(parsed, insert_index=1)
         types = []
@@ -400,11 +405,12 @@ class TestToDocsRequests:
             elif "createParagraphBullets" in r:
                 types.append("bullets")
         assert types[0] == "insert"
-        # Text styles before paragraph styles before bullets
+        # Paragraph styles and bullets before text styles, so character
+        # formatting survives the named-style reset.
         text_idx = types.index("text_style")
         para_idx = types.index("para_style")
         bullet_idx = types.index("bullets")
-        assert text_idx < para_idx < bullet_idx
+        assert para_idx < bullet_idx < text_idx
 
 
 class TestParseNormalTextEmission:
@@ -492,3 +498,101 @@ class TestToDocsRequestsTabId:
         reqs = to_docs_requests(parsed, insert_index=1)
         style_reqs = [r for r in reqs if "updateTextStyle" in r]
         assert "tabId" not in style_reqs[0]["updateTextStyle"]["range"]
+
+
+class TestParagraphStyleBeforeTextStyle:
+    """Regression: per-tab bold/italic was clobbered by a trailing
+    updateParagraphStyle. Paragraph styles must precede text styles so the
+    named-style reset does not wipe character formatting.
+    """
+
+    def _types(self, reqs):
+        types = []
+        for r in reqs:
+            if "updateTextStyle" in r:
+                types.append("text")
+            elif "updateParagraphStyle" in r:
+                types.append("para")
+        return types
+
+    def test_bold_paragraph_emits_para_before_text(self):
+        parsed = parse_markdown("This has **bold** in it.")
+        reqs = to_docs_requests(parsed, insert_index=1)
+        types = self._types(reqs)
+        assert types == ["para", "text"]
+
+    def test_all_para_styles_precede_all_text_styles(self):
+        md = "This has **bold** and *italic* and a [link](https://x.com)."
+        parsed = parse_markdown(md)
+        reqs = to_docs_requests(parsed, insert_index=1)
+        types = self._types(reqs)
+        last_para = max(i for i, t in enumerate(types) if t == "para")
+        first_text = min(i for i, t in enumerate(types) if t == "text")
+        assert last_para < first_text
+        # Bold, italic, and link all still emitted.
+        assert types.count("text") == 3
+
+
+class TestBackslashEscapes:
+    """Issue 2: backslash escapes must be removed and the escaped marker
+    must not take on its markdown meaning.
+    """
+
+    def test_escaped_asterisks_not_italic(self):
+        result = parse_markdown(r"A literal star \*not italic\* here.")
+        assert result.plain_text == "A literal star *not italic* here.\n"
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert italic == []
+
+    def test_escaped_brackets_not_link(self):
+        result = parse_markdown(r"Not a link: \[click here\](https://x.com).")
+        assert result.plain_text == "Not a link: [click here](https://x.com).\n"
+        links = [s for s in result.styles if "link" in s.style]
+        assert links == []
+
+    def test_escaped_brackets_only(self):
+        result = parse_markdown(r"\[brackets\]")
+        assert result.plain_text == "[brackets]\n"
+
+    def test_escaped_tilde_backslash_removed(self):
+        result = parse_markdown(r"\~tilde\~")
+        assert result.plain_text == "~tilde~\n"
+
+    def test_escaped_marker_does_not_break_adjacent_real_formatting(self):
+        result = parse_markdown(r"\* and **bold**")
+        assert result.plain_text == "* and bold\n"
+        bold = [s for s in result.styles if s.style.get("bold")]
+        assert len(bold) == 1
+        # Bold applies to "bold", offset past the literal "* and ".
+        assert result.plain_text[bold[0].start:bold[0].end] == "bold"
+
+    def test_real_and_escaped_italic_coexist(self):
+        result = parse_markdown(r"*real* and \*fake\*")
+        assert result.plain_text == "real and *fake*\n"
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert len(italic) == 1
+        assert result.plain_text[italic[0].start:italic[0].end] == "real"
+
+    def test_escaped_backtick_not_code(self):
+        result = parse_markdown(r"use \`literal\` backticks")
+        assert result.plain_text == "use `literal` backticks\n"
+        code = [s for s in result.styles if "weightedFontFamily" in s.style]
+        assert code == []
+
+    def test_double_backslash_becomes_single(self):
+        result = parse_markdown(r"path C:\\Users")
+        assert result.plain_text == "path C:\\Users\n"
+
+    def test_backslash_before_non_punctuation_kept(self):
+        # \U is not an escapable char, so the backslash stays literal.
+        result = parse_markdown(r"path C:\Users")
+        assert result.plain_text == "path C:\\Users\n"
+
+    def test_escape_in_heading(self):
+        result = parse_markdown(r"# Title with \*literal\* stars")
+        assert result.plain_text == "Title with *literal* stars\n"
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert italic == []
+        heading = [s for s in result.styles
+                   if s.style.get("namedStyleType") == "HEADING_1"]
+        assert len(heading) == 1

--- a/tests/test_mdparse.py
+++ b/tests/test_mdparse.py
@@ -386,11 +386,13 @@ class TestToDocsRequests:
         assert reqs == []
 
     def test_request_ordering(self):
-        """Insert first, then paragraph styles, then bullets, then text styles.
+        """Insert first, then paragraph styles, then text styles, then bullets.
 
-        Text styles must come last: applying a ``namedStyleType`` (paragraph
-        style) re-resolves a run's direct character formatting, so bold/italic
-        applied before it would be clobbered. See the per-tab formatting bug.
+        Paragraph styles come before text styles: applying a ``namedStyleType``
+        re-resolves a run's direct character formatting, so bold/italic applied
+        before it would be clobbered (the per-tab formatting bug). Bullets come
+        last because createParagraphBullets removes the leading tabs that encode
+        nesting level, shifting indices — text styles must already be attached.
         """
         parsed = parse_markdown("# **Bold** heading\n- item")
         reqs = to_docs_requests(parsed, insert_index=1)
@@ -405,12 +407,10 @@ class TestToDocsRequests:
             elif "createParagraphBullets" in r:
                 types.append("bullets")
         assert types[0] == "insert"
-        # Paragraph styles and bullets before text styles, so character
-        # formatting survives the named-style reset.
         text_idx = types.index("text_style")
         para_idx = types.index("para_style")
         bullet_idx = types.index("bullets")
-        assert para_idx < bullet_idx < text_idx
+        assert para_idx < text_idx < bullet_idx
 
 
 class TestParseNormalTextEmission:
@@ -579,6 +579,15 @@ class TestBackslashEscapes:
         code = [s for s in result.styles if "weightedFontFamily" in s.style]
         assert code == []
 
+    def test_code_span_keeps_backslashes(self):
+        # Code spans are literal — backslashes must NOT be stripped inside
+        # them (e.g. a regex). Outside code, escapes still resolve.
+        result = parse_markdown(r"regex `\d+\.\d+` and \* outside")
+        assert result.plain_text == "regex \\d+\\.\\d+ and * outside\n"
+        code = [s for s in result.styles if "weightedFontFamily" in s.style]
+        assert len(code) == 1
+        assert result.plain_text[code[0].start:code[0].end] == r"\d+\.\d+"
+
     def test_double_backslash_becomes_single(self):
         result = parse_markdown(r"path C:\\Users")
         assert result.plain_text == "path C:\\Users\n"
@@ -596,3 +605,217 @@ class TestBackslashEscapes:
         heading = [s for s in result.styles
                    if s.style.get("namedStyleType") == "HEADING_1"]
         assert len(heading) == 1
+
+
+class TestParseStrikethrough:
+    def test_strikethrough(self):
+        result = parse_markdown("~~gone~~")
+        assert result.plain_text == "gone\n"
+        struck = [s for s in result.styles if s.style.get("strikethrough")]
+        assert len(struck) == 1
+        assert struck[0].start == 0
+        assert struck[0].end == 4
+
+    def test_strikethrough_in_sentence(self):
+        result = parse_markdown("keep ~~drop~~ keep")
+        assert result.plain_text == "keep drop keep\n"
+        struck = [s for s in result.styles if s.style.get("strikethrough")]
+        assert len(struck) == 1
+        assert struck[0].start == 5
+        assert struck[0].end == 9
+
+
+class TestNestedEmphasis:
+    def test_italic_inside_bold(self):
+        result = parse_markdown("**bold _it_**")
+        assert result.plain_text == "bold it\n"
+        bold = [s for s in result.styles if s.style.get("bold")]
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert len(bold) == 1 and bold[0].start == 0 and bold[0].end == 7
+        assert len(italic) == 1 and italic[0].start == 5 and italic[0].end == 7
+
+    def test_italic_inside_strikethrough(self):
+        result = parse_markdown("~~struck *it*~~")
+        assert result.plain_text == "struck it\n"
+        struck = [s for s in result.styles if s.style.get("strikethrough")]
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert len(struck) == 1 and struck[0].end == 9
+        assert len(italic) == 1 and italic[0].start == 7 and italic[0].end == 9
+
+    def test_bold_inside_link(self):
+        result = parse_markdown("[**hi** there](https://x.com)")
+        assert result.plain_text == "hi there\n"
+        link = [s for s in result.styles if "link" in s.style]
+        bold = [s for s in result.styles if s.style.get("bold")]
+        assert len(link) == 1 and link[0].start == 0 and link[0].end == 8
+        assert len(bold) == 1 and bold[0].start == 0 and bold[0].end == 2
+
+    def test_abutting_bold_then_italic(self):
+        # The closing ** of the bold span must not poison the italic span's
+        # lookbehind. Regression for the per-position-search boundary bug.
+        result = parse_markdown("**a***b*")
+        assert result.plain_text == "ab\n"
+        bold = [s for s in result.styles if s.style.get("bold")]
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert len(bold) == 1
+        assert result.plain_text[bold[0].start:bold[0].end] == "a"
+        assert len(italic) == 1
+        assert result.plain_text[italic[0].start:italic[0].end] == "b"
+
+    def test_abutting_strikethrough_then_italic(self):
+        result = parse_markdown("~~a~~*b*")
+        assert result.plain_text == "ab\n"
+        struck = [s for s in result.styles if s.style.get("strikethrough")]
+        italic = [s for s in result.styles if s.style.get("italic")]
+        assert len(struck) == 1
+        assert result.plain_text[struck[0].start:struck[0].end] == "a"
+        assert len(italic) == 1
+        assert result.plain_text[italic[0].start:italic[0].end] == "b"
+
+
+class TestBlockquote:
+    def test_blockquote_indented(self):
+        result = parse_markdown("> quoted")
+        assert result.plain_text == "quoted\n"
+        para = [s for s in result.styles if s.type == "paragraph_style"]
+        assert len(para) == 1
+        assert para[0].style["namedStyleType"] == "NORMAL_TEXT"
+        assert "indentStart" in para[0].style
+
+    def test_blockquote_inline_formatting(self):
+        result = parse_markdown("> has **bold**")
+        assert result.plain_text == "has bold\n"
+        assert [s for s in result.styles if s.style.get("bold")]
+
+
+class TestHorizontalRule:
+    def test_hr_dashes(self):
+        result = parse_markdown("---")
+        assert result.plain_text == "\n"
+        para = [s for s in result.styles if s.type == "paragraph_style"]
+        assert len(para) == 1
+        assert "borderBottom" in para[0].style
+
+    def test_hr_asterisks(self):
+        result = parse_markdown("***")
+        para = [s for s in result.styles if s.type == "paragraph_style"]
+        assert "borderBottom" in para[0].style
+
+    def test_hr_underscores(self):
+        result = parse_markdown("___")
+        para = [s for s in result.styles if s.type == "paragraph_style"]
+        assert "borderBottom" in para[0].style
+
+    def test_triple_star_with_text_is_not_hr(self):
+        result = parse_markdown("***both***")
+        para = [s for s in result.styles if s.type == "paragraph_style"]
+        assert "borderBottom" not in para[0].style
+        assert [s for s in result.styles if s.style.get("bold")]
+
+
+class TestFencedCode:
+    def test_fenced_code_block(self):
+        result = parse_markdown("```\nline1\nline2\n```")
+        assert result.plain_text == "line1\nline2\n"
+        code = [s for s in result.styles if "weightedFontFamily" in s.style]
+        assert len(code) == 2
+
+    def test_fence_with_language(self):
+        result = parse_markdown("```python\nx = 1\n```")
+        assert result.plain_text == "x = 1\n"
+
+    def test_fence_content_not_inline_parsed(self):
+        result = parse_markdown("```\n**not bold**\n```")
+        assert result.plain_text == "**not bold**\n"
+        assert not [s for s in result.styles if s.style.get("bold")]
+
+    def test_fence_preserves_indentation(self):
+        result = parse_markdown("```\n  indented\n```")
+        assert result.plain_text == "  indented\n"
+
+
+class TestNestedLists:
+    def test_nested_bullet_gets_leading_tab(self):
+        result = parse_markdown("- a\n  - b")
+        assert result.plain_text == "a\n\tb\n"
+        bullets = [s for s in result.styles if s.type == "bullets"]
+        assert len(bullets) == 2
+
+    def test_four_space_indent_is_two_levels(self):
+        result = parse_markdown("- a\n    - b")
+        assert result.plain_text == "a\n\t\tb\n"
+
+    def test_numbered_nesting(self):
+        result = parse_markdown("1. a\n   1. b")
+        assert result.plain_text == "a\n\tb\n"
+
+    def test_inline_styles_offset_past_leading_tabs(self):
+        result = parse_markdown("- a\n  - **b**")
+        assert result.plain_text == "a\n\tb\n"
+        bold = [s for s in result.styles if s.style.get("bold")]
+        # "b" sits after the newline + tab → index 3
+        assert len(bold) == 1
+        assert result.plain_text[bold[0].start:bold[0].end] == "b"
+
+
+class TestNewToDocsRequests:
+    def test_blockquote_fields_include_indent(self):
+        reqs = to_docs_requests(parse_markdown("> q"), insert_index=1)
+        ups = [r for r in reqs if "updateParagraphStyle" in r][0]
+        fields = ups["updateParagraphStyle"]["fields"]
+        assert "indentStart" in fields and "namedStyleType" in fields
+
+    def test_hr_fields_include_border(self):
+        reqs = to_docs_requests(parse_markdown("---"), insert_index=1)
+        ups = [r for r in reqs if "updateParagraphStyle" in r][0]
+        assert "borderBottom" in ups["updateParagraphStyle"]["fields"]
+
+    def test_strikethrough_field(self):
+        reqs = to_docs_requests(parse_markdown("~~x~~"), insert_index=1)
+        uts = [r for r in reqs if "updateTextStyle" in r][0]
+        assert uts["updateTextStyle"]["fields"] == "strikethrough"
+
+    def test_bullets_emitted_in_forward_order(self):
+        # Ordered lists only number continuously when items are created
+        # top-to-bottom, so bullets are emitted in ascending start order.
+        reqs = to_docs_requests(
+            parse_markdown("- a\n  - b\n- c"), insert_index=1,
+        )
+        bullets = [r for r in reqs if "createParagraphBullets" in r]
+        starts = [
+            b["createParagraphBullets"]["range"]["startIndex"] for b in bullets
+        ]
+        assert starts == sorted(starts)
+
+    def test_nested_bullet_range_adjusted_for_removed_tabs(self):
+        # The level-1 item removes 1 tab; the following level-0 item's
+        # createParagraphBullets range is shifted left by that 1.
+        reqs = to_docs_requests(
+            parse_markdown("- a\n  - b\n- c"), insert_index=1,
+        )
+        starts = [
+            r["createParagraphBullets"]["range"]["startIndex"]
+            for r in reqs if "createParagraphBullets" in r
+        ]
+        assert starts == [1, 3, 5]
+
+
+class TestTableTabAdjustment:
+    def test_removed_tabs_before_counts_preceding_nest_tabs(self):
+        md = "- a\n  - b\n\n| H |\n|---|\n| x |"
+        result = parse_markdown(md)
+        assert len(result.tables) == 1
+        assert result.tables[0].removed_tabs_before == 1
+
+    def test_no_tabs_before_table_is_zero(self):
+        result = parse_markdown("text\n| H |\n|---|\n| x |")
+        assert result.tables[0].removed_tabs_before == 0
+
+    def test_total_removed_tabs_tracked(self):
+        # 1 tab (level-1) + 2 tabs (level-2) = 3 total.
+        result = parse_markdown("- a\n  - b\n    - c")
+        assert result.removed_tabs == 3
+
+    def test_total_removed_tabs_zero_without_nesting(self):
+        result = parse_markdown("- a\n- b\nplain")
+        assert result.removed_tabs == 0

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Improves the **per-tab** markdown write path (`gdoc write --tab` / `insert --tab`), which hand-builds Docs API `batchUpdate` requests rather than going through Drive's markdown importer (so multi-tab docs aren't collapsed). Two commits:

**1. `fix:` bold/italic + escapes (foundational bug fix)**
- Bold/italic were silently dropped: `updateTextStyle` was emitted before `updateParagraphStyle`, and applying a `namedStyleType` re-resolves a run's direct character formatting, clearing the just-set bold/italic. Paragraph styles (and bullets) are now emitted before text styles.
- Backslash escapes weren't processed (`\*x\*` kept the backslash *and* still rendered italic). `_parse_inline` now resolves escapes per the CommonMark ASCII-punctuation set.

**2. `feat:` expand the supported subset**
- Nested emphasis (`**bold _italic_**`) via a recursive inline scanner, strikethrough, blockquotes, horizontal rules, fenced code blocks, nested bullet/numbered lists, and inline formatting inside table cells.
- Plus correctness fixes found in review: abutting same-marker emphasis (`**a***b*`) keeps both spans; code spans stay literal (a regex like `` `\d+\.\d+` `` keeps its backslashes); ordered lists number continuously; a horizontal rule at end-of-input survives the trailing-newline trim; multi-match `edit` table offsets account for the tabs `createParagraphBullets` removes.

Whole-document `write` (Drive's importer) was never affected by any of this.

See `gdoc.md` for the full supported subset and known gaps (images render as `!` + link; nested-list glyphs don't cycle by depth).

## Testing
- `uv run pytest tests/` — full suite passes (added tests for every feature and each fix).
- Verified live against Google Drive: all features render; code-span backslashes, ordered-list numbering, and the EOF horizontal rule confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded markdown support for tab-based content insertion, including strikethrough, code blocks, links, blockquotes, and horizontal rules.

* **Bug Fixes**
  * Fixed bold and italic formatting preservation and ordering.
  * Improved backslash escape handling for CommonMark compatibility.
  * Corrected continuous numbering for ordered lists.
  * Ensured horizontal rules are preserved at content end.
  * Enhanced table and list formatting precision.

* **Documentation**
  * Added guidance on supported markdown features and limitations for tab-based writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->