### PR TITLE
feat: configurable page mode for `gdoc new` (0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] — 2026-07-04
+
+### Added
+- **Configurable page mode for `gdoc new`.** New docs can be created pageless
+  or paged. Drive's markdown importer always produces *paged* docs (it ignores
+  the account's pageless default), so docs made via `new --file` came out
+  paged regardless of preference. `gdoc new` now applies an explicit page mode
+  after creating the doc: a `--pageless` / `--paged` flag overrides a persisted
+  default set with `gdoc config --page-mode {pageless,paged}` (stored in
+  `~/.config/gdoc/config.json`). With **no flag and no configured default**,
+  the doc is left exactly as the create path produced it — a blank `gdoc new`
+  still inherits the account's pageless/paged default, and markdown imports
+  stay paged — so the feature never silently overrides an account preference.
+  Applying the mode is best-effort — a failure (of any kind) warns on stderr
+  but does not fail the creation, and the write's version bump is folded into
+  the doc's state baseline so it doesn't surface as a spurious change. Adds a
+  `config` subcommand (honors `--json`/`--verbose`/`--plain`) and the
+  `set_page_mode` Docs API helper
+  (`updateDocumentStyle` → `documentFormat.documentMode`).
+
 ## [0.12.0] — 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to `gdoc` are documented here. This project follows
   `set_page_mode` Docs API helper
   (`updateDocumentStyle` → `documentFormat.documentMode`).
 
+### Fixed
+- **`new --file` with images seeded a stale version baseline.** Image inserts
+  advance the doc's Drive version after creation, but state was seeded with
+  the create-time version, so the next command reported a spurious
+  "doc edited" change. The version is now re-read (best-effort) after image
+  insertion, matching the page-mode write's baseline handling.
+
 ## [0.12.0] — 2026-06-22
 
 ### Added

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -78,6 +78,39 @@ def replace_all_text(
         _translate_http_error(e, doc_id)
 
 
+def set_page_mode(doc_id: str, pageless: bool) -> None:
+    """Set a document's page mode (pageless vs paged).
+
+    Writes ``documentStyle.documentFormat.documentMode`` via updateDocumentStyle.
+    Blank docs inherit the account's page-mode default, while markdown-imported
+    docs are always created paged; this makes the mode explicit either way.
+
+    Args:
+        doc_id: The document ID.
+        pageless: If True, set PAGELESS; otherwise PAGES (paged).
+    """
+    mode = "PAGELESS" if pageless else "PAGES"
+    try:
+        service = get_docs_service()
+        service.documents().batchUpdate(
+            documentId=doc_id,
+            body={
+                "requests": [
+                    {
+                        "updateDocumentStyle": {
+                            "documentStyle": {
+                                "documentFormat": {"documentMode": mode},
+                            },
+                            "fields": "documentFormat.documentMode",
+                        }
+                    }
+                ]
+            },
+        ).execute()
+    except HttpError as e:
+        _translate_http_error(e, doc_id)
+
+
 def _extract_paragraphs_text(content: list[dict]) -> str:
     """Extract concatenated text from body content paragraph elements."""
     parts = []

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2449,6 +2449,17 @@ def _cmd_new_from_file(args) -> int:
         _insert_images(new_id, images)
 
     new_version = _apply_page_mode(args, new_id)
+    if new_version is None and images:
+        # Image inserts advanced the Drive version past the create-time value
+        # (a page-mode write already folds in a refresh); re-read it
+        # best-effort so state isn't seeded with a stale baseline that makes
+        # the next command report a spurious "doc edited" change.
+        from gdoc.api.drive import get_file_version
+
+        try:
+            new_version = get_file_version(new_id).get("version")
+        except Exception:
+            new_version = None
     if new_version is not None:
         version = new_version
 

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2448,6 +2448,10 @@ def _cmd_new_from_file(args) -> int:
     if images:
         _insert_images(new_id, images)
 
+    new_version = _apply_page_mode(args, new_id)
+    if new_version is not None:
+        version = new_version
+
     # Output
     from gdoc.format import format_json, get_output_mode
 
@@ -2540,6 +2544,77 @@ def _insert_images(doc_id: str, images) -> None:
                 pass
 
 
+def cmd_config(args) -> int:
+    """Handler for `gdoc config`."""
+    from gdoc.format import format_json, get_output_mode
+    from gdoc.util import get_default_page_mode, set_default_page_mode
+
+    mode = get_output_mode(args)
+    page_mode = getattr(args, "page_mode", None)
+    if page_mode:
+        set_default_page_mode(page_mode)
+        # Human confirmation to stderr; the value itself is echoed to stdout
+        # below (same as the GET path) so a script can capture what it set.
+        print(f"OK page_mode set to: {page_mode}", file=sys.stderr)
+        current = page_mode
+    else:
+        current = get_default_page_mode()
+
+    if mode == "json":
+        print(format_json(page_mode=current))
+    else:
+        # None = unset; the doc's mode is left to the create path.
+        print(f"page_mode\t{current or 'unset'}")
+    return 0
+
+
+def _apply_page_mode(args, doc_id: str) -> int | None:
+    """Set the page mode on a freshly created doc (best-effort).
+
+    Resolution order: --pageless/--paged flag, then the configured default
+    (`gdoc config --page-mode`). With no flag and no configured default the
+    doc is left exactly as the create path produced it — blank docs inherit
+    the account's page-mode default, markdown imports stay paged — and no API
+    call is made.
+
+    Returns the doc's post-update Drive version when a mode was actually
+    written (the write advances the version, so the caller must refresh its
+    state baseline or the next command reports a spurious "doc edited"
+    change), else None. A failure here is non-fatal — the doc already
+    exists — so it warns and returns None.
+    """
+    if getattr(args, "pageless", False):
+        pageless = True
+    elif getattr(args, "paged", False):
+        pageless = False
+    else:
+        from gdoc.util import get_default_page_mode
+
+        mode = get_default_page_mode()
+        if mode is None:
+            return None  # no explicit preference — leave the doc untouched
+        pageless = mode == "pageless"
+
+    from gdoc.api.docs import set_page_mode
+
+    try:
+        set_page_mode(doc_id, pageless)
+    except Exception as e:  # best-effort: the doc is already created
+        print(f"WARN: could not set page mode: {e}", file=sys.stderr)
+        return None
+
+    # The updateDocumentStyle write bumped the Drive version; re-read it so the
+    # caller seeds state with the post-write baseline. Best-effort: a failed
+    # refresh just falls back to the create-time version (a stale banner is
+    # better than aborting after the doc exists).
+    from gdoc.api.drive import get_file_version
+
+    try:
+        return get_file_version(doc_id).get("version")
+    except Exception:
+        return None
+
+
 def cmd_new(args) -> int:
     """Handler for `gdoc new`."""
     if getattr(args, "file_path", None):
@@ -2556,6 +2631,10 @@ def cmd_new(args) -> int:
     new_id = result["id"]
     version = result.get("version")
     url = result.get("webViewLink", "")
+
+    new_version = _apply_page_mode(args, new_id)
+    if new_version is not None:
+        version = new_version
 
     from gdoc.format import get_output_mode, format_json
 
@@ -2764,6 +2843,18 @@ def build_parser() -> GdocArgumentParser:
         help="Workspace domain hint for the Google account chooser (e.g. company.com)",
     )
     auth_p.set_defaults(func=cmd_auth)
+
+    # config
+    config_p = sub.add_parser(
+        "config", parents=[output_parent],
+        help="Get or set gdoc configuration",
+    )
+    config_p.add_argument(
+        "--page-mode", choices=["pageless", "paged"],
+        help="Default page mode for docs created by `gdoc new` "
+        "(unset = inherit the account default; markdown imports stay paged)",
+    )
+    config_p.set_defaults(func=cmd_config)
 
     # ls
     ls_p = sub.add_parser("ls", parents=[output_parent], help="List files in Drive")
@@ -3252,6 +3343,15 @@ def build_parser() -> GdocArgumentParser:
     new_p.add_argument(
         "--file", dest="file_path",
         help="Create doc from a local markdown file",
+    )
+    new_mode = new_p.add_mutually_exclusive_group()
+    new_mode.add_argument(
+        "--pageless", action="store_true",
+        help="Create pageless (overrides the configured default)",
+    )
+    new_mode.add_argument(
+        "--paged", action="store_true",
+        help="Create paged (overrides the configured default)",
     )
     new_p.set_defaults(func=cmd_new)
 

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -100,6 +100,37 @@ def set_default_account(account: str) -> None:
     _save_config(config)
 
 
+_VALID_PAGE_MODES = ("pageless", "paged")
+
+
+def get_default_page_mode() -> str | None:
+    """Return the configured default page mode for docs created by `gdoc new`.
+
+    'pageless' or 'paged' if the user set one via `gdoc config --page-mode`,
+    else None — meaning "no explicit preference". A None result tells
+    `gdoc new` to leave the doc as the create path produced it: blank docs
+    inherit the account's page-mode default, and markdown-imported docs stay
+    paged. Defaulting to None rather than 'paged' avoids silently overriding a
+    pageless account default on the blank path.
+    """
+    mode = _load_config().get("page_mode")
+    if mode in _VALID_PAGE_MODES:
+        return mode
+    return None
+
+
+def set_default_page_mode(mode: str) -> None:
+    """Set the default page mode used by `gdoc new` when no flag is given."""
+    if mode not in _VALID_PAGE_MODES:
+        raise GdocError(
+            f"Invalid page mode: {mode!r}. Use 'pageless' or 'paged'.",
+            exit_code=3,
+        )
+    config = _load_config()
+    config["page_mode"] = mode
+    _save_config(config)
+
+
 def get_token_path() -> Path:
     """Return the token path for the active account.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.12.0"
+version = "0.13.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_file_mgmt.py
+++ b/tests/test_file_mgmt.py
@@ -11,6 +11,14 @@ from gdoc.notify import ChangeInfo
 from gdoc.util import AuthError, GdocError
 
 
+@pytest.fixture(autouse=True)
+def _stub_apply_page_mode(monkeypatch):
+    """cmd_new applies a page mode via a Docs API call; stub it here so these
+    behavior tests don't touch auth/network. Page-mode behavior is covered in
+    test_page_mode.py."""
+    monkeypatch.setattr("gdoc.cli._apply_page_mode", lambda *a, **k: None)
+
+
 def _make_args(command, **overrides):
     """Build a SimpleNamespace mimicking parsed args."""
     defaults = {

--- a/tests/test_new_file.py
+++ b/tests/test_new_file.py
@@ -10,6 +10,14 @@ from gdoc.cli import cmd_new
 from gdoc.util import GdocError
 
 
+@pytest.fixture(autouse=True)
+def _stub_apply_page_mode(monkeypatch):
+    """cmd_new applies a page mode via a Docs API call; stub it here so these
+    behavior tests don't touch auth/network. Page-mode behavior is covered in
+    test_page_mode.py."""
+    monkeypatch.setattr("gdoc.cli._apply_page_mode", lambda *a, **k: None)
+
+
 API_RESULT = {
     "id": "new_doc_123",
     "name": "From File",

--- a/tests/test_new_file.py
+++ b/tests/test_new_file.py
@@ -138,6 +138,7 @@ class TestNewFromFile:
 
 
 class TestNewFromFileWithImages:
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.docs.get_docs_service")
     @patch("gdoc.api.drive.delete_file")
@@ -155,6 +156,7 @@ class TestNewFromFileWithImages:
         mock_delete,
         mock_docs_svc,
         _update,
+        _version,
         tmp_path,
         capsys,
     ):
@@ -194,6 +196,7 @@ class TestNewFromFileWithImages:
         # Verify temp image cleanup
         mock_delete.assert_called_once_with("temp123")
 
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.docs.get_docs_service")
     @patch("gdoc.api.docs.get_document")
@@ -207,6 +210,7 @@ class TestNewFromFileWithImages:
         mock_get_doc,
         mock_docs_svc,
         _update,
+        _version,
         tmp_path,
         capsys,
     ):
@@ -248,3 +252,108 @@ class TestNewFromFileWithImages:
                     assert uri == "https://example.com/img.png"
                     found_insert = True
         assert found_insert
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 9})
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document")
+    @patch(
+        "gdoc.api.drive.create_doc_from_markdown",
+        return_value=API_RESULT,
+    )
+    def test_state_seeded_with_post_image_version(
+        self,
+        mock_create,
+        mock_get_doc,
+        mock_docs_svc,
+        mock_update,
+        mock_version,
+        tmp_path,
+        capsys,
+    ):
+        """Image inserts bump the Drive version; state must be seeded with
+        the post-insert version, not the create-time one, or the next
+        command reports a spurious "doc edited" change."""
+        md = tmp_path / "doc.md"
+        md.write_text("![alt](https://example.com/img.png)\n")
+
+        mock_get_doc.return_value = {
+            "body": {
+                "content": [{
+                    "paragraph": {
+                        "elements": [{
+                            "startIndex": 1,
+                            "textRun": {
+                                "content": "<<IMG_0>>\n",
+                            },
+                        }],
+                    },
+                }],
+            },
+        }
+        mock_svc = MagicMock()
+        mock_docs_svc.return_value = mock_svc
+        mock_svc.documents().batchUpdate().execute.return_value = {}
+
+        args = _make_args(file_path=str(md))
+        rc = cmd_new(args)
+        assert rc == 0
+
+        mock_version.assert_called_once_with("new_doc_123")
+        mock_update.assert_called_once_with(
+            "new_doc_123", None, command="new",
+            quiet=False, command_version=9,
+        )
+
+    @patch(
+        "gdoc.api.drive.get_file_version",
+        side_effect=RuntimeError("boom"),
+    )
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document")
+    @patch(
+        "gdoc.api.drive.create_doc_from_markdown",
+        return_value=API_RESULT,
+    )
+    def test_image_version_refresh_failure_is_nonfatal(
+        self,
+        mock_create,
+        mock_get_doc,
+        mock_docs_svc,
+        mock_update,
+        _version,
+        tmp_path,
+        capsys,
+    ):
+        """A failed post-image version re-read falls back to the create-time
+        version instead of aborting — the doc already exists."""
+        md = tmp_path / "doc.md"
+        md.write_text("![alt](https://example.com/img.png)\n")
+
+        mock_get_doc.return_value = {
+            "body": {
+                "content": [{
+                    "paragraph": {
+                        "elements": [{
+                            "startIndex": 1,
+                            "textRun": {
+                                "content": "<<IMG_0>>\n",
+                            },
+                        }],
+                    },
+                }],
+            },
+        }
+        mock_svc = MagicMock()
+        mock_docs_svc.return_value = mock_svc
+        mock_svc.documents().batchUpdate().execute.return_value = {}
+
+        args = _make_args(file_path=str(md))
+        rc = cmd_new(args)
+        assert rc == 0
+
+        mock_update.assert_called_once_with(
+            "new_doc_123", None, command="new",
+            quiet=False, command_version=1,
+        )

--- a/tests/test_page_mode.py
+++ b/tests/test_page_mode.py
@@ -1,0 +1,458 @@
+"""Tests for page-mode configuration and application (pageless vs paged).
+
+Covers:
+- gdoc.api.docs.set_page_mode (updateDocumentStyle request + error translation)
+- gdoc.util.get_default_page_mode / set_default_page_mode (config.json)
+- gdoc.cli._apply_page_mode (flag > config > leave-as-is, best-effort,
+  refreshes the state version after a write)
+- gdoc.cli.cmd_config (get/set the default, honoring output mode)
+- cmd_new wiring (blank + --file paths apply the resolved mode)
+- gdoc.cli.build_parser (config subcommand + --pageless/--paged mutex)
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc.cli import _apply_page_mode, cmd_config, cmd_new
+from gdoc.util import AuthError, GdocError
+
+
+def _http_error(status, reason):
+    resp = httplib2.Response({"status": str(status)})
+    err = HttpError(resp, b"")
+    err.reason = reason
+    return err
+
+
+def _call_body(mock_batch_update):
+    call = mock_batch_update.call_args
+    return call.kwargs.get("body", call[1].get("body"))
+
+
+# --- set_page_mode API wrapper ---
+
+class TestSetPageModeAPI:
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_pageless_request_body(self, mock_get):
+        svc = MagicMock()
+        mock_get.return_value = svc
+        from gdoc.api.docs import set_page_mode
+
+        set_page_mode("doc1", pageless=True)
+
+        call = svc.documents().batchUpdate.call_args
+        body = call.kwargs.get("body", call[1].get("body"))
+        req = body["requests"][0]["updateDocumentStyle"]
+        assert (
+            req["documentStyle"]["documentFormat"]["documentMode"] == "PAGELESS"
+        )
+        assert req["fields"] == "documentFormat.documentMode"
+        assert call.kwargs.get(
+            "documentId", call[1].get("documentId")
+        ) == "doc1"
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_paged_request_body(self, mock_get):
+        svc = MagicMock()
+        mock_get.return_value = svc
+        from gdoc.api.docs import set_page_mode
+
+        set_page_mode("doc1", pageless=False)
+
+        body = _call_body(svc.documents().batchUpdate)
+        req = body["requests"][0]["updateDocumentStyle"]
+        assert req["documentStyle"]["documentFormat"]["documentMode"] == "PAGES"
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_translated(self, mock_get):
+        svc = MagicMock()
+        mock_get.return_value = svc
+        svc.documents().batchUpdate().execute.side_effect = _http_error(
+            404, "Not Found",
+        )
+        from gdoc.api.docs import set_page_mode
+
+        with pytest.raises(GdocError, match="Document not found: doc1"):
+            set_page_mode("doc1", pageless=True)
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_401_translated(self, mock_get):
+        svc = MagicMock()
+        mock_get.return_value = svc
+        svc.documents().batchUpdate().execute.side_effect = _http_error(
+            401, "Unauthorized",
+        )
+        from gdoc.api.docs import set_page_mode
+
+        with pytest.raises(AuthError, match="Authentication expired"):
+            set_page_mode("doc1", pageless=True)
+
+
+# --- config get/set ---
+
+class TestPageModeConfig:
+    def test_default_is_none_when_unset(self, tmp_path):
+        # Unset means "no explicit preference": leave the create path's mode
+        # alone rather than forcing paged (which would override a pageless
+        # account default on the blank path).
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            from gdoc.util import get_default_page_mode
+
+            assert get_default_page_mode() is None
+
+    def test_set_and_get_pageless(self, tmp_path):
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            from gdoc.util import (
+                get_default_page_mode,
+                set_default_page_mode,
+            )
+
+            set_default_page_mode("pageless")
+            assert get_default_page_mode() == "pageless"
+
+    def test_set_back_to_paged(self, tmp_path):
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            from gdoc.util import (
+                get_default_page_mode,
+                set_default_page_mode,
+            )
+
+            set_default_page_mode("pageless")
+            set_default_page_mode("paged")
+            assert get_default_page_mode() == "paged"
+
+    def test_invalid_value_rejected(self, tmp_path):
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            from gdoc.util import set_default_page_mode
+
+            with pytest.raises(GdocError) as exc_info:
+                set_default_page_mode("landscape")
+            assert exc_info.value.exit_code == 3
+
+    def test_invalid_stored_value_falls_back_to_none(self, tmp_path):
+        cfg = tmp_path / "config.json"
+        cfg.write_text('{"page_mode": "bogus"}')
+        with patch("gdoc.util.CONFIG_PATH", cfg):
+            from gdoc.util import get_default_page_mode
+
+            assert get_default_page_mode() is None
+
+    def test_preserves_other_config_keys(self, tmp_path):
+        cfg = tmp_path / "config.json"
+        cfg.write_text('{"default_account": "pete@example.com"}')
+        with patch("gdoc.util.CONFIG_PATH", cfg):
+            from gdoc.util import set_default_page_mode
+
+            set_default_page_mode("pageless")
+            data = json.loads(cfg.read_text())
+            assert data["default_account"] == "pete@example.com"
+            assert data["page_mode"] == "pageless"
+
+
+# --- _apply_page_mode resolution ---
+
+class TestApplyPageMode:
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_pageless_flag(self, mock_set, _ver):
+        args = SimpleNamespace(pageless=True, paged=False)
+        _apply_page_mode(args, "doc1")
+        mock_set.assert_called_once_with("doc1", True)
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_paged_flag(self, mock_set, _ver):
+        args = SimpleNamespace(pageless=False, paged=True)
+        _apply_page_mode(args, "doc1")
+        mock_set.assert_called_once_with("doc1", False)
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+    @patch("gdoc.util.get_default_page_mode", return_value="pageless")
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_falls_back_to_config_pageless(self, mock_set, _cfg, _ver):
+        args = SimpleNamespace(pageless=False, paged=False)
+        _apply_page_mode(args, "doc1")
+        mock_set.assert_called_once_with("doc1", True)
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+    @patch("gdoc.util.get_default_page_mode", return_value="paged")
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_falls_back_to_config_paged(self, mock_set, _cfg, _ver):
+        args = SimpleNamespace(pageless=False, paged=False)
+        _apply_page_mode(args, "doc1")
+        mock_set.assert_called_once_with("doc1", False)
+
+    @patch("gdoc.util.get_default_page_mode", return_value=None)
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_no_preference_leaves_doc_untouched(self, mock_set, _cfg):
+        # No flag and no configured default: the doc keeps whatever mode the
+        # create path produced. No API call, no version refresh.
+        args = SimpleNamespace(pageless=False, paged=False)
+        assert _apply_page_mode(args, "doc1") is None
+        mock_set.assert_not_called()
+
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 9})
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_returns_refreshed_version_after_write(self, _set, _ver):
+        # The updateDocumentStyle write bumps the Drive version; the caller
+        # needs the post-write value to seed an accurate state baseline.
+        args = SimpleNamespace(pageless=True, paged=False)
+        assert _apply_page_mode(args, "doc1") == 9
+
+    @patch(
+        "gdoc.api.drive.get_file_version",
+        side_effect=GdocError("refresh failed"),
+    )
+    @patch("gdoc.api.docs.set_page_mode")
+    def test_version_refresh_failure_is_nonfatal(self, _set, _ver):
+        # set_page_mode succeeded (the write landed) but the follow-up
+        # version re-read failed: degrade to None rather than raise. The
+        # caller then keeps the create-time version — a stale banner is
+        # better than aborting after the doc exists.
+        args = SimpleNamespace(pageless=True, paged=False)
+        assert _apply_page_mode(args, "doc1") is None
+
+    @patch("gdoc.api.docs.set_page_mode", side_effect=GdocError("boom"))
+    def test_gdoc_error_is_nonfatal(self, mock_set, capsys):
+        args = SimpleNamespace(pageless=True, paged=False)
+        # Must not raise — the doc is already created.
+        assert _apply_page_mode(args, "doc1") is None
+        assert "could not set page mode" in capsys.readouterr().err
+
+    @patch(
+        "gdoc.api.docs.set_page_mode",
+        side_effect=ConnectionError("network down"),
+    )
+    def test_non_gdoc_error_is_also_nonfatal(self, mock_set, capsys):
+        # set_page_mode only translates HttpError; a transient socket/SSL/auth
+        # failure is not a GdocError. The best-effort guarantee must still hold
+        # (the doc already exists), so it is swallowed too.
+        args = SimpleNamespace(pageless=True, paged=False)
+        assert _apply_page_mode(args, "doc1") is None
+        assert "could not set page mode" in capsys.readouterr().err
+
+
+# --- cmd_config ---
+
+class TestCmdConfig:
+    def test_show_unset(self, tmp_path, capsys):
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            args = SimpleNamespace(page_mode=None)
+            rc = cmd_config(args)
+            assert rc == 0
+            assert capsys.readouterr().out.strip() == "page_mode\tunset"
+
+    def test_show_json(self, tmp_path, capsys):
+        # config opts into --json/--verbose/--plain via output_parent, so it
+        # must honor them like every other subcommand (machine-parseable out).
+        cfg = tmp_path / "config.json"
+        cfg.write_text('{"page_mode": "pageless"}')
+        with patch("gdoc.util.CONFIG_PATH", cfg):
+            args = SimpleNamespace(page_mode=None, json=True)
+            rc = cmd_config(args)
+            assert rc == 0
+            assert json.loads(capsys.readouterr().out) == {
+                "ok": True, "page_mode": "pageless",
+            }
+
+    def test_set_pageless(self, tmp_path, capsys):
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            args = SimpleNamespace(page_mode="pageless")
+            rc = cmd_config(args)
+            assert rc == 0
+            assert "OK page_mode set to: pageless" in capsys.readouterr().err
+            from gdoc.util import get_default_page_mode
+
+            assert get_default_page_mode() == "pageless"
+
+    def test_set_json(self, tmp_path, capsys):
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            args = SimpleNamespace(page_mode="paged", json=True)
+            rc = cmd_config(args)
+            assert rc == 0
+            assert json.loads(capsys.readouterr().out) == {
+                "ok": True, "page_mode": "paged",
+            }
+
+    def test_set_echoes_value_to_stdout(self, tmp_path, capsys):
+        # SET must put the value on stdout (not only the stderr hint), so
+        # `out=$(gdoc config --page-mode pageless)` captures it — the TSV
+        # contract every other write command follows.
+        with patch("gdoc.util.CONFIG_PATH", tmp_path / "config.json"):
+            args = SimpleNamespace(page_mode="pageless")
+            rc = cmd_config(args)
+            assert rc == 0
+            captured = capsys.readouterr()
+            assert captured.out.strip() == "page_mode\tpageless"
+            assert "OK page_mode set to: pageless" in captured.err
+
+
+# --- cmd_new wiring ---
+
+def _new_args(**overrides):
+    defaults = {
+        "command": "new",
+        "title": "T",
+        "folder": None,
+        "file_path": None,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": False,
+        "pageless": False,
+        "paged": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+_BLANK_RESULT = {
+    "id": "doc1",
+    "name": "T",
+    "version": 1,
+    "webViewLink": "https://docs.google.com/document/d/doc1/edit",
+}
+
+
+class TestCmdNewAppliesPageMode:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 2})
+    @patch("gdoc.api.docs.set_page_mode")
+    @patch("gdoc.api.drive.create_doc", return_value=_BLANK_RESULT)
+    def test_blank_new_pageless_flag(self, _create, mock_set, _ver, _update):
+        cmd_new(_new_args(pageless=True))
+        mock_set.assert_called_once_with("doc1", True)
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 2})
+    @patch("gdoc.util.get_default_page_mode", return_value="pageless")
+    @patch("gdoc.api.docs.set_page_mode")
+    @patch("gdoc.api.drive.create_doc", return_value=_BLANK_RESULT)
+    def test_blank_new_uses_config_default(
+        self, _create, mock_set, _cfg, _ver, _update,
+    ):
+        # Mock a *pageless* config default so this actually discriminates
+        # "config was consulted" from "hardcoded fallback": if _apply_page_mode
+        # ignored config, it would pass the opposite value.
+        cmd_new(_new_args())
+        mock_set.assert_called_once_with("doc1", True)
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.util.get_default_page_mode", return_value=None)
+    @patch("gdoc.api.docs.set_page_mode")
+    @patch("gdoc.api.drive.create_doc", return_value=_BLANK_RESULT)
+    def test_blank_new_no_preference_skips_write(
+        self, _create, mock_set, _cfg, _update,
+    ):
+        # No flag, no config: leave the account default in place (no write).
+        cmd_new(_new_args())
+        mock_set.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 5})
+    @patch("gdoc.api.docs.set_page_mode")
+    @patch("gdoc.api.drive.create_doc", return_value=_BLANK_RESULT)
+    def test_state_seeded_with_post_write_version(
+        self, _create, _set, _ver, mock_update,
+    ):
+        # The page-mode write advances the Drive version (create-time was 1);
+        # state must be seeded with the refreshed version (5), not the stale 1,
+        # or the next command reports a spurious "doc edited" change.
+        cmd_new(_new_args(pageless=True))
+        assert mock_update.call_args.kwargs["command_version"] == 5
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 4})
+    @patch("gdoc.api.docs.set_page_mode")
+    @patch(
+        "gdoc.api.drive.create_doc_from_markdown",
+        return_value=_BLANK_RESULT,
+    )
+    def test_markdown_import_applies_pageless_flag(
+        self, _create, mock_set, _ver, mock_update, tmp_path,
+    ):
+        md = tmp_path / "doc.md"
+        md.write_text("# Hi\n")
+        cmd_new(_new_args(file_path=str(md), pageless=True))
+        mock_set.assert_called_once_with("doc1", True)
+        # --file is the feature's motivating path: verify the refreshed
+        # version (4) is folded into the state baseline, not the stale
+        # create-time 1 (guards the same regression as the blank-path test).
+        assert mock_update.call_args.kwargs["command_version"] == 4
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 2})
+    @patch("gdoc.util.get_default_page_mode", return_value="pageless")
+    @patch("gdoc.api.docs.set_page_mode")
+    @patch(
+        "gdoc.api.drive.create_doc_from_markdown",
+        return_value=_BLANK_RESULT,
+    )
+    def test_markdown_import_uses_config_default(
+        self, _create, mock_set, _cfg, _ver, _update, tmp_path,
+    ):
+        # The literal headline use case from the PR Usage block:
+        # `gdoc config --page-mode pageless` then `gdoc new --file notes.md`
+        # (no flag) must flip the imported doc to pageless via the config
+        # default. End-to-end guard for _cmd_new_from_file's wiring.
+        md = tmp_path / "doc.md"
+        md.write_text("# Hi\n")
+        cmd_new(_new_args(file_path=str(md)))
+        mock_set.assert_called_once_with("doc1", True)
+
+
+# --- argparse wiring (build_parser) ---
+
+class TestParserWiring:
+    """Guard the new parser wiring: dropping set_defaults, mistyping the
+    choices, or breaking the mutex group would otherwise ship green (the
+    handler tests bypass build_parser via SimpleNamespace).
+    """
+
+    def test_new_pageless_paged_mutually_exclusive(self):
+        from gdoc.cli import build_parser
+
+        with pytest.raises(SystemExit) as exc:
+            build_parser().parse_args(["new", "--pageless", "--paged", "T"])
+        assert exc.value.code == 3
+
+    def test_new_pageless_flag_parses(self):
+        from gdoc.cli import build_parser, cmd_new
+
+        args = build_parser().parse_args(["new", "--pageless", "T"])
+        assert args.pageless is True
+        assert args.paged is False
+        assert args.func is cmd_new
+
+    def test_new_paged_flag_parses(self):
+        from gdoc.cli import build_parser
+
+        args = build_parser().parse_args(["new", "--paged", "T"])
+        assert args.paged is True
+        assert args.pageless is False
+
+    def test_config_rejects_bad_page_mode(self):
+        from gdoc.cli import build_parser
+
+        with pytest.raises(SystemExit) as exc:
+            build_parser().parse_args(["config", "--page-mode", "landscape"])
+        assert exc.value.code == 3
+
+    def test_config_dispatches(self):
+        from gdoc.cli import build_parser, cmd_config
+
+        args = build_parser().parse_args(["config", "--page-mode", "pageless"])
+        assert args.func is cmd_config
+        assert args.page_mode == "pageless"
+
+    def test_config_no_args_dispatches(self):
+        from gdoc.cli import build_parser, cmd_config
+
+        args = build_parser().parse_args(["config"])
+        assert args.func is cmd_config
+        assert args.page_mode is None

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Why

Docs created through Drive's markdown importer (`gdoc new --file`) always come out **paged**, even when the Google account's default is pageless — so docs made from real content never match a pageless preference. Blank `gdoc new` inherits the account default; the import path doesn't. Verified empirically: markdown import → `documentMode: PAGES`, blank create → `PAGELESS`.

## What

`gdoc new` can now apply an explicit page mode after creating the doc, with an optional persisted default (mirrors the existing `default_account` pattern in `util.py`):

- **`--pageless` / `--paged`** flags on `gdoc new`.
- **`gdoc config --page-mode {pageless,paged}`** — new subcommand persisting the default in `~/.config/gdoc/config.json` (honors `--json`/`--verbose`/`--plain`). Bare `gdoc config` prints the current value (`unset` when none).
- **`set_page_mode`** helper in `api/docs.py`: one `updateDocumentStyle` request targeting `documentFormat.documentMode`.

**Resolution order: flag > config > leave-as-is.** With no flag and no configured default, the doc is left exactly as the create path produced it — blank `gdoc new` keeps inheriting the account default, and markdown imports stay paged. The feature never silently overrides an account preference and is fully non-breaking; it only writes a mode when explicitly asked (per-doc flag or persisted config).

Best-effort: a page-mode set failure warns (`WARN:`) on stderr but does **not** fail doc creation — the doc already exists at that point. When a mode is written, the `updateDocumentStyle` call advances the doc's Drive version, so the new version is re-read and folded into the awareness-state baseline — otherwise the next command would report a spurious "doc edited" change.

## Usage

```bash
gdoc config --page-mode pageless        # persist a default
gdoc new "Doc" --file notes.md          # now pageless
gdoc new "Doc" --file notes.md --paged  # per-doc override
```

## Notes for review

- **Design call — best-effort vs. persistent failures.** `_apply_page_mode` catches every exception so `new` never aborts after the doc already exists. The trade-off: if the token lacks the Docs scope, `updateDocumentStyle` 403s every time and `gdoc new --pageless` silently no-ops (exit 0), with no `page_mode` field in `--json` for a caller to check. Transient blips should be swallowed; a persistent auth error arguably should surface. Happy to change this if you have a preference.
- **Relies on `documentStyle.documentFormat.documentMode`**, discovered empirically — it doesn't appear in the public Docs API v1 `DocumentStyle` reference. If Google ever renames it, the feature degrades silently to a stderr `WARN:` (tests mock the API, so they wouldn't catch it).

## Testing

- `tests/test_page_mode.py` (36 tests): API-helper request body + error translation, config get/set (incl. `--json`), flag > config > leave-as-is resolution, best-effort failure paths, version-refresh and its failure branch, `cmd_new` wiring for blank and `--file`, and parser wiring (mutex, choices).
- Full suite (1191 tests) passes locally; no new lint errors.
- Verified end-to-end against the live Docs API: `--pageless` → `PAGELESS`, `--paged`/config=paged → `PAGES`, no preference → doc left as created.
- Reviewed pre-submission with a multi-agent review pass (full trail on our fork: https://github.com/jpaddison3/gdoc/pull/3); 12 findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
