### PR TITLE
Preserve headings in per-tab cat export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Per-tab `cat` now preserves headings.** `cat --tab` / `cat --all-tabs`
+  built their output from a plain-text extractor that ignored
+  `paragraphStyle`, so headings came back as plain paragraphs (the whole-doc
+  Drive export already emitted `#` headings). A read-modify-write cycle
+  through `cat --tab` → `edit`/`insert` therefore silently demoted the
+  previous heading to body text. `get_tab_text(..., markdown=True)` now
+  prefixes heading paragraphs with the matching number of `#` marks, and
+  default `cat --tab`/`--all-tabs` request it. `cat --plain --tab` is
+  unchanged — it still returns the verbatim text `edit` matches against.
+
 ## [0.12.0] — 2026-06-22
 
 ### Added

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -135,17 +135,36 @@ def count_document_tabs(doc_id: str) -> int:
     return len(flatten_tabs(doc.get("tabs", [])))
 
 
-def get_tab_text(tab: dict) -> str:
-    """Extract plain text from a tab's body content.
+def get_tab_text(tab: dict, markdown: bool = False) -> str:
+    """Extract text from a tab's body content.
 
-    Handles paragraphs and tables (tab-joined cells per row).
+    Handles paragraphs and tables (tab-joined cells per row). When
+    *markdown* is True, heading paragraphs are prefixed with the matching
+    number of ``#`` marks so a per-tab export round-trips through
+    ``insert``/``edit`` without silently demoting headings to plain
+    paragraphs. The whole-doc Drive export already emits ``#`` headings;
+    this brings the per-tab path (which builds markdown by hand) into
+    line. With *markdown* False (the ``--plain`` path) text is returned
+    verbatim -- the matchable form ``gdoc edit`` searches against.
     """
     body = tab.get("body", {})
     content = body.get("content", [])
     parts = []
     for element in content:
         if "paragraph" in element:
-            parts.append(_extract_paragraphs_text([element]))
+            text = _extract_paragraphs_text([element])
+            if markdown and text.strip():
+                named_style = (
+                    element["paragraph"]
+                    .get("paragraphStyle", {})
+                    .get("namedStyleType", "")
+                )
+                level = _HEADING_LEVELS.get(named_style)
+                if level:
+                    # lstrip leading spaces/tabs so the "# " prefix can't
+                    # stack a widening gap across read->write round-trips.
+                    text = "#" * level + " " + text.lstrip(" \t")
+            parts.append(text)
         elif "table" in element:
             table = element["table"]
             for row in table.get("tableRows", []):

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -330,6 +330,10 @@ def cmd_cat(args) -> int:
 
         tabs = get_document_tabs(doc_id)
 
+        # Default view renders markdown (headings survive round-trips);
+        # --plain returns the verbatim text gdoc edit matches against.
+        want_md = not getattr(args, "plain", False)
+
         if tab:
             # Match by title (case-insensitive) first, then by ID
             match = None
@@ -344,7 +348,7 @@ def cmd_cat(args) -> int:
                         break
             if match is None:
                 raise GdocError(f"tab not found: {tab}", exit_code=3)
-            content = get_tab_text(match)
+            content = get_tab_text(match, markdown=want_md)
             if no_images:
                 from gdoc.mdimport import strip_images
                 content = strip_images(content)
@@ -361,7 +365,7 @@ def cmd_cat(args) -> int:
             parts = []
             for t in tabs:
                 parts.append(f"=== Tab: {t['title']} ===\n")
-                parts.append(get_tab_text(t))
+                parts.append(get_tab_text(t, markdown=want_md))
             content = "".join(parts)
             if no_images:
                 from gdoc.mdimport import strip_images

--- a/tests/test_cat_tabs.py
+++ b/tests/test_cat_tabs.py
@@ -145,6 +145,32 @@ class TestCatTab:
             mock_export.assert_not_called()
         mock_tabs.assert_called_once_with("abc123")
 
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_tab_text", return_value="text\n")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_default_requests_markdown(
+        self, _svc, mock_tabs, mock_text, _pf, _update,
+    ):
+        """Default --tab renders markdown so headings survive round-trips."""
+        mock_tabs.return_value = [_tab("t1", "Notes")]
+        cmd_cat(_make_args(tab="Notes"))
+        assert mock_text.call_args.kwargs.get("markdown") is True
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_tab_text", return_value="text\n")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_plain_requests_verbatim(
+        self, _svc, mock_tabs, mock_text, _pf, _update,
+    ):
+        """--plain --tab returns the verbatim, matchable text (no '#')."""
+        mock_tabs.return_value = [_tab("t1", "Notes")]
+        cmd_cat(_make_args(tab="Notes", plain=True))
+        assert mock_text.call_args.kwargs.get("markdown") is False
+
 
 class TestCatAllTabs:
     @patch("gdoc.state.update_state_after_command")

--- a/tests/test_tabs_api.py
+++ b/tests/test_tabs_api.py
@@ -260,6 +260,42 @@ class TestGetTabText:
         ]}}
         assert get_tab_text(tab) == ""
 
+    def _heading(self, text, style):
+        return {"paragraph": {
+            "paragraphStyle": {"namedStyleType": style},
+            "elements": [{"textRun": {"content": text}}],
+        }}
+
+    def test_heading_plain_by_default(self):
+        # Default (markdown=False) is the matchable form gdoc edit uses:
+        # no "#" prefix, so a heading reads back as its bare text.
+        tab = {"body": {"content": [self._heading("Title\n", "HEADING_1")]}}
+        assert get_tab_text(tab) == "Title\n"
+
+    def test_heading_markdown_prefix_levels(self):
+        tab = {"body": {"content": [
+            self._heading("One\n", "HEADING_1"),
+            self._heading("Two\n", "HEADING_2"),
+            self._heading("Six\n", "HEADING_6"),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == "# One\n## Two\n###### Six\n"
+
+    def test_heading_markdown_leaves_normal_text(self):
+        tab = {"body": {"content": [
+            self._heading("Body\n", "NORMAL_TEXT"),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == "Body\n"
+
+    def test_heading_markdown_collapses_leading_space(self):
+        # A stored leading space must not stack into "##  Two"; lstrip
+        # keeps the round-trip stable.
+        tab = {"body": {"content": [self._heading(" Two\n", "HEADING_2")]}}
+        assert get_tab_text(tab, markdown=True) == "## Two\n"
+
+    def test_heading_markdown_ignores_blank_heading(self):
+        tab = {"body": {"content": [self._heading("\n", "HEADING_1")]}}
+        assert get_tab_text(tab, markdown=True) == "\n"
+
 
 class TestResolveTab:
     def _tabs(self):


### PR DESCRIPTION
## Problem

`cat --tab` / `cat --all-tabs` build their output from `get_tab_text()`, a plain-text extractor that reads only `textRun` content and ignores `paragraphStyle.namedStyleType`. Headings in a tab therefore come back as plain paragraphs — even though the whole-doc Drive export (`cat` without `--tab`) already emits `#` headings.

That makes a read-modify-write cycle lossy. Appending a new dated section above the previous one via `cat --tab` → `edit --tab`:

1. `cat --tab` reports the previous heading `# 2026-06-15` as plain `2026-06-15`.
2. You write it back as the trailing anchor that keeps the old entry below the new one.
3. `edit` renders the replacement as markdown, but with no `#` the previously-heading paragraph is rebuilt as body text — silently demoted.

`toc` still lists it as a heading, so the regression is easy to miss.

## Fix

`get_tab_text(tab, markdown=False)` gains a `markdown` flag. When `True`, heading paragraphs are prefixed with the matching number of `#` marks (reusing the existing `_HEADING_LEVELS` map; leading spaces/tabs are `lstrip`ped so the prefix can't stack a widening gap across round-trips). `cmd_cat` passes:

- `markdown=True` for the default `cat --tab` / `--all-tabs` view, so headings survive round-trips and match the whole-doc export.
- `markdown=False` for `cat --plain --tab`, which stays the verbatim text `edit` matches against.

Default is `markdown=False`, so `get_tab_text`'s signature stays backward-compatible and existing call sites/tests are unchanged.

**Scope:** heading levels only — the structural element behind the demotion. Bold/italic/lists in a tab are still flattened by the per-tab *reader*; that's a separate, larger gap from the richer per-tab *write* support added in 0.12.0.

## Tests

- `tests/test_tabs_api.py`: H1–H6 prefixes, plain default (no prefix), `NORMAL_TEXT` untouched, leading-space collapse, blank-heading no-op.
- `tests/test_cat_tabs.py`: default `--tab` requests `markdown=True`; `--plain --tab` requests `markdown=False`.

Full suite: **1162 passed**; `ruff` clean on changed lines.
