### PR TITLE
feat: export to PDF/DOCX/HTML and edit images in existing docs (0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,27 @@ All notable changes to `gdoc` are documented here. This project follows
   refused before any upload) or a public image URL, anchored
   by `--after TEXT` (retries with smart-quote folding; ambiguous anchors
   are refused), a raw `--index`, or `--end`; `--width`/`--height` set the
-  display size in points. Multi-tab documents require `--tab`, and the
+  display size in points (validated as positive finite numbers before
+  anything is uploaded). Multi-tab documents require `--tab`, and the
   write is pinned to the read revision via
   `writeControl.requiredRevisionId`. Local files are uploaded to Drive as
   a temporary public-read file and deleted after the insert — a failed
-  cleanup warns with the file ID instead of leaving the exposure silent.
-  Prints the new image object ID. (#35)
+  cleanup warns with the file ID instead of leaving the exposure silent,
+  and if a Workspace policy blocks the public share the just-created
+  file is deleted rather than orphaned. Prints the new image object
+  ID. (#35)
 - **`gdoc replace-image` — swap an image's content by object ID.**
   `gdoc replace-image DOC OBJECT_ID new.png` replaces the image content
   in place (IDs from `gdoc images`), keeping the existing display size
   (CENTER_CROP). The owning tab is located automatically, including
   nested child tabs. (#35)
+
+### Fixed
+- **`gdoc images` now lists objects from every tab.** It previously
+  walked only the legacy first-tab fields, so images in other tabs were
+  invisible — including to the `replace-image` workflow that points
+  users at it for object IDs. Entries gain a `tab` field (`--plain`
+  appends it as a final column).
 
 ## [0.17.0] — 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] — 2026-08-07
+
+### Added
+- **`gdoc export` — render a document to PDF, DOCX, and more.**
+  `gdoc export DOC --out report.pdf` writes a rendered artifact via Drive
+  export; the format is inferred from the `--out` extension or set with
+  `--format` (`pdf`, `docx`, `odt`, `epub`, `html`, `md`, `txt`, `rtf`).
+  Binary formats require `--out` (no PDF bytes to a terminal); text
+  formats print to stdout without it. Exports cover the whole document,
+  all tabs included. (#35)
+- **`gdoc insert-image` — add an image to an existing document.**
+  Takes a local file (PNG/JPG/GIF/WebP) or a public image URL, anchored
+  by `--after TEXT` (retries with smart-quote folding; ambiguous anchors
+  are refused), a raw `--index`, or `--end`; `--width`/`--height` set the
+  display size in points. Multi-tab documents require `--tab`, and the
+  write is pinned to the read revision via
+  `writeControl.requiredRevisionId`. Local files are uploaded to Drive as
+  a temporary public-read file and deleted after the insert — a failed
+  cleanup warns with the file ID instead of leaving the exposure silent.
+  Prints the new image object ID. (#35)
+- **`gdoc replace-image` — swap an image's content by object ID.**
+  `gdoc replace-image DOC OBJECT_ID new.png` replaces the image content
+  in place (IDs from `gdoc images`), keeping the existing display size
+  (CENTER_CROP). The owning tab is located automatically, including
+  nested child tabs. (#35)
+
 ## [0.14.0] — 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to `gdoc` are documented here. This project follows
   formats print to stdout without it. Exports cover the whole document,
   all tabs included. (#35)
 - **`gdoc insert-image` — add an image to an existing document.**
-  Takes a local file (PNG/JPG/GIF/WebP) or a public image URL, anchored
+  Takes a local file (PNG/JPG/GIF — the Docs API rejects WebP, so it is
+  refused before any upload) or a public image URL, anchored
   by `--after TEXT` (retries with smart-quote folding; ambiguous anchors
   are refused), a raw `--index`, or `--end`; `--width`/`--height` set the
   display size in points. Multi-tab documents require `--tab`, and the

--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ gdoc images DOC_ID
 # Download images to a local directory
 gdoc images --download /tmp/imgs DOC_ID
 
+# Export a rendered PDF/DOCX/HTML file
+gdoc export DOC_ID --out report.pdf
+
+# Insert an image into an existing doc
+gdoc insert-image DOC_ID diagram.png --after "Architecture"
+
+# Replace an image's content in place (IDs from `gdoc images`)
+gdoc replace-image DOC_ID kix.abc123 diagram-v2.png
+
 # Read a spreadsheet (markdown table; --plain for TSV)
 gdoc cat SHEET_ID
 
@@ -178,6 +187,7 @@ gdoc cat 1aBcDeFg...
 | `info DOC` | Show title, owner, modified date, word count (tab list for spreadsheets) |
 | `ls [FOLDER]` | List files in Drive root or a folder (`--type docs\|sheets\|all`) |
 | `images DOC` | List images, charts, and drawings (`--download DIR` to save locally) |
+| `export DOC --out FILE` | Render to `pdf`, `docx`, `odt`, `epub`, `html`, `md`, `txt`, or `rtf` (format inferred from the extension, or `--format`; all tabs included) |
 | `find QUERY` | Search files by name or content |
 
 ### Writing
@@ -189,6 +199,8 @@ gdoc cat 1aBcDeFg...
 | `write DOC FILE` | Overwrite document from a local markdown file |
 | `cells SHEET RANGE` | Write values into a spreadsheet range (`-v VALUE` per cell, `--file rows.csv`, `--stdin` for TSV; `--append` adds rows, `--user-entered` parses formulas/dates) |
 | `new TITLE` | Create a blank document (`--folder` to specify location, `--file` to import markdown with images) |
+| `insert-image DOC IMG` | Insert a local image or public URL (`--after TEXT`, `--index N`, or `--end`; `--tab` for multi-tab docs; `--width`/`--height` in points) |
+| `replace-image DOC ID IMG` | Swap an image's content in place, keeping its size (IDs from `gdoc images`) |
 | `cp DOC TITLE` | Duplicate a document |
 
 ### Revisions & diffs
@@ -485,6 +497,27 @@ gdoc images --download /tmp/imgs DOC kix.abc
 ```
 
 Drawings cannot be exported (the Google API exposes no content for them). Charts are rendered as images via their content URI. Downloaded files can be viewed directly by multimodal AI agents.
+
+## Image editing
+
+Add an image to an existing document, or swap one's content in place:
+
+```bash
+# Insert after anchor text (two matches = error; use a longer anchor)
+gdoc insert-image DOC diagram.png --after "Architecture"
+
+# Append at the end of a tab, with an explicit display size
+gdoc insert-image DOC https://example.org/chart.png --tab Notes --end --width 400
+
+# Replace an image's content, keeping its current size (center-cropped)
+gdoc replace-image DOC kix.abc123 diagram-v2.png
+```
+
+Multi-tab documents require `--tab` so the insert can't land in the wrong
+tab. Local files are uploaded to Drive as a temporary public-read file
+(Google's servers fetch the image by URL), then deleted immediately after
+the insert — if that cleanup ever fails, gdoc warns with the file ID
+instead of leaving the exposure silent.
 
 ## Command allowlist
 

--- a/README.md
+++ b/README.md
@@ -514,7 +514,9 @@ gdoc replace-image DOC kix.abc123 diagram-v2.png
 ```
 
 Multi-tab documents require `--tab` so the insert can't land in the wrong
-tab. Local files are uploaded to Drive as a temporary public-read file
+tab. Local files must be PNG, JPG, or GIF — the Docs API rejects WebP, so
+gdoc refuses it up front (markdown import via `new --file` still accepts
+WebP). Local files are uploaded to Drive as a temporary public-read file
 (Google's servers fetch the image by URL), then deleted immediately after
 the insert — if that cleanup ever fails, gdoc warns with the file ID
 instead of leaving the exposure silent.

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -878,27 +878,13 @@ def _insert_table(
         _translate_http_error(e, doc_id)
 
 
-def list_inline_objects(doc_id: str) -> list[dict]:
-    """List all inline and positioned objects in a document.
+def _collect_object_refs(body: dict) -> list[tuple[str, int, str]]:
+    """Walk body.content for object references.
 
-    Walks body.content for inlineObjectElement and positionedObjectId
-    references, joins with document.inlineObjects and positionedObjects
-    maps, and classifies each object.
-
-    Returns list of dicts with id, type, title, description, dimensions,
-    content_uri, source_uri, start_index, and chart metadata.
+    Returns (object_id, start_index, source) tuples, where source is
+    "inline" or "positioned".
     """
-    try:
-        doc = get_document(doc_id)
-    except GdocError:
-        raise
-
-    inline_map = doc.get("inlineObjects", {})
-    positioned_map = doc.get("positionedObjects", {})
-
-    # Walk body.content to find references and their startIndex
-    refs: list[tuple[str, int, str]] = []  # (object_id, start_index, source)
-    body = doc.get("body", {})
+    refs: list[tuple[str, int, str]] = []
     for element in body.get("content", []):
         paragraph = element.get("paragraph")
         if paragraph is None:
@@ -914,68 +900,114 @@ def list_inline_objects(doc_id: str) -> list[dict]:
         para_start = element.get("startIndex", 0)
         for pid in positioned_ids:
             refs.append((pid, para_start, "positioned"))
+    return refs
+
+
+def list_inline_objects(doc_id: str) -> list[dict]:
+    """List all inline and positioned objects in a document, every tab.
+
+    Walks each tab's body.content for inlineObjectElement and
+    positionedObjectId references, joins with the tab's inlineObjects
+    and positionedObjects maps, and classifies each object.
+
+    Returns list of dicts with id, tab, type, title, description,
+    dimensions, content_uri, source_uri, start_index, and chart
+    metadata. `tab` is "" for documents fetched without tab content.
+    """
+    doc = get_document_with_tabs(doc_id)
+
+    # (tab_id, body, inline_map, positioned_map) per content segment
+    segments: list[tuple[str, dict, dict, dict]] = []
+    tabs = doc.get("tabs")
+    if tabs:
+        def walk(ts: list[dict]):
+            for t in ts:
+                doc_tab = t.get("documentTab", {})
+                yield (
+                    t.get("tabProperties", {}).get("tabId", ""),
+                    doc_tab.get("body", {}),
+                    doc_tab.get("inlineObjects", {}),
+                    doc_tab.get("positionedObjects", {}),
+                )
+                yield from walk(t.get("childTabs", []))
+
+        segments = list(walk(tabs))
+    else:
+        segments = [(
+            "",
+            doc.get("body", {}),
+            doc.get("inlineObjects", {}),
+            doc.get("positionedObjects", {}),
+        )]
 
     results = []
     seen = set()
 
-    for obj_id, start_index, source in refs:
-        if obj_id in seen:
-            continue
-        seen.add(obj_id)
+    for tab_id, body, inline_map, positioned_map in segments:
+        for obj_id, start_index, source in _collect_object_refs(body):
+            if (tab_id, obj_id) in seen:
+                continue
+            seen.add((tab_id, obj_id))
 
-        if source == "inline":
-            obj_data = inline_map.get(obj_id, {})
-        else:
-            obj_data = positioned_map.get(obj_id, {})
-
-        props = obj_data.get("inlineObjectProperties", {}) or obj_data.get(
-            "positionedObjectProperties", {}
-        )
-        embedded = props.get("embeddedObject", {})
-
-        # Classify type
-        obj_type = "image"
-        spreadsheet_id = None
-        chart_id = None
-        if "embeddedDrawingProperties" in embedded:
-            obj_type = "drawing"
-        elif "linkedContentReference" in embedded:
-            lcr = embedded["linkedContentReference"]
-            if "sheetsChartReference" in lcr:
-                obj_type = "chart"
-                scr = lcr["sheetsChartReference"]
-                spreadsheet_id = scr.get("spreadsheetId")
-                chart_id = scr.get("chartId")
-
-        # Extract dimensions
-        size = embedded.get("size", {})
-        width = size.get("width", {}).get("magnitude", 0)
-        height = size.get("height", {}).get("magnitude", 0)
-
-        # Content URI (None for drawings)
-        content_uri = None
-        if obj_type != "drawing":
-            image_props = embedded.get("imageProperties", {})
-            content_uri = image_props.get("contentUri")
-
-        entry = {
-            "id": obj_id,
-            "type": obj_type,
-            "title": embedded.get("title", ""),
-            "description": embedded.get("description", ""),
-            "width_pt": width,
-            "height_pt": height,
-            "content_uri": content_uri,
-            "source_uri": embedded.get("imageProperties", {}).get("sourceUri"),
-            "start_index": start_index,
-        }
-        if obj_type == "chart":
-            entry["spreadsheet_id"] = spreadsheet_id
-            entry["chart_id"] = chart_id
-
-        results.append(entry)
+            if source == "inline":
+                obj_data = inline_map.get(obj_id, {})
+            else:
+                obj_data = positioned_map.get(obj_id, {})
+            results.append(_classify_object(obj_id, obj_data, start_index, tab_id))
 
     return results
+
+
+def _classify_object(
+    obj_id: str, obj_data: dict, start_index: int, tab_id: str,
+) -> dict:
+    """Build the metadata entry for one inline/positioned object."""
+    props = obj_data.get("inlineObjectProperties", {}) or obj_data.get(
+        "positionedObjectProperties", {}
+    )
+    embedded = props.get("embeddedObject", {})
+
+    # Classify type
+    obj_type = "image"
+    spreadsheet_id = None
+    chart_id = None
+    if "embeddedDrawingProperties" in embedded:
+        obj_type = "drawing"
+    elif "linkedContentReference" in embedded:
+        lcr = embedded["linkedContentReference"]
+        if "sheetsChartReference" in lcr:
+            obj_type = "chart"
+            scr = lcr["sheetsChartReference"]
+            spreadsheet_id = scr.get("spreadsheetId")
+            chart_id = scr.get("chartId")
+
+    # Extract dimensions
+    size = embedded.get("size", {})
+    width = size.get("width", {}).get("magnitude", 0)
+    height = size.get("height", {}).get("magnitude", 0)
+
+    # Content URI (None for drawings)
+    content_uri = None
+    if obj_type != "drawing":
+        image_props = embedded.get("imageProperties", {})
+        content_uri = image_props.get("contentUri")
+
+    entry = {
+        "id": obj_id,
+        "tab": tab_id,
+        "type": obj_type,
+        "title": embedded.get("title", ""),
+        "description": embedded.get("description", ""),
+        "width_pt": width,
+        "height_pt": height,
+        "content_uri": content_uri,
+        "source_uri": embedded.get("imageProperties", {}).get("sourceUri"),
+        "start_index": start_index,
+    }
+    if obj_type == "chart":
+        entry["spreadsheet_id"] = spreadsheet_id
+        entry["chart_id"] = chart_id
+    return entry
 
 
 def download_image(content_uri: str, dest_path: str) -> None:

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -988,6 +988,130 @@ def download_image(content_uri: str, dest_path: str) -> None:
         f.write(data)
 
 
+def insert_inline_image(
+    doc_id: str,
+    uri: str,
+    index: int,
+    tab_id: str | None = None,
+    revision_id: str = "",
+    width_pt: float | None = None,
+    height_pt: float | None = None,
+) -> str:
+    """Insert an inline image at a document index via insertInlineImage.
+
+    Args:
+        doc_id: The document ID.
+        uri: Publicly fetchable image URL (Google's servers download it).
+        index: UTF-16 insertion index (from find_text_in_document).
+        tab_id: Tab the index lives in (omitted → first tab).
+        revision_id: If non-empty, sent as writeControl.requiredRevisionId
+            so the insert can't land on stale coordinates.
+        width_pt: Optional display width in points.
+        height_pt: Optional display height in points.
+
+    Returns:
+        The new inline object ID (usable with `gdoc images`/replace_image).
+    """
+    location: dict = {"index": index}
+    if tab_id:
+        location["tabId"] = tab_id
+    request: dict = {"location": location, "uri": uri}
+    size: dict = {}
+    if width_pt:
+        size["width"] = {"magnitude": width_pt, "unit": "PT"}
+    if height_pt:
+        size["height"] = {"magnitude": height_pt, "unit": "PT"}
+    if size:
+        request["objectSize"] = size
+    body: dict = {"requests": [{"insertInlineImage": request}]}
+    if revision_id:
+        body["writeControl"] = {"requiredRevisionId": revision_id}
+    try:
+        service = get_docs_service()
+        result = (
+            service.documents()
+            .batchUpdate(documentId=doc_id, body=body)
+            .execute()
+        )
+    except HttpError as e:
+        _raise_if_stale_revision(e)
+        _translate_http_error(e, doc_id)
+    replies = result.get("replies", [])
+    return (replies[0] if replies else {}).get(
+        "insertInlineImage", {},
+    ).get("objectId", "")
+
+
+def replace_image(
+    doc_id: str,
+    object_id: str,
+    uri: str,
+    tab_id: str | None = None,
+    revision_id: str = "",
+) -> None:
+    """Replace an existing image's content via replaceImage.
+
+    The existing image keeps its size; the new content is scaled and
+    center-cropped to fit (CENTER_CROP is the only supported method).
+
+    Args:
+        doc_id: The document ID.
+        object_id: Inline object ID of the image (see `gdoc images`).
+        uri: Publicly fetchable replacement image URL.
+        tab_id: Tab the image lives in (omitted → first tab).
+        revision_id: If non-empty, sent as writeControl.requiredRevisionId.
+    """
+    request: dict = {
+        "imageObjectId": object_id,
+        "uri": uri,
+        "imageReplaceMethod": "CENTER_CROP",
+    }
+    if tab_id:
+        request["tabId"] = tab_id
+    body: dict = {"requests": [{"replaceImage": request}]}
+    if revision_id:
+        body["writeControl"] = {"requiredRevisionId": revision_id}
+    try:
+        service = get_docs_service()
+        service.documents().batchUpdate(
+            documentId=doc_id, body=body,
+        ).execute()
+    except HttpError as e:
+        _raise_if_stale_revision(e)
+        _translate_http_error(e, doc_id)
+
+
+def _raise_if_stale_revision(e: HttpError) -> None:
+    """Turn a writeControl revision-mismatch 400 into a clear retry hint."""
+    if int(e.resp.status) == 400 and "revision" in str(e).lower():
+        raise GdocError(
+            "document changed while the command was running; re-run it"
+        )
+
+
+def find_object_tab(doc: dict, object_id: str) -> str | None:
+    """Find which tab holds an inline/positioned object ID.
+
+    Walks the tab tree of a documents.get(includeTabsContent=True) response.
+    Returns the tab ID, or None if no tab declares the object (including
+    docs fetched without tab content).
+    """
+    def walk(tabs: list[dict]) -> str | None:
+        for tab in tabs:
+            doc_tab = tab.get("documentTab", {})
+            if (
+                object_id in doc_tab.get("inlineObjects", {})
+                or object_id in doc_tab.get("positionedObjects", {})
+            ):
+                return tab.get("tabProperties", {}).get("tabId")
+            found = walk(tab.get("childTabs", []))
+            if found is not None:
+                return found
+        return None
+
+    return walk(doc.get("tabs", []))
+
+
 _HEADING_LEVELS = {
     "HEADING_1": 1, "HEADING_2": 2, "HEADING_3": 3,
     "HEADING_4": 4, "HEADING_5": 5, "HEADING_6": 6,

--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -43,16 +43,7 @@ def export_doc(doc_id: str, mime_type: str = "text/markdown") -> str:
 
     Returns the decoded UTF-8 content string.
     """
-    try:
-        service = get_drive_service()
-        content = (
-            service.files()
-            .export_media(fileId=doc_id, mimeType=mime_type)
-            .execute()
-        )
-        return content.decode("utf-8")
-    except HttpError as e:
-        _translate_http_error(e, doc_id)
+    return export_doc_bytes(doc_id, mime_type).decode("utf-8")
 
 
 def export_doc_bytes(doc_id: str, mime_type: str) -> bytes:

--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -55,6 +55,23 @@ def export_doc(doc_id: str, mime_type: str = "text/markdown") -> str:
         _translate_http_error(e, doc_id)
 
 
+def export_doc_bytes(doc_id: str, mime_type: str) -> bytes:
+    """Export a Google Docs document as raw bytes.
+
+    Like export_doc, but without UTF-8 decoding — for binary formats
+    (PDF, DOCX, ODT, EPUB) that must be written to a file as-is.
+    """
+    try:
+        service = get_drive_service()
+        return (
+            service.files()
+            .export_media(fileId=doc_id, mimeType=mime_type)
+            .execute()
+        )
+    except HttpError as e:
+        _translate_http_error(e, doc_id)
+
+
 def list_files(query: str) -> list[dict]:
     """List files matching a Drive API query, auto-paginating."""
     try:

--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -284,11 +284,21 @@ def upload_temp_image(file_path: str, mime_type: str) -> dict:
             )
             .execute()
         )
-        # Make publicly readable for inline image insertion
-        service.permissions().create(
-            fileId=result["id"],
-            body={"type": "anyone", "role": "reader"},
-        ).execute()
+        # Make publicly readable for inline image insertion. If that is
+        # blocked (e.g. a Workspace policy forbids anyone-sharing), the
+        # caller never learns the file ID, so delete the orphan here
+        # rather than leaving a gdoc-temp-* file behind on every attempt.
+        try:
+            service.permissions().create(
+                fileId=result["id"],
+                body={"type": "anyone", "role": "reader"},
+            ).execute()
+        except HttpError:
+            try:
+                service.files().delete(fileId=result["id"]).execute()
+            except HttpError:
+                pass
+            raise
         return result
     except HttpError as e:
         _translate_http_error(e, file_path)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2506,7 +2506,14 @@ def cmd_export(args) -> int:
         else:
             print(f"OK exported {out} ({fmt}, {len(content)} bytes)")
     else:
-        sys.stdout.write(content.decode("utf-8"))
+        from gdoc.format import format_json, get_output_mode
+
+        text = content.decode("utf-8")
+        if get_output_mode(args) == "json":
+            print(format_json(format=fmt, bytes=len(content), content=text))
+        else:
+            # terse/plain/verbose: the document content IS the output
+            sys.stdout.write(text)
 
     from gdoc.state import update_state_after_command
 
@@ -2514,6 +2521,19 @@ def cmd_export(args) -> int:
         doc_id, change_info, command="export", quiet=quiet,
     )
     return 0
+
+
+# Formats the Docs API insertInlineImage/replaceImage requests accept.
+# Deliberately narrower than markdown import (`new --file` also takes
+# WebP): the API rejects WebP, and failing fast here avoids creating a
+# public-read temp file that the API is guaranteed to refuse
+# (live-verified: 400 "should be ... in supported formats").
+_INSERT_IMAGE_MIMES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+}
 
 
 def _validate_image_source(image: str) -> str | None:
@@ -2529,14 +2549,12 @@ def _validate_image_source(image: str) -> str | None:
     if not os.path.isfile(image):
         raise GdocError(f"image file not found: {image}", exit_code=3)
 
-    from gdoc.mdimport import _MIME_TYPES
-
     ext = os.path.splitext(image)[1].lower()
-    mime = _MIME_TYPES.get(ext)
+    mime = _INSERT_IMAGE_MIMES.get(ext)
     if not mime:
         raise GdocError(
             f"unsupported image type: {ext or image} "
-            "(png, jpg, gif, webp)",
+            "(the Docs API accepts png, jpg, gif)",
             exit_code=3,
         )
     return mime
@@ -2558,7 +2576,16 @@ def _resolve_image_source(image: str) -> tuple[str, str | None]:
     from gdoc.api.drive import upload_temp_image
 
     result = upload_temp_image(image, mime)
-    return result["webContentLink"], result["id"]
+    uri = result.get("webContentLink")
+    if not uri:
+        # The temp file is already public-read; don't leak it just
+        # because Drive omitted the download link from the response.
+        _cleanup_temp_image(result.get("id"))
+        raise GdocError(
+            "Drive returned no download link for the temporary image "
+            "upload; try again"
+        )
+    return uri, result["id"]
 
 
 def _cleanup_temp_image(temp_file_id: str | None) -> None:
@@ -2599,34 +2626,17 @@ def _resolve_image_target_tab(doc: dict, tab_name: str | None) -> dict | None:
     return tabs[0] if tabs else None
 
 
-def cmd_insert_image(args) -> int:
-    """Handler for `gdoc insert-image`: add an image to an existing doc."""
-    doc_id = _resolve_doc_id(args.doc)
-    quiet = getattr(args, "quiet", False)
-    after = getattr(args, "after", None)
-    index = getattr(args, "index", None)
-    _validate_image_source(args.image)
-
-    from gdoc.notify import pre_flight
-
-    change_info = pre_flight(doc_id, quiet=quiet)
-    _require_doc(doc_id, change_info)
-    if change_info and change_info.has_conflict:
-        print("WARN: doc changed since last read", file=sys.stderr)
-
-    from gdoc.api.docs import find_text_in_document, get_document_with_tabs
-
-    doc = get_document_with_tabs(doc_id)
-    revision_id = doc.get("revisionId", "")
-    tab = _resolve_image_target_tab(doc, getattr(args, "tab", None))
-    tab_id = tab["id"] if tab else None
-    body = tab["body"] if tab else doc.get("body", {})
+def _resolve_insert_index(
+    body: dict, index: int | None, after: str | None,
+) -> int:
+    """Resolve the UTF-16 insertion index from --index, --after, or --end."""
+    from gdoc.api.docs import find_text_in_document
 
     if index is not None:
         if index < 1:
             raise GdocError("--index must be >= 1", exit_code=3)
-        insert_at = index
-    elif after is not None:
+        return index
+    if after is not None:
         matches = find_text_in_document(None, after, body=body)
         if not matches:
             matches = find_text_in_document(
@@ -2650,12 +2660,37 @@ def cmd_insert_image(args) -> int:
                 "use a longer anchor",
                 exit_code=3,
             )
-        insert_at = matches[0]["endIndex"]
-    else:
-        # --end: last index inside the body's final structural element
-        # (the segment's closing newline — inserting there appends).
-        content = body.get("content", [])
-        insert_at = content[-1].get("endIndex", 2) - 1 if content else 1
+        return matches[0]["endIndex"]
+    # --end: last index inside the body's final structural element
+    # (the segment's closing newline — inserting there appends).
+    content = body.get("content", [])
+    return content[-1].get("endIndex", 2) - 1 if content else 1
+
+
+def cmd_insert_image(args) -> int:
+    """Handler for `gdoc insert-image`: add an image to an existing doc."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    _validate_image_source(args.image)
+
+    from gdoc.notify import pre_flight
+
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+    if change_info and change_info.has_conflict:
+        print("WARN: doc changed since last read", file=sys.stderr)
+
+    from gdoc.api.docs import get_document_with_tabs
+
+    doc = get_document_with_tabs(doc_id)
+    revision_id = doc.get("revisionId", "")
+    tab = _resolve_image_target_tab(doc, getattr(args, "tab", None))
+    tab_id = tab["id"] if tab else None
+    body = tab["body"] if tab else doc.get("body", {})
+
+    insert_at = _resolve_insert_index(
+        body, getattr(args, "index", None), getattr(args, "after", None),
+    )
 
     uri, temp_file_id = _resolve_image_source(args.image)
 

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2423,6 +2423,350 @@ def cmd_images(args) -> int:
     return 0
 
 
+# Rendered/binary formats must go to a file; text formats may hit stdout.
+_EXPORT_MIME = {
+    "pdf": "application/pdf",
+    "docx": (
+        "application/vnd.openxmlformats-officedocument"
+        ".wordprocessingml.document"
+    ),
+    "odt": "application/vnd.oasis.opendocument.text",
+    "epub": "application/epub+zip",
+    "html": "text/html",
+    "md": "text/markdown",
+    "txt": "text/plain",
+    "rtf": "application/rtf",
+}
+_BINARY_FORMATS = {"pdf", "docx", "odt", "epub"}
+_EXT_TO_FORMAT = {
+    ".pdf": "pdf",
+    ".docx": "docx",
+    ".odt": "odt",
+    ".epub": "epub",
+    ".html": "html",
+    ".htm": "html",
+    ".md": "md",
+    ".markdown": "md",
+    ".txt": "txt",
+    ".rtf": "rtf",
+}
+
+
+def cmd_export(args) -> int:
+    """Handler for `gdoc export`: render a doc to PDF/DOCX/HTML/etc."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    fmt = getattr(args, "format", None)
+    out = getattr(args, "out", None)
+
+    if not fmt:
+        ext = os.path.splitext(out or "")[1].lower()
+        fmt = _EXT_TO_FORMAT.get(ext)
+        if not fmt:
+            raise GdocError(
+                "cannot infer format; pass --format or use a known "
+                "--out extension (" + ", ".join(sorted(_EXPORT_MIME)) + ")",
+                exit_code=3,
+            )
+    if fmt in _BINARY_FORMATS and not out:
+        raise GdocError(
+            f"--out is required for binary formats ({fmt})", exit_code=3,
+        )
+
+    from gdoc.notify import pre_flight
+
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+
+    from gdoc.api.drive import export_doc_bytes
+
+    content = export_doc_bytes(doc_id, _EXPORT_MIME[fmt])
+
+    if out:
+        try:
+            with open(out, "wb") as f:
+                f.write(content)
+        except OSError as e:
+            raise GdocError(f"cannot write {out}: {e}", exit_code=3) from e
+
+        from gdoc.format import format_json, get_output_mode
+
+        mode = get_output_mode(args)
+        if mode == "json":
+            print(format_json(path=out, format=fmt, bytes=len(content)))
+        elif mode == "plain":
+            print(f"path\t{out}")
+            print(f"format\t{fmt}")
+            print(f"bytes\t{len(content)}")
+        elif mode == "verbose":
+            print(f"Exported: {doc_id}")
+            print(f"Format: {fmt}")
+            print(f"Path: {out}")
+            print(f"Bytes: {len(content)}")
+        else:
+            print(f"OK exported {out} ({fmt}, {len(content)} bytes)")
+    else:
+        sys.stdout.write(content.decode("utf-8"))
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(
+        doc_id, change_info, command="export", quiet=quiet,
+    )
+    return 0
+
+
+def _validate_image_source(image: str) -> str | None:
+    """Validate an image argument (URL or local path).
+
+    Returns the local file's MIME type, or None for a remote URL.
+    Raises GdocError (exit 3) for a missing file or unsupported type,
+    so handlers can fail fast before making API calls.
+    """
+    if image.startswith(("http://", "https://")):
+        return None
+
+    if not os.path.isfile(image):
+        raise GdocError(f"image file not found: {image}", exit_code=3)
+
+    from gdoc.mdimport import _MIME_TYPES
+
+    ext = os.path.splitext(image)[1].lower()
+    mime = _MIME_TYPES.get(ext)
+    if not mime:
+        raise GdocError(
+            f"unsupported image type: {ext or image} "
+            "(png, jpg, gif, webp)",
+            exit_code=3,
+        )
+    return mime
+
+
+def _resolve_image_source(image: str) -> tuple[str, str | None]:
+    """Turn an image argument (URL or local path) into an insertable URI.
+
+    Local files are uploaded to Drive as a temporary public-read file
+    (Google's servers must be able to fetch the URI); the caller must
+    delete the returned temp file ID when done.
+
+    Returns (uri, temp_file_id) — temp_file_id is None for remote URLs.
+    """
+    mime = _validate_image_source(image)
+    if mime is None:
+        return image, None
+
+    from gdoc.api.drive import upload_temp_image
+
+    result = upload_temp_image(image, mime)
+    return result["webContentLink"], result["id"]
+
+
+def _cleanup_temp_image(temp_file_id: str | None) -> None:
+    """Delete a temp Drive image, warning loudly if the delete fails.
+
+    The temp file is public-read (that's how Docs fetches it), so a failed
+    cleanup is an exposure the user must know about, not a silent leak.
+    """
+    if not temp_file_id:
+        return
+    from gdoc.api.drive import delete_file
+
+    try:
+        delete_file(temp_file_id)
+    except Exception as e:
+        print(
+            f"WARN: could not delete temporary Drive file {temp_file_id} "
+            f"(public-read); delete it manually: {e}",
+            file=sys.stderr,
+        )
+
+
+def _resolve_image_target_tab(doc: dict, tab_name: str | None) -> dict | None:
+    """Pick the tab an image operation targets; None = legacy body.
+
+    A multi-tab document with no --tab is ambiguous — refuse rather than
+    guess, since an insert lands at a raw index.
+    """
+    from gdoc.api.docs import flatten_tabs, resolve_tab
+
+    tabs = flatten_tabs(doc.get("tabs", []))
+    if tab_name:
+        return resolve_tab(tabs, tab_name)
+    if len(tabs) > 1:
+        raise GdocError(
+            f"document has {len(tabs)} tabs; specify --tab", exit_code=3,
+        )
+    return tabs[0] if tabs else None
+
+
+def cmd_insert_image(args) -> int:
+    """Handler for `gdoc insert-image`: add an image to an existing doc."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    after = getattr(args, "after", None)
+    index = getattr(args, "index", None)
+    _validate_image_source(args.image)
+
+    from gdoc.notify import pre_flight
+
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+    if change_info and change_info.has_conflict:
+        print("WARN: doc changed since last read", file=sys.stderr)
+
+    from gdoc.api.docs import find_text_in_document, get_document_with_tabs
+
+    doc = get_document_with_tabs(doc_id)
+    revision_id = doc.get("revisionId", "")
+    tab = _resolve_image_target_tab(doc, getattr(args, "tab", None))
+    tab_id = tab["id"] if tab else None
+    body = tab["body"] if tab else doc.get("body", {})
+
+    if index is not None:
+        if index < 1:
+            raise GdocError("--index must be >= 1", exit_code=3)
+        insert_at = index
+    elif after is not None:
+        matches = find_text_in_document(None, after, body=body)
+        if not matches:
+            matches = find_text_in_document(
+                None, after, body=body, normalize=True,
+            )
+        if not matches:
+            from gdoc.api.docs import diagnose_no_match
+
+            # normalize=True was already retried above, so don't let the
+            # diagnosis suggest it.
+            reason = diagnose_no_match(
+                None, after, body=body, already_normalized=True,
+            )
+            msg = f"--after anchor not found: {after!r}"
+            if reason:
+                msg += f"; {reason}"
+            raise GdocError(msg, exit_code=3)
+        if len(matches) > 1:
+            raise GdocError(
+                f"--after anchor is ambiguous ({len(matches)} matches); "
+                "use a longer anchor",
+                exit_code=3,
+            )
+        insert_at = matches[0]["endIndex"]
+    else:
+        # --end: last index inside the body's final structural element
+        # (the segment's closing newline — inserting there appends).
+        content = body.get("content", [])
+        insert_at = content[-1].get("endIndex", 2) - 1 if content else 1
+
+    uri, temp_file_id = _resolve_image_source(args.image)
+
+    from gdoc.api.docs import insert_inline_image
+
+    try:
+        object_id = insert_inline_image(
+            doc_id, uri, insert_at,
+            tab_id=tab_id,
+            revision_id=revision_id,
+            width_pt=getattr(args, "width", None),
+            height_pt=getattr(args, "height", None),
+        )
+    finally:
+        _cleanup_temp_image(temp_file_id)
+
+    from gdoc.api.drive import get_file_version
+
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(
+            object_id=object_id, tab=tab_id or "", index=insert_at,
+        ))
+    elif mode == "plain":
+        print(f"object_id\t{object_id}")
+        print(f"index\t{insert_at}")
+    elif mode == "verbose":
+        print(f"Inserted image: {object_id}")
+        print(f"Index: {insert_at}")
+        if tab_id:
+            print(f"Tab: {tab_id}")
+    else:
+        print(f"OK inserted image {object_id}")
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(
+        doc_id, change_info, command="insert-image",
+        quiet=quiet, command_version=command_version,
+    )
+    return 0
+
+
+def cmd_replace_image(args) -> int:
+    """Handler for `gdoc replace-image`: swap an image's content by ID."""
+    doc_id = _resolve_doc_id(args.doc)
+    object_id = args.object_id
+    quiet = getattr(args, "quiet", False)
+    _validate_image_source(args.image)
+
+    from gdoc.notify import pre_flight
+
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+    if change_info and change_info.has_conflict:
+        print("WARN: doc changed since last read", file=sys.stderr)
+
+    from gdoc.api.docs import find_object_tab, get_document_with_tabs
+
+    doc = get_document_with_tabs(doc_id)
+    revision_id = doc.get("revisionId", "")
+    tab_id = find_object_tab(doc, object_id)
+    if tab_id is None and object_id not in doc.get("inlineObjects", {}):
+        raise GdocError(
+            f"image object not found: {object_id} (see `gdoc images`)",
+            exit_code=3,
+        )
+
+    uri, temp_file_id = _resolve_image_source(args.image)
+
+    from gdoc.api.docs import replace_image
+
+    try:
+        replace_image(
+            doc_id, object_id, uri,
+            tab_id=tab_id, revision_id=revision_id,
+        )
+    finally:
+        _cleanup_temp_image(temp_file_id)
+
+    from gdoc.api.drive import get_file_version
+
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(object_id=object_id, status="replaced"))
+    elif mode == "plain":
+        print(f"object_id\t{object_id}")
+        print("status\treplaced")
+    elif mode == "verbose":
+        print(f"Replaced image: {object_id}")
+        print("Method: CENTER_CROP (existing size kept)")
+    else:
+        print(f"OK replaced image {object_id}")
+
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(
+        doc_id, change_info, command="replace-image",
+        quiet=quiet, command_version=command_version,
+    )
+    return 0
+
+
 def cmd_auth(args) -> int:
     """Handler for `gdoc auth`."""
     set_default = getattr(args, "set_default", None)
@@ -3384,6 +3728,87 @@ def build_parser() -> GdocArgumentParser:
         "--quiet", action="store_true", help="Skip pre-flight checks",
     )
     images_p.set_defaults(func=cmd_images)
+
+    # export
+    export_p = sub.add_parser(
+        "export", parents=[output_parent],
+        help="Export a doc to PDF, DOCX, HTML, and more",
+        description=(
+            "Render a document to a file via Drive export. Exports cover "
+            "the whole document (all tabs). Binary formats (pdf, docx, "
+            "odt, epub) require --out; text formats print to stdout "
+            "without it."
+        ),
+    )
+    export_p.add_argument("doc", help="Document ID or URL")
+    export_p.add_argument(
+        "--format", choices=sorted(_EXPORT_MIME),
+        help="Export format (default: inferred from --out extension)",
+    )
+    export_p.add_argument(
+        "--out", metavar="FILE", help="Output file path",
+    )
+    export_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    export_p.set_defaults(func=cmd_export)
+
+    # insert-image
+    ii_p = sub.add_parser(
+        "insert-image", parents=[output_parent],
+        help="Insert an image into an existing doc",
+        description=(
+            "Insert a local image file or a public image URL into a doc. "
+            "Local files are uploaded to Drive as a temporary public-read "
+            "file and deleted after the insert."
+        ),
+    )
+    ii_p.add_argument("doc", help="Document ID or URL")
+    ii_p.add_argument("image", help="Local image path or public image URL")
+    ii_p.add_argument(
+        "--tab", help="Tab title or ID (required for multi-tab docs)",
+    )
+    ii_where = ii_p.add_mutually_exclusive_group(required=True)
+    ii_where.add_argument(
+        "--after", metavar="TEXT",
+        help="Insert immediately after this anchor text",
+    )
+    ii_where.add_argument(
+        "--index", type=int, metavar="N",
+        help="Insert at a raw UTF-16 document index (advanced)",
+    )
+    ii_where.add_argument(
+        "--end", action="store_true", help="Append at the end of the tab",
+    )
+    ii_p.add_argument(
+        "--width", type=float, metavar="PT", help="Display width in points",
+    )
+    ii_p.add_argument(
+        "--height", type=float, metavar="PT",
+        help="Display height in points",
+    )
+    ii_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    ii_p.set_defaults(func=cmd_insert_image)
+
+    # replace-image
+    ri_p = sub.add_parser(
+        "replace-image", parents=[output_parent],
+        help="Replace an existing image's content by object ID",
+        description=(
+            "Swap the content of an image in place (object IDs come from "
+            "`gdoc images`). The image keeps its current size; the new "
+            "content is scaled and center-cropped to fit."
+        ),
+    )
+    ri_p.add_argument("doc", help="Document ID or URL")
+    ri_p.add_argument("object_id", help="Image object ID (see `gdoc images`)")
+    ri_p.add_argument("image", help="Local image path or public image URL")
+    ri_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    ri_p.set_defaults(func=cmd_replace_image)
 
     # info
     info_p = sub.add_parser("info", parents=[output_parent], help="Show document metadata")

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2399,6 +2399,7 @@ def cmd_images(args) -> int:
                 print(
                     f"{img['id']}\t{img['type']}\t{img['title']}"
                     f"\t{img['width_pt']}\t{img['height_pt']}"
+                    f"\t{img.get('tab', '')}"
                 )
         elif not images:
             print("No images.")
@@ -2669,8 +2670,17 @@ def _resolve_insert_index(
 
 def cmd_insert_image(args) -> int:
     """Handler for `gdoc insert-image`: add an image to an existing doc."""
+    import math
+
     doc_id = _resolve_doc_id(args.doc)
     quiet = getattr(args, "quiet", False)
+    for name in ("width", "height"):
+        val = getattr(args, name, None)
+        if val is not None and (not math.isfinite(val) or val <= 0):
+            raise GdocError(
+                f"--{name} must be a positive number of points",
+                exit_code=3,
+            )
     _validate_image_source(args.image)
 
     from gdoc.notify import pre_flight

--- a/gdoc/state.py
+++ b/gdoc/state.py
@@ -83,7 +83,7 @@ def update_state_after_command(
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     state.last_seen = now
 
-    is_read = command in ("cat", "info", "pull")
+    is_read = command in ("cat", "info", "pull", "export")
 
     if quiet:
         # Decision #14: --quiet state update rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.14.0"
+version = "0.15.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -149,6 +149,30 @@ class TestCmdExport:
         assert "bytes\t5" in lines
 
     @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"12345")
+    def test_verbose_output(self, mock_export, _update, tmp_path, capsys):
+        out = tmp_path / "r.pdf"
+        args = _make_args(out=str(out), verbose=True)
+        cmd_export(args)
+        lines = capsys.readouterr().out.splitlines()
+        assert "Exported: doc123" in lines
+        assert "Format: pdf" in lines
+        assert f"Path: {out}" in lines
+        assert "Bytes: 5" in lines
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"# Title\n")
+    def test_stdout_json_wraps_content(self, mock_export, _update, capsys):
+        args = _make_args(format="md", json=True)
+        rc = cmd_export(args)
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["format"] == "md"
+        assert data["bytes"] == 8
+        assert data["content"] == "# Title\n"
+
+    @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.export_doc_bytes", return_value=b"x")
     def test_unwritable_out_errors(self, mock_export, _update, tmp_path):
         out = tmp_path / "missing-dir" / "r.pdf"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,165 @@
+"""Tests for `gdoc export` and the export_doc_bytes API wrapper."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc.api.drive import export_doc_bytes
+from gdoc.cli import cmd_export
+from gdoc.util import GdocError
+
+PDF_MIME = "application/pdf"
+DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument"
+    ".wordprocessingml.document"
+)
+
+
+def _http_error(status, content=b""):
+    resp = httplib2.Response({"status": str(status)})
+    resp.reason = "Error"
+    return HttpError(resp, content, uri="")
+
+
+def _make_args(**overrides):
+    defaults = {
+        "command": "export",
+        "doc": "doc123",
+        "format": None,
+        "out": None,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": True,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestExportDocBytes:
+    @patch("gdoc.api.drive.get_drive_service")
+    def test_returns_raw_bytes(self, mock_svc):
+        service = MagicMock()
+        export_media = service.files.return_value.export_media
+        export_media.return_value.execute.return_value = b"%PDF-1.7 raw\xff"
+        mock_svc.return_value = service
+
+        result = export_doc_bytes("doc123", PDF_MIME)
+
+        assert result == b"%PDF-1.7 raw\xff"
+        export_media.assert_called_once_with(
+            fileId="doc123", mimeType=PDF_MIME,
+        )
+
+    @patch("gdoc.api.drive.get_drive_service")
+    def test_404_raises_gdoc_error(self, mock_svc):
+        service = MagicMock()
+        export_media = service.files.return_value.export_media
+        export_media.return_value.execute.side_effect = _http_error(404)
+        mock_svc.return_value = service
+
+        with pytest.raises(GdocError, match="not found"):
+            export_doc_bytes("doc123", PDF_MIME)
+
+
+class TestCmdExport:
+    def test_binary_format_without_out_errors(self):
+        args = _make_args(format="pdf")
+        with pytest.raises(GdocError, match="--out is required") as exc_info:
+            cmd_export(args)
+        assert exc_info.value.exit_code == 3
+
+    def test_no_format_no_out_errors(self):
+        args = _make_args()
+        with pytest.raises(GdocError, match="cannot infer format") as exc_info:
+            cmd_export(args)
+        assert exc_info.value.exit_code == 3
+
+    def test_unknown_out_extension_errors(self, tmp_path):
+        args = _make_args(out=str(tmp_path / "report.xyz"))
+        with pytest.raises(GdocError, match="cannot infer format") as exc_info:
+            cmd_export(args)
+        assert exc_info.value.exit_code == 3
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"%PDF-fake")
+    def test_format_inferred_from_out_extension(
+        self, mock_export, _update, tmp_path, capsys,
+    ):
+        out = tmp_path / "report.pdf"
+        args = _make_args(out=str(out))
+        rc = cmd_export(args)
+        assert rc == 0
+        mock_export.assert_called_once_with("doc123", PDF_MIME)
+        assert out.read_bytes() == b"%PDF-fake"
+        assert (
+            f"OK exported {out} (pdf, 9 bytes)"
+            in capsys.readouterr().out
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"docx-bytes")
+    def test_docx_mime_passed(self, mock_export, _update, tmp_path):
+        args = _make_args(format="docx", out=str(tmp_path / "r.docx"))
+        cmd_export(args)
+        mock_export.assert_called_once_with("doc123", DOCX_MIME)
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"# Title\n")
+    def test_text_format_prints_to_stdout(self, mock_export, _update, capsys):
+        args = _make_args(format="md")
+        rc = cmd_export(args)
+        assert rc == 0
+        assert capsys.readouterr().out == "# Title\n"
+        mock_export.assert_called_once_with("doc123", "text/markdown")
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"<html></html>")
+    def test_html_to_stdout_allowed(self, mock_export, _update, capsys):
+        args = _make_args(format="html")
+        rc = cmd_export(args)
+        assert rc == 0
+        assert capsys.readouterr().out == "<html></html>"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"12345")
+    def test_json_output(self, mock_export, _update, tmp_path, capsys):
+        out = tmp_path / "r.pdf"
+        args = _make_args(out=str(out), json=True)
+        cmd_export(args)
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["path"] == str(out)
+        assert data["format"] == "pdf"
+        assert data["bytes"] == 5
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"12345")
+    def test_plain_output(self, mock_export, _update, tmp_path, capsys):
+        out = tmp_path / "r.pdf"
+        args = _make_args(out=str(out), plain=True)
+        cmd_export(args)
+        lines = capsys.readouterr().out.splitlines()
+        assert f"path\t{out}" in lines
+        assert "format\tpdf" in lines
+        assert "bytes\t5" in lines
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"x")
+    def test_unwritable_out_errors(self, mock_export, _update, tmp_path):
+        out = tmp_path / "missing-dir" / "r.pdf"
+        args = _make_args(out=str(out))
+        with pytest.raises(GdocError, match="cannot write") as exc_info:
+            cmd_export(args)
+        assert exc_info.value.exit_code == 3
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.export_doc_bytes", return_value=b"x")
+    def test_state_updated(self, mock_export, mock_update, tmp_path):
+        args = _make_args(out=str(tmp_path / "r.pdf"))
+        cmd_export(args)
+        assert mock_update.call_args.kwargs["command"] == "export"

--- a/tests/test_image_edit.py
+++ b/tests/test_image_edit.py
@@ -101,6 +101,11 @@ class TestInsertInlineImage:
         with pytest.raises(GdocError, match="not found"):
             insert_inline_image("doc1", IMG_URL, 19)
 
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_empty_replies_returns_empty_id(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(batch_response={})
+        assert insert_inline_image("doc1", IMG_URL, 19) == ""
+
 
 class TestReplaceImage:
     @patch("gdoc.api.docs.get_docs_service")
@@ -415,6 +420,36 @@ class TestCmdInsertImage:
         assert exc_info.value.exit_code == 3
         mock_get.assert_not_called()
 
+    @patch("gdoc.api.drive.upload_temp_image")
+    def test_webp_rejected_before_upload(
+        self, mock_upload, mock_get, mock_insert, _ver, _update, tmp_path,
+    ):
+        # The Docs API rejects WebP (live-verified 400) — refuse it before
+        # a public-read temp file exists.
+        img = tmp_path / "pic.webp"
+        img.write_bytes(b"RIFF....WEBP")
+        args = _make_args("insert-image", image=str(img), index=5)
+        with pytest.raises(GdocError, match="unsupported") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+        mock_upload.assert_not_called()
+
+    @patch("gdoc.api.drive.delete_file")
+    @patch("gdoc.api.drive.upload_temp_image", return_value={"id": "tmp1"})
+    def test_missing_web_content_link_cleans_up(
+        self, mock_upload, mock_delete, mock_get, mock_insert, _ver, _update,
+        tmp_path,
+    ):
+        # Drive can omit webContentLink; the already-public temp file must
+        # still be deleted and the failure reported.
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+        args = _make_args("insert-image", image=str(img), index=5)
+        with pytest.raises(GdocError, match="no download link"):
+            cmd_insert_image(args)
+        mock_delete.assert_called_once_with("tmp1")
+        mock_insert.assert_not_called()
+
 
 _REPLACE_DOC = {
     "revisionId": "rev1",
@@ -480,6 +515,23 @@ class TestCmdReplaceImage:
         assert rc == 0
         mock_upload.assert_called_once_with(str(img), "image/jpeg")
         assert mock_replace.call_args.args[2] == "https://dl/tmp2"
+        mock_delete.assert_called_once_with("tmp2")
+
+    @patch("gdoc.api.drive.delete_file")
+    @patch("gdoc.api.drive.upload_temp_image",
+           return_value={"id": "tmp2", "webContentLink": "https://dl/tmp2"})
+    def test_temp_cleaned_up_when_replace_fails(
+        self, mock_upload, mock_delete, mock_get, mock_replace, _ver,
+        _update, tmp_path,
+    ):
+        mock_replace.side_effect = GdocError("API error (400): bad image")
+        img = tmp_path / "new.jpg"
+        img.write_bytes(b"\xff\xd8")
+        args = _make_args(
+            "replace-image", object_id="kix.img1", image=str(img),
+        )
+        with pytest.raises(GdocError):
+            cmd_replace_image(args)
         mock_delete.assert_called_once_with("tmp2")
 
     def test_json_output(

--- a/tests/test_image_edit.py
+++ b/tests/test_image_edit.py
@@ -1,0 +1,495 @@
+"""Tests for insert-image/replace-image commands and their API wrappers."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc.api.docs import find_object_tab, insert_inline_image, replace_image
+from gdoc.cli import cmd_insert_image, cmd_replace_image
+from gdoc.util import GdocError
+
+IMG_URL = "https://example.org/pic.png"
+
+
+def _http_error(status, content=b""):
+    resp = httplib2.Response({"status": str(status)})
+    resp.reason = "Error"
+    return HttpError(resp, content, uri="")
+
+
+def _mock_docs_service(batch_response=None, batch_error=None):
+    """Docs service mock whose batchUpdate().execute() returns or raises."""
+    service = MagicMock()
+    execute = service.documents.return_value.batchUpdate.return_value.execute
+    if batch_error is not None:
+        execute.side_effect = batch_error
+    else:
+        execute.return_value = batch_response or {}
+    return service
+
+
+_INSERT_OK = {
+    "replies": [{"insertInlineImage": {"objectId": "kix.newimg"}}],
+}
+
+
+class TestInsertInlineImage:
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_happy_path_returns_object_id(self, mock_svc):
+        service = _mock_docs_service(batch_response=_INSERT_OK)
+        mock_svc.return_value = service
+
+        result = insert_inline_image("doc1", IMG_URL, 19)
+
+        assert result == "kix.newimg"
+        call = service.documents.return_value.batchUpdate.call_args
+        assert call.kwargs["documentId"] == "doc1"
+        assert call.kwargs["body"] == {
+            "requests": [
+                {
+                    "insertInlineImage": {
+                        "location": {"index": 19},
+                        "uri": IMG_URL,
+                    }
+                }
+            ]
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tab_revision_and_size_in_request(self, mock_svc):
+        service = _mock_docs_service(batch_response=_INSERT_OK)
+        mock_svc.return_value = service
+
+        insert_inline_image(
+            "doc1", IMG_URL, 19,
+            tab_id="t2", revision_id="rev9",
+            width_pt=200.0, height_pt=100.0,
+        )
+
+        body = service.documents.return_value.batchUpdate.call_args.kwargs[
+            "body"
+        ]
+        assert body["writeControl"] == {"requiredRevisionId": "rev9"}
+        request = body["requests"][0]["insertInlineImage"]
+        assert request["location"] == {"index": 19, "tabId": "t2"}
+        assert request["objectSize"] == {
+            "width": {"magnitude": 200.0, "unit": "PT"},
+            "height": {"magnitude": 100.0, "unit": "PT"},
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_revision_mismatch_400_is_clear_error(self, mock_svc):
+        content = (
+            b'{"error": {"code": 400, "message": "The provided revision ID '
+            b'does not match the latest revision of the document."}}'
+        )
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(400, content),
+        )
+        with pytest.raises(GdocError, match="document changed"):
+            insert_inline_image("doc1", IMG_URL, 19, revision_id="rev9")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_raises_gdoc_error(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(404),
+        )
+        with pytest.raises(GdocError, match="not found"):
+            insert_inline_image("doc1", IMG_URL, 19)
+
+
+class TestReplaceImage:
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_request_shape(self, mock_svc):
+        service = _mock_docs_service(batch_response={})
+        mock_svc.return_value = service
+
+        replace_image(
+            "doc1", "kix.img1", IMG_URL, tab_id="t2", revision_id="rev9",
+        )
+
+        call = service.documents.return_value.batchUpdate.call_args
+        assert call.kwargs["body"] == {
+            "requests": [
+                {
+                    "replaceImage": {
+                        "imageObjectId": "kix.img1",
+                        "uri": IMG_URL,
+                        "imageReplaceMethod": "CENTER_CROP",
+                        "tabId": "t2",
+                    }
+                }
+            ],
+            "writeControl": {"requiredRevisionId": "rev9"},
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_tab_no_revision_omits_fields(self, mock_svc):
+        service = _mock_docs_service(batch_response={})
+        mock_svc.return_value = service
+
+        replace_image("doc1", "kix.img1", IMG_URL)
+
+        body = service.documents.return_value.batchUpdate.call_args.kwargs[
+            "body"
+        ]
+        assert "writeControl" not in body
+        assert "tabId" not in body["requests"][0]["replaceImage"]
+
+
+def _tab(tab_id, text, start=1, title=None, inline_objects=None,
+         positioned_objects=None, children=None):
+    """Build a Docs API tab dict with one paragraph of text."""
+    tab = {
+        "tabProperties": {
+            "tabId": tab_id, "title": title or tab_id, "index": 0,
+        },
+        "documentTab": {
+            "body": {
+                "content": [
+                    {
+                        "endIndex": start + len(text),
+                        "paragraph": {
+                            "elements": [
+                                {
+                                    "startIndex": start,
+                                    "textRun": {"content": text},
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+        },
+    }
+    if inline_objects:
+        tab["documentTab"]["inlineObjects"] = inline_objects
+    if positioned_objects:
+        tab["documentTab"]["positionedObjects"] = positioned_objects
+    if children:
+        tab["childTabs"] = children
+    return tab
+
+
+class TestFindObjectTab:
+    def test_found_in_second_tab(self):
+        doc = {
+            "tabs": [
+                _tab("t1", "one\n"),
+                _tab("t2", "two\n", inline_objects={"kix.img1": {}}),
+            ]
+        }
+        assert find_object_tab(doc, "kix.img1") == "t2"
+
+    def test_found_in_child_tab(self):
+        doc = {
+            "tabs": [
+                _tab("t1", "one\n", children=[
+                    _tab("t1c", "child\n", inline_objects={"kix.img1": {}}),
+                ]),
+            ]
+        }
+        assert find_object_tab(doc, "kix.img1") == "t1c"
+
+    def test_positioned_object_found(self):
+        doc = {
+            "tabs": [
+                _tab("t1", "one\n", positioned_objects={"kix.pos1": {}}),
+            ]
+        }
+        assert find_object_tab(doc, "kix.pos1") == "t1"
+
+    def test_not_found_returns_none(self):
+        doc = {"tabs": [_tab("t1", "one\n")]}
+        assert find_object_tab(doc, "kix.other") is None
+
+
+# "Intro Architecture Detail\n": "Architecture" starts at doc index 7
+# (start=1 + offset 6) and ends at 19; body endIndex is 27.
+_ONE_TAB_DOC = {
+    "revisionId": "rev1",
+    "tabs": [_tab("t1", "Intro Architecture Detail\n")],
+}
+
+_TWO_TAB_DOC = {
+    "revisionId": "rev1",
+    "tabs": [
+        _tab("t1", "Intro only\n"),
+        _tab("t2", "Architecture here\n", title="Notes"),
+    ],
+}
+
+
+def _make_args(command, **overrides):
+    defaults = {
+        "command": command,
+        "doc": "doc123",
+        "image": IMG_URL,
+        "tab": None,
+        "after": None,
+        "index": None,
+        "end": False,
+        "width": None,
+        "height": None,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": True,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+@patch("gdoc.api.docs.insert_inline_image", return_value="kix.newimg")
+@patch("gdoc.api.docs.get_document_with_tabs", return_value=_ONE_TAB_DOC)
+class TestCmdInsertImage:
+    def test_after_anchor_inserts_at_end_index(
+        self, mock_get, mock_insert, _ver, mock_update, capsys,
+    ):
+        args = _make_args("insert-image", after="Architecture")
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        mock_insert.assert_called_once_with(
+            "doc123", IMG_URL, 19,
+            tab_id="t1", revision_id="rev1",
+            width_pt=None, height_pt=None,
+        )
+        assert "OK inserted image kix.newimg" in capsys.readouterr().out
+        assert mock_update.call_args.kwargs["command_version"] == 7
+
+    def test_normalized_anchor_fallback(
+        self, mock_get, mock_insert, _ver, _update,
+    ):
+        mock_get.return_value = {
+            "revisionId": "rev1",
+            "tabs": [_tab("t1", "It’s here\n")],
+        }
+        args = _make_args("insert-image", after="It's")
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        assert mock_insert.call_args.args[2] == 5  # after "It's"
+
+    def test_anchor_not_found(self, mock_get, mock_insert, _ver, _update):
+        args = _make_args("insert-image", after="Nonexistent")
+        with pytest.raises(GdocError, match="anchor not found") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+        mock_insert.assert_not_called()
+
+    def test_ambiguous_anchor(self, mock_get, mock_insert, _ver, _update):
+        mock_get.return_value = {
+            "revisionId": "rev1",
+            "tabs": [_tab("t1", "foo bar foo\n")],
+        }
+        args = _make_args("insert-image", after="foo")
+        with pytest.raises(GdocError, match="ambiguous") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+
+    def test_multi_tab_requires_tab_flag(
+        self, mock_get, mock_insert, _ver, _update,
+    ):
+        mock_get.return_value = _TWO_TAB_DOC
+        args = _make_args("insert-image", after="Architecture")
+        with pytest.raises(GdocError, match="specify --tab") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+
+    def test_tab_flag_selects_tab(
+        self, mock_get, mock_insert, _ver, _update,
+    ):
+        mock_get.return_value = _TWO_TAB_DOC
+        args = _make_args("insert-image", after="Architecture", tab="Notes")
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        assert mock_insert.call_args.kwargs["tab_id"] == "t2"
+
+    def test_index_used_directly(self, mock_get, mock_insert, _ver, _update):
+        args = _make_args("insert-image", index=5)
+        cmd_insert_image(args)
+        assert mock_insert.call_args.args[2] == 5
+
+    def test_index_zero_rejected(self, mock_get, mock_insert, _ver, _update):
+        args = _make_args("insert-image", index=0)
+        with pytest.raises(GdocError, match="--index") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+
+    def test_end_appends_before_final_newline(
+        self, mock_get, mock_insert, _ver, _update,
+    ):
+        args = _make_args("insert-image", end=True)
+        cmd_insert_image(args)
+        # body endIndex 27 → insert at 26, the segment's closing newline
+        assert mock_insert.call_args.args[2] == 26
+
+    def test_width_height_passed(self, mock_get, mock_insert, _ver, _update):
+        args = _make_args(
+            "insert-image", index=5, width=200.0, height=100.0,
+        )
+        cmd_insert_image(args)
+        assert mock_insert.call_args.kwargs["width_pt"] == 200.0
+        assert mock_insert.call_args.kwargs["height_pt"] == 100.0
+
+    def test_json_output(self, mock_get, mock_insert, _ver, _update, capsys):
+        args = _make_args("insert-image", after="Architecture", json=True)
+        cmd_insert_image(args)
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["object_id"] == "kix.newimg"
+        assert data["tab"] == "t1"
+        assert data["index"] == 19
+
+    @patch("gdoc.api.drive.delete_file")
+    @patch("gdoc.api.drive.upload_temp_image",
+           return_value={"id": "tmp1", "webContentLink": "https://dl/tmp1"})
+    def test_local_file_uploaded_and_cleaned_up(
+        self, mock_upload, mock_delete, mock_get, mock_insert, _ver, _update,
+        tmp_path,
+    ):
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+        args = _make_args("insert-image", image=str(img), index=5)
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        mock_upload.assert_called_once_with(str(img), "image/png")
+        assert mock_insert.call_args.args[1] == "https://dl/tmp1"
+        mock_delete.assert_called_once_with("tmp1")
+
+    @patch("gdoc.api.drive.delete_file")
+    @patch("gdoc.api.drive.upload_temp_image",
+           return_value={"id": "tmp1", "webContentLink": "https://dl/tmp1"})
+    def test_temp_cleaned_up_when_insert_fails(
+        self, mock_upload, mock_delete, mock_get, mock_insert, _ver, _update,
+        tmp_path,
+    ):
+        mock_insert.side_effect = GdocError("API error (400): bad image")
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+        args = _make_args("insert-image", image=str(img), index=5)
+        with pytest.raises(GdocError):
+            cmd_insert_image(args)
+        mock_delete.assert_called_once_with("tmp1")
+
+    @patch("gdoc.api.drive.delete_file", side_effect=GdocError("denied"))
+    @patch("gdoc.api.drive.upload_temp_image",
+           return_value={"id": "tmp1", "webContentLink": "https://dl/tmp1"})
+    def test_cleanup_failure_warns_but_succeeds(
+        self, mock_upload, mock_delete, mock_get, mock_insert, _ver, _update,
+        tmp_path, capsys,
+    ):
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+        args = _make_args("insert-image", image=str(img), index=5)
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "WARN" in err
+        assert "tmp1" in err
+
+    def test_missing_local_file_fails_fast(
+        self, mock_get, mock_insert, _ver, _update, tmp_path,
+    ):
+        args = _make_args(
+            "insert-image", image=str(tmp_path / "nope.png"), index=5,
+        )
+        with pytest.raises(GdocError, match="not found") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+        mock_get.assert_not_called()
+
+    def test_unsupported_extension_fails_fast(
+        self, mock_get, mock_insert, _ver, _update, tmp_path,
+    ):
+        img = tmp_path / "pic.bmp"
+        img.write_bytes(b"BM")
+        args = _make_args("insert-image", image=str(img), index=5)
+        with pytest.raises(GdocError, match="unsupported") as exc_info:
+            cmd_insert_image(args)
+        assert exc_info.value.exit_code == 3
+        mock_get.assert_not_called()
+
+
+_REPLACE_DOC = {
+    "revisionId": "rev1",
+    "tabs": [
+        _tab("t1", "one\n"),
+        _tab("t2", "two\n", inline_objects={"kix.img1": {}}),
+    ],
+}
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.drive.get_file_version", return_value={"version": 8})
+@patch("gdoc.api.docs.replace_image")
+@patch("gdoc.api.docs.get_document_with_tabs", return_value=_REPLACE_DOC)
+class TestCmdReplaceImage:
+    def test_replaces_in_owning_tab(
+        self, mock_get, mock_replace, _ver, mock_update, capsys,
+    ):
+        args = _make_args(
+            "replace-image", object_id="kix.img1",
+        )
+        rc = cmd_replace_image(args)
+        assert rc == 0
+        mock_replace.assert_called_once_with(
+            "doc123", "kix.img1", IMG_URL,
+            tab_id="t2", revision_id="rev1",
+        )
+        assert "OK replaced image kix.img1" in capsys.readouterr().out
+        assert mock_update.call_args.kwargs["command_version"] == 8
+
+    def test_object_not_found(self, mock_get, mock_replace, _ver, _update):
+        args = _make_args("replace-image", object_id="kix.missing")
+        with pytest.raises(GdocError, match="not found") as exc_info:
+            cmd_replace_image(args)
+        assert exc_info.value.exit_code == 3
+        mock_replace.assert_not_called()
+
+    def test_legacy_doc_without_tabs(
+        self, mock_get, mock_replace, _ver, _update,
+    ):
+        mock_get.return_value = {
+            "revisionId": "rev1",
+            "inlineObjects": {"kix.img1": {}},
+        }
+        args = _make_args("replace-image", object_id="kix.img1")
+        rc = cmd_replace_image(args)
+        assert rc == 0
+        assert mock_replace.call_args.kwargs["tab_id"] is None
+
+    @patch("gdoc.api.drive.delete_file")
+    @patch("gdoc.api.drive.upload_temp_image",
+           return_value={"id": "tmp2", "webContentLink": "https://dl/tmp2"})
+    def test_local_file_uploaded_and_cleaned_up(
+        self, mock_upload, mock_delete, mock_get, mock_replace, _ver,
+        _update, tmp_path,
+    ):
+        img = tmp_path / "new.jpg"
+        img.write_bytes(b"\xff\xd8")
+        args = _make_args(
+            "replace-image", object_id="kix.img1", image=str(img),
+        )
+        rc = cmd_replace_image(args)
+        assert rc == 0
+        mock_upload.assert_called_once_with(str(img), "image/jpeg")
+        assert mock_replace.call_args.args[2] == "https://dl/tmp2"
+        mock_delete.assert_called_once_with("tmp2")
+
+    def test_json_output(
+        self, mock_get, mock_replace, _ver, _update, capsys,
+    ):
+        args = _make_args(
+            "replace-image", object_id="kix.img1", json=True,
+        )
+        cmd_replace_image(args)
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["object_id"] == "kix.img1"
+        assert data["status"] == "replaced"

--- a/tests/test_image_edit.py
+++ b/tests/test_image_edit.py
@@ -398,6 +398,21 @@ class TestCmdInsertImage:
         assert "WARN" in err
         assert "tmp1" in err
 
+    @patch("gdoc.api.drive.upload_temp_image")
+    def test_invalid_dimensions_fail_fast(
+        self, mock_upload, mock_get, mock_insert, _ver, _update,
+    ):
+        for bad in (0.0, -5.0, float("nan"), float("inf")):
+            args = _make_args("insert-image", index=5, width=bad)
+            with pytest.raises(GdocError, match="--width") as exc_info:
+                cmd_insert_image(args)
+            assert exc_info.value.exit_code == 3
+        args = _make_args("insert-image", index=5, height=0.0)
+        with pytest.raises(GdocError, match="--height"):
+            cmd_insert_image(args)
+        mock_upload.assert_not_called()
+        mock_insert.assert_not_called()
+
     def test_missing_local_file_fails_fast(
         self, mock_get, mock_insert, _ver, _update, tmp_path,
     ):
@@ -449,6 +464,32 @@ class TestCmdInsertImage:
             cmd_insert_image(args)
         mock_delete.assert_called_once_with("tmp1")
         mock_insert.assert_not_called()
+
+
+class TestUploadTempImageCleanup:
+    @patch("gdoc.api.drive.get_drive_service")
+    def test_blocked_public_share_deletes_upload(self, mock_svc, tmp_path):
+        """A Workspace policy can forbid anyone-sharing; the just-created
+        temp file must not be orphaned when permissions.create fails."""
+        from gdoc.api.drive import upload_temp_image
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+
+        service = MagicMock()
+        files = service.files.return_value
+        files.create.return_value.execute.return_value = {
+            "id": "tmp1", "webContentLink": "https://dl/tmp1",
+        }
+        service.permissions.return_value.create.return_value.execute.side_effect = (
+            _http_error(403)
+        )
+        mock_svc.return_value = service
+
+        with pytest.raises(GdocError):
+            upload_temp_image(str(img), "image/png")
+
+        files.delete.assert_called_once_with(fileId="tmp1")
 
 
 _REPLACE_DOC = {

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -128,8 +128,56 @@ def _make_body_with_inline_refs(*obj_ids):
 # --- list_inline_objects tests ---
 
 
+class TestListInlineObjectsTabs:
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_objects_found_in_every_tab(self, mock_get_doc):
+        """Objects in tabs beyond the first are listed, tagged with the
+        owning tab ID (they feed replace-image's object lookup)."""
+        def tab(tab_id, obj_id):
+            return {
+                "tabProperties": {"tabId": tab_id, "title": tab_id},
+                "documentTab": {
+                    "body": {
+                        "content": _make_body_with_inline_refs(obj_id),
+                    },
+                    "inlineObjects": _make_inline_image(obj_id),
+                },
+            }
+
+        mock_get_doc.return_value = {
+            "tabs": [tab("t1", "kix.one"), tab("t2", "kix.two")],
+        }
+
+        result = list_inline_objects("doc123")
+
+        assert [(o["id"], o["tab"]) for o in result] == [
+            ("kix.one", "t1"), ("kix.two", "t2"),
+        ]
+
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_child_tab_objects_found(self, mock_get_doc):
+        child = {
+            "tabProperties": {"tabId": "t1c", "title": "child"},
+            "documentTab": {
+                "body": {"content": _make_body_with_inline_refs("kix.kid")},
+                "inlineObjects": _make_inline_image("kix.kid"),
+            },
+        }
+        mock_get_doc.return_value = {
+            "tabs": [{
+                "tabProperties": {"tabId": "t1", "title": "t1"},
+                "documentTab": {"body": {"content": []}},
+                "childTabs": [child],
+            }],
+        }
+
+        result = list_inline_objects("doc123")
+
+        assert [(o["id"], o["tab"]) for o in result] == [("kix.kid", "t1c")]
+
+
 class TestListInlineObjects:
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_image_metadata(self, mock_get_doc):
         inline = _make_inline_image("kix.abc", title="Logo", width=200, height=100)
         body = _make_body_with_inline_refs("kix.abc")
@@ -145,7 +193,7 @@ class TestListInlineObjects:
         assert img["height_pt"] == 100
         assert img["content_uri"] == "https://lh3.google.com/img1"
 
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_drawing_classification(self, mock_get_doc):
         drawing = _make_inline_drawing("kix.draw")
         body = _make_body_with_inline_refs("kix.draw")
@@ -156,7 +204,7 @@ class TestListInlineObjects:
         assert result[0]["type"] == "drawing"
         assert result[0]["content_uri"] is None
 
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_chart_classification(self, mock_get_doc):
         chart = _make_inline_chart("kix.chart", title="Q1 Revenue",
                                    spreadsheet_id="sID", chart_id=99)
@@ -172,7 +220,7 @@ class TestListInlineObjects:
         assert c["chart_id"] == 99
         assert c["content_uri"] == "https://lh3.google.com/chart1"
 
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_mixed_objects(self, mock_get_doc):
         inline = {}
         inline.update(_make_inline_image("kix.img", title="Photo"))
@@ -188,13 +236,13 @@ class TestListInlineObjects:
         assert "drawing" in types
         assert "chart" in types
 
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_empty_doc(self, mock_get_doc):
         mock_get_doc.return_value = _make_doc()
         result = list_inline_objects("doc123")
         assert result == []
 
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_positioned_objects(self, mock_get_doc):
         positioned = {
             "kix.pos": {
@@ -234,7 +282,7 @@ class TestListInlineObjects:
         assert result[0]["type"] == "image"
         assert result[0]["title"] == "Floating"
 
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_dedup_same_id(self, mock_get_doc):
         """Same object ID referenced twice should only appear once."""
         inline = _make_inline_image("kix.dup", title="Dup")
@@ -305,7 +353,7 @@ _SAMPLE_OBJECTS = [
 class TestCmdImages:
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     def test_terse_output(self, _doc, _pf, _update, capsys):
         args = _make_args()
         rc = cmd_images(args)
@@ -319,7 +367,7 @@ class TestCmdImages:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     def test_json_output(self, _doc, _pf, _update, capsys):
         args = _make_args(json=True)
         rc = cmd_images(args)
@@ -334,7 +382,7 @@ class TestCmdImages:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     def test_plain_output(self, _doc, _pf, _update, capsys):
         args = _make_args(plain=True)
         rc = cmd_images(args)
@@ -349,7 +397,7 @@ class TestCmdImages:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     def test_verbose_output(self, _doc, _pf, _update, capsys):
         args = _make_args(verbose=True)
         rc = cmd_images(args)
@@ -360,7 +408,7 @@ class TestCmdImages:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document")
+    @patch("gdoc.api.docs.get_document_with_tabs")
     def test_empty_no_images(self, mock_doc, _pf, _update, capsys):
         mock_doc.return_value = _make_doc()
         args = _make_args()
@@ -372,7 +420,7 @@ class TestCmdImages:
 class TestCmdImagesFilter:
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     def test_filter_by_id(self, _doc, _pf, _update, capsys):
         args = _make_args(image_id="kix.abc")
         rc = cmd_images(args)
@@ -383,7 +431,7 @@ class TestCmdImagesFilter:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     def test_filter_not_found(self, _doc, _pf, _update):
         args = _make_args(image_id="kix.nonexistent")
         with pytest.raises(GdocError, match="image not found"):
@@ -393,7 +441,7 @@ class TestCmdImagesFilter:
 class TestCmdImagesDownload:
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     @patch("gdoc.api.docs.download_image")
     def test_download_images(self, mock_dl, _doc, _pf, _update, capsys, tmp_path):
         download_dir = str(tmp_path / "imgs")
@@ -412,7 +460,7 @@ class TestCmdImagesDownload:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     @patch("gdoc.api.docs.download_image")
     def test_download_creates_dir(self, mock_dl, _doc, _pf, _update, tmp_path):
         download_dir = str(tmp_path / "new" / "nested")
@@ -422,7 +470,7 @@ class TestCmdImagesDownload:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     @patch("gdoc.api.docs.download_image")
     def test_download_specific_image(
         self, mock_dl, _doc, _pf, _update, capsys, tmp_path,
@@ -437,7 +485,7 @@ class TestCmdImagesDownload:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
-    @patch("gdoc.api.docs.get_document", return_value=_SAMPLE_DOC)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_SAMPLE_DOC)
     @patch("gdoc.api.docs.download_image")
     def test_download_skips_no_uri(self, mock_dl, _doc, _pf, _update, capsys, tmp_path):
         """Drawing has no content_uri; should be skipped with warning."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -124,6 +124,16 @@ class TestUpdateStateAfterCommand:
             assert state.last_version == 50
             assert state.last_read_version == 50  # info is a read
 
+    def test_normal_export_is_a_read(self, tmp_path):
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            info = self._make_change_info(current_version=60)
+            update_state_after_command(
+                "doc1", info, command="export", quiet=False,
+            )
+            state = load_state("doc1")
+            assert state.last_version == 60
+            assert state.last_read_version == 60  # export reads the full doc
+
     def test_quiet_cat_version_stays_stale(self, tmp_path):
         """Decision #14: --quiet cat does not update version fields."""
         with patch("gdoc.state.STATE_DIR", tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
Closes #35.

Completes the revise → render → inspect loop from the issue: documents can now be rendered to real artifact files, and images in existing documents can be added or swapped without rebuilding the doc.

## `gdoc export`

```bash
gdoc export DOC --out report.pdf          # format inferred from extension
gdoc export DOC --format docx --out r.docx
gdoc export DOC --format md               # text formats may stream to stdout
```

- New bytes-safe `export_doc_bytes` Drive wrapper (the existing `export_doc` always decoded UTF-8, which corrupts binary formats).
- Formats: `pdf`, `docx`, `odt`, `epub`, `html`, `md`, `txt`, `rtf`. Binary formats require `--out` — no PDF bytes to a terminal.
- Exports cover the whole document (all tabs), stated in the command description.
- `export` advances the awareness read baseline (`last_read_version`) like `cat`/`pull` — it is a full-document read.

## `gdoc insert-image`

```bash
gdoc insert-image DOC diagram.png --after 'Architecture'
gdoc insert-image DOC https://example.org/chart.png --tab Notes --end --width 400
```

- Anchors: `--after TEXT` (retries with smart-quote/dash folding; ambiguous anchors are refused with a count), raw `--index`, or `--end`.
- Multi-tab docs require `--tab` — an insert at a raw index must not land in the wrong tab.
- Write is pinned to the read revision via `writeControl.requiredRevisionId`; a mismatch fails with a clear re-run hint instead of writing at stale coordinates.
- Local files upload as a temporary public-read Drive file (Google fetches the URI), deleted in `finally`; a failed cleanup prints a WARN with the file ID instead of leaving the exposure silent (per the issue's safety note).
- Prints the new object ID (usable with `gdoc images` / `replace-image`).

## `gdoc replace-image`

```bash
gdoc replace-image DOC kix.abc123 diagram-v2.png
```

- Wraps `replaceImage` (CENTER_CROP — the only supported method; existing display size kept, stated in output).
- The owning tab is located automatically by walking the tab tree (including child tabs and positioned objects); unknown IDs fail with exit 3 before any write.

## Verification

- 45 new tests (1282 total, all passing); ruff clean on touched code; stub gate OK.
- Live smoke test against a real doc: exported valid PDF (`file` reports `PDF document`) and DOCX, inserted a remote-URL image anchored mid-paragraph and a local PNG at `--end` (temp upload + cleanup verified), replaced an image and confirmed the new content in a re-export. Smoke doc deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)