### PR TITLE
Render inline formatting and lists in per-tab cat export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable changes to `gdoc` are documented here. This project follows
   prefixes heading paragraphs with the matching number of `#` marks, and
   default `cat --tab`/`--all-tabs` request it. `cat --plain --tab` is
   unchanged — it still returns the verbatim text `edit` matches against.
+- **Per-tab `cat` now renders inline formatting and lists.** Extending the
+  markdown export above, `cat --tab` / `cat --all-tabs` now emit `**bold**`,
+  `*italic*`, `~~strikethrough~~`, `[text](url)` links, and bullet/numbered
+  lists (nested, two spaces per level, ordered items counted 1, 2, 3 —
+  ordered vs bullet read from the tab's list glyph map). Previously these all
+  flattened to plain text on read even though `insert`/`write --tab` could
+  produce them. `cat --plain --tab` remains verbatim. Not yet rendered:
+  inline code, blockquotes, and markdown tables (tables still export as
+  tab-separated cells).
 
 ## [0.12.0] — 2026-06-22
 

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -105,6 +105,9 @@ def flatten_tabs(tabs: list[dict], _level: int = 0) -> list[dict]:
             "index": props.get("index", 0),
             "nesting_level": _level,
             "body": doc_tab.get("body", {}),
+            # listId -> list definition; needed to tell ordered from bullet
+            # lists when rendering a tab as markdown.
+            "lists": doc_tab.get("lists", {}),
         })
         for child in tab.get("childTabs", []):
             result.extend(flatten_tabs([child], _level=_level + 1))
@@ -135,37 +138,139 @@ def count_document_tabs(doc_id: str) -> int:
     return len(flatten_tabs(doc.get("tabs", [])))
 
 
+def _list_is_ordered(lists: dict, list_id: str, level: int) -> bool:
+    """Whether a list level is ordered (numbered) rather than a bullet.
+
+    A Docs list level carries a ``glyphType`` (DECIMAL/ALPHA/ROMAN/...) when
+    ordered and a ``glyphSymbol`` (a bullet character) when not.
+    """
+    levels = (
+        lists.get(list_id, {})
+        .get("listProperties", {})
+        .get("nestingLevels", [])
+    )
+    if 0 <= level < len(levels):
+        glyph_type = levels[level].get("glyphType", "")
+        return bool(glyph_type) and glyph_type != "GLYPH_TYPE_UNSPECIFIED"
+    return False
+
+
+def _style_run_markdown(content: str, style: dict) -> str:
+    """Wrap one text run's content in markdown emphasis / link syntax.
+
+    Surrounding spaces and the trailing paragraph newline are kept outside
+    the markers (``** bold **`` is not valid markdown), so only the visible
+    core is wrapped. Emphasis nests as ``***bold italic***`` and
+    ``~~struck~~``; a link becomes ``[text](url)``.
+    """
+    newline = ""
+    text = content
+    if text.endswith("\n"):
+        text, newline = text[:-1], "\n"
+    if not text.strip():
+        return content
+    lead = text[: len(text) - len(text.lstrip(" "))]
+    trail = text[len(text.rstrip(" ")):]
+    core = text.strip(" ")
+
+    link = (style.get("link") or {}).get("url")
+    if link:
+        core = f"[{core}]({link})"
+    else:
+        if style.get("bold") and style.get("italic"):
+            core = f"***{core}***"
+        elif style.get("bold"):
+            core = f"**{core}**"
+        elif style.get("italic"):
+            core = f"*{core}*"
+        if style.get("strikethrough"):
+            core = f"~~{core}~~"
+    return f"{lead}{core}{trail}{newline}"
+
+
+def _runs_markdown(elements: list[dict]) -> str:
+    """Join a paragraph's text runs, styling each as markdown."""
+    parts = []
+    for pe in elements:
+        text_run = pe.get("textRun")
+        if text_run is None:
+            continue
+        content = text_run.get("content", "")
+        if content:
+            parts.append(
+                _style_run_markdown(content, text_run.get("textStyle", {}))
+            )
+    return "".join(parts)
+
+
+def _paragraph_markdown(
+    paragraph: dict, lists: dict, ordered_counters: dict
+) -> str:
+    """Render one paragraph as markdown: headings, list items, inline styles.
+
+    ``ordered_counters`` (nesting level -> running ordinal) is carried across
+    paragraphs by the caller so numbered lists count 1, 2, 3.
+    """
+    text = _runs_markdown(paragraph.get("elements", []))
+    newline = ""
+    if text.endswith("\n"):
+        text, newline = text[:-1], "\n"
+
+    bullet = paragraph.get("bullet")
+    if bullet is not None and text.strip():
+        level = bullet.get("nestingLevel", 0)
+        # A shallower item ends any deeper numbering.
+        for deeper in [lvl for lvl in ordered_counters if lvl > level]:
+            del ordered_counters[deeper]
+        indent = "  " * level  # 2 columns per level (matches the md parser)
+        if _list_is_ordered(lists, bullet.get("listId", ""), level):
+            ordered_counters[level] = ordered_counters.get(level, 0) + 1
+            marker = f"{ordered_counters[level]}."
+        else:
+            ordered_counters.pop(level, None)
+            marker = "-"
+        item = text.lstrip(" \t")
+        return f"{indent}{marker} {item}{newline}"
+
+    # Not a list item: numbering restarts at the next list.
+    ordered_counters.clear()
+
+    named_style = paragraph.get("paragraphStyle", {}).get("namedStyleType", "")
+    level = _HEADING_LEVELS.get(named_style)
+    if level and text.strip():
+        # lstrip leading spaces/tabs so the "# " prefix can't stack a
+        # widening gap across read->write round-trips.
+        return "#" * level + " " + text.lstrip(" \t") + newline
+    return text + newline
+
+
 def get_tab_text(tab: dict, markdown: bool = False) -> str:
     """Extract text from a tab's body content.
 
     Handles paragraphs and tables (tab-joined cells per row). When
-    *markdown* is True, heading paragraphs are prefixed with the matching
-    number of ``#`` marks so a per-tab export round-trips through
-    ``insert``/``edit`` without silently demoting headings to plain
-    paragraphs. The whole-doc Drive export already emits ``#`` headings;
-    this brings the per-tab path (which builds markdown by hand) into
-    line. With *markdown* False (the ``--plain`` path) text is returned
-    verbatim -- the matchable form ``gdoc edit`` searches against.
+    *markdown* is True, the per-tab export (which builds markdown by hand,
+    unlike the whole-doc Drive export) renders headings (``#``), bullet and
+    numbered lists (nested, 2 spaces per level), and inline emphasis
+    (``**bold**``, ``*italic*``, ``~~strike~~``) and ``[links](url)``, so a
+    tab round-trips through ``insert``/``edit`` without losing structure.
+    With *markdown* False (the ``--plain`` path) text is returned verbatim
+    -- the matchable form ``gdoc edit`` searches against.
     """
     body = tab.get("body", {})
     content = body.get("content", [])
+    lists = tab.get("lists", {}) if markdown else {}
     parts = []
+    ordered_counters: dict = {}
     for element in content:
         if "paragraph" in element:
-            text = _extract_paragraphs_text([element])
-            if markdown and text.strip():
-                named_style = (
-                    element["paragraph"]
-                    .get("paragraphStyle", {})
-                    .get("namedStyleType", "")
-                )
-                level = _HEADING_LEVELS.get(named_style)
-                if level:
-                    # lstrip leading spaces/tabs so the "# " prefix can't
-                    # stack a widening gap across read->write round-trips.
-                    text = "#" * level + " " + text.lstrip(" \t")
-            parts.append(text)
+            if not markdown:
+                parts.append(_extract_paragraphs_text([element]))
+                continue
+            parts.append(
+                _paragraph_markdown(element["paragraph"], lists, ordered_counters)
+            )
         elif "table" in element:
+            ordered_counters.clear()
             table = element["table"]
             for row in table.get("tableRows", []):
                 cells = []

--- a/tests/test_tabs_api.py
+++ b/tests/test_tabs_api.py
@@ -60,7 +60,7 @@ class TestFlattenTabs:
         assert len(result) == 1
         assert result[0] == {
             "id": "t1", "title": "Tab 1", "index": 0,
-            "nesting_level": 0, "body": {"content": []},
+            "nesting_level": 0, "body": {"content": []}, "lists": {},
         }
 
     def test_multiple_tabs(self):
@@ -295,6 +295,109 @@ class TestGetTabText:
     def test_heading_markdown_ignores_blank_heading(self):
         tab = {"body": {"content": [self._heading("\n", "HEADING_1")]}}
         assert get_tab_text(tab, markdown=True) == "\n"
+
+
+def _run(text, **style):
+    return {"textRun": {"content": text, "textStyle": style}}
+
+
+def _para(*runs, style="NORMAL_TEXT", bullet=None):
+    p = {
+        "paragraphStyle": {"namedStyleType": style},
+        "elements": list(runs),
+    }
+    if bullet is not None:
+        p["bullet"] = bullet
+    return {"paragraph": p}
+
+
+class TestGetTabTextInlineMarkdown:
+    def test_bold(self):
+        tab = {"body": {"content": [_para(_run("hi "), _run("there\n", bold=True))]}}
+        assert get_tab_text(tab, markdown=True) == "hi **there**\n"
+
+    def test_italic(self):
+        tab = {"body": {"content": [_para(_run("a "), _run("b\n", italic=True))]}}
+        assert get_tab_text(tab, markdown=True) == "a *b*\n"
+
+    def test_bold_italic(self):
+        tab = {"body": {"content": [_para(_run("x\n", bold=True, italic=True))]}}
+        assert get_tab_text(tab, markdown=True) == "***x***\n"
+
+    def test_strikethrough(self):
+        tab = {"body": {"content": [_para(_run("gone\n", strikethrough=True))]}}
+        assert get_tab_text(tab, markdown=True) == "~~gone~~\n"
+
+    def test_link_uses_url_not_underline(self):
+        # Docs auto-underlines links; the underline flag must not leak out.
+        run = _run("site\n", underline=True, link={"url": "https://e.com"})
+        tab = {"body": {"content": [_para(run)]}}
+        assert get_tab_text(tab, markdown=True) == "[site](https://e.com)\n"
+
+    def test_spaces_kept_outside_markers(self):
+        tab = {"body": {"content": [_para(_run(" b \n", bold=True))]}}
+        assert get_tab_text(tab, markdown=True) == " **b** \n"
+
+    def test_plain_mode_ignores_styles(self):
+        tab = {"body": {"content": [_para(_run("x\n", bold=True))]}}
+        assert get_tab_text(tab) == "x\n"
+
+
+class TestGetTabTextListMarkdown:
+    _BULLETS = {"L1": {"listProperties": {"nestingLevels": [
+        {"glyphSymbol": "●"}, {"glyphSymbol": "○"},
+    ]}}}
+    _ORDERED = {"L2": {"listProperties": {"nestingLevels": [
+        {"glyphType": "DECIMAL"}, {"glyphType": "ALPHA"},
+    ]}}}
+
+    def test_bullet_list(self):
+        tab = {"lists": self._BULLETS, "body": {"content": [
+            _para(_run("one\n"), bullet={"listId": "L1"}),
+            _para(_run("two\n"), bullet={"listId": "L1"}),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == "- one\n- two\n"
+
+    def test_ordered_list_counts(self):
+        tab = {"lists": self._ORDERED, "body": {"content": [
+            _para(_run("a\n"), bullet={"listId": "L2"}),
+            _para(_run("b\n"), bullet={"listId": "L2"}),
+            _para(_run("c\n"), bullet={"listId": "L2"}),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == "1. a\n2. b\n3. c\n"
+
+    def test_nested_bullet_indented(self):
+        tab = {"lists": self._BULLETS, "body": {"content": [
+            _para(_run("top\n"), bullet={"listId": "L1", "nestingLevel": 0}),
+            _para(_run("sub\n"), bullet={"listId": "L1", "nestingLevel": 1}),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == "- top\n  - sub\n"
+
+    def test_ordered_numbering_resets_after_break(self):
+        tab = {"lists": self._ORDERED, "body": {"content": [
+            _para(_run("a\n"), bullet={"listId": "L2"}),
+            _para(_run("b\n"), bullet={"listId": "L2"}),
+            _para(_run("\n")),  # blank paragraph ends the list
+            _para(_run("a\n"), bullet={"listId": "L2"}),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == "1. a\n2. b\n\n1. a\n"
+
+    def test_nested_ordered_counters_independent(self):
+        tab = {"lists": self._ORDERED, "body": {"content": [
+            _para(_run("one\n"), bullet={"listId": "L2", "nestingLevel": 0}),
+            _para(_run("a\n"), bullet={"listId": "L2", "nestingLevel": 1}),
+            _para(_run("b\n"), bullet={"listId": "L2", "nestingLevel": 1}),
+            _para(_run("two\n"), bullet={"listId": "L2", "nestingLevel": 0}),
+        ]}}
+        assert get_tab_text(tab, markdown=True) == (
+            "1. one\n  1. a\n  2. b\n2. two\n"
+        )
+
+    def test_lists_ignored_in_plain_mode(self):
+        tab = {"lists": self._BULLETS, "body": {"content": [
+            _para(_run("one\n"), bullet={"listId": "L1"}),
+        ]}}
+        assert get_tab_text(tab) == "one\n"
 
 
 class TestResolveTab:


### PR DESCRIPTION
Follow-up to #31 (per-tab heading export). Same `markdown=True` path, now covering inline formatting and lists.

## Problem

The per-tab reader (`get_tab_text`) behind `cat --tab` / `cat --all-tabs` only concatenates `textRun` content, so inline emphasis and lists flatten to plain text on read — even though `insert` / `write --tab` (0.12.0) can *produce* them. Round-tripping a tab through `cat` loses `**bold**`, `*italic*`, `~~strike~~`, links, and every bullet/number.

## Fix

In `markdown=True` mode `get_tab_text` now renders:

- **Inline** from `textRun.textStyle`: `**bold**`, `*italic*`, `***bold italic***`, `~~strike~~`, and `[text](url)` (a link's auto-underline is ignored). Surrounding spaces and the paragraph newline stay outside the markers.
- **Lists** from `paragraph.bullet`: `-` bullets and `1.`/`2.`/`3.` numbered items, nested two spaces per level (matching the parser's `_list_level`), ordered-vs-bullet resolved from the tab's list glyph map (`glyphType` = ordered, `glyphSymbol` = bullet). `flatten_tabs` now carries each tab's `lists` map for this.

`markdown=False` (`--plain`) is untouched — still the verbatim text `edit` matches against — and `get_tab_text`'s default stays `False`, so other callers are unchanged.

**Not yet handled** (noted in the changelog): inline code, blockquotes, and markdown tables (tables still export as tab-separated cells). Nested lists render only when the stored paragraphs carry `bullet.nestingLevel`; `insert`'s own nested-list write gap (noted in 0.12.0) is separate.

## Tests

`tests/test_tabs_api.py`: bold / italic / bold-italic / strikethrough, link (underline ignored), spaces-outside-markers, plain-mode passthrough; bullet lists, ordered counting, nested indent, numbering reset after a break, independent per-level ordered counters, plain-mode passthrough.

Full suite: **1175 passed**; `ruff` clean (incl. no Python 3.10 f-string escape issues).
