### PR TITLE
feat(mcp): add MCP server to enable gdoc on Claude Cowork etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to `gdoc` are documented here. This project follows
 
 ### Added
 - **MCP server: `gdoc mcp`.** Serves gdoc over the Model Context Protocol
-  on stdio, so desktop chat clients that launch a local server (Claude
-  Desktop, ChatGPT desktop) can read and edit Docs without shell access —
+  on stdio, so clients that launch a local server (Claude Desktop, the
+  Codex CLI) can read and edit Docs without shell access —
   previously gdoc was only reachable from a coding agent. 29 subcommands
   are exposed as tools, with input schemas derived from the argparse
   parser so new flags surface automatically. `--read-only` restricts the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.20.0] — 2026-08-14
 
 ### Added
 - **MCP server: `gdoc mcp`.** Serves gdoc over the Model Context Protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **MCP server: `gdoc mcp`.** Serves gdoc over the Model Context Protocol
+  on stdio, so desktop chat clients that launch a local server (Claude
+  Desktop, ChatGPT desktop) can read and edit Docs without shell access —
+  previously gdoc was only reachable from a coding agent. 31 subcommands
+  are exposed as tools, with input schemas derived from the argparse
+  parser so new flags surface automatically. `--read-only` restricts the
+  surface to commands that cannot modify Docs or Drive, `--allow` takes an
+  explicit subset, and `--account` pins every call to one account.
+  `write` and `insert` additionally accept inline `text`, since a chat
+  client has no filesystem to write a markdown file to. No new
+  dependencies: the stdio transport is newline-delimited JSON-RPC 2.0,
+  implemented in `gdoc/mcp.py`. Commands run in-process through the same
+  dispatch as the CLI, factored out of `main()` as `run_argv()`.
+
 ## [0.19.0] — 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,29 @@ All notable changes to `gdoc` are documented here. This project follows
 - **MCP server: `gdoc mcp`.** Serves gdoc over the Model Context Protocol
   on stdio, so desktop chat clients that launch a local server (Claude
   Desktop, ChatGPT desktop) can read and edit Docs without shell access —
-  previously gdoc was only reachable from a coding agent. 31 subcommands
+  previously gdoc was only reachable from a coding agent. 29 subcommands
   are exposed as tools, with input schemas derived from the argparse
   parser so new flags surface automatically. `--read-only` restricts the
-  surface to commands that cannot modify Docs or Drive, `--allow` takes an
-  explicit subset, and `--account` pins every call to one account.
-  `write` and `insert` additionally accept inline `text`, since a chat
-  client has no filesystem to write a markdown file to. No new
-  dependencies: the stdio transport is newline-delimited JSON-RPC 2.0,
-  implemented in `gdoc/mcp.py`. Commands run in-process through the same
-  dispatch as the CLI, factored out of `main()` as `run_argv()`.
+  surface to commands that cannot modify Docs or Drive, `--allow` takes
+  an explicit subset (`GDOC_ALLOW_COMMANDS` is honoured too), and
+  `--account` sets the account for every call (an explicit `account`
+  argument on a call wins). `write`, `insert`, and `new` take markdown
+  content as inline `text`, since a chat client has no filesystem to
+  write a markdown file to; parameters that name local files
+  (`edit --old-file/--new-file`, `diff FILE`/`--out`/`--format html`,
+  `images --download`, `cells --file/--stdin`) are not exposed at all,
+  so a prompt-injected model cannot read or write files on the host.
+  `diff` reporting "differences found" (CLI exit code 1) is a normal
+  result, not a tool error. No new dependencies: the stdio transport is
+  newline-delimited JSON-RPC 2.0, implemented in `gdoc/mcp.py`. Commands
+  run in-process through the same dispatch as the CLI, factored out of
+  `main()` as `run_argv()`; each call runs with stdin detached so a
+  stdin-reading command can never swallow the protocol stream.
+
+### Fixed
+- Markdown file reads and writes (`write`, `insert`, `new --file`,
+  `push`, `pull`, sync hooks) now use explicit UTF-8 instead of the
+  locale default encoding.
 
 ## [0.19.0] — 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ expired auth, still do).
 ## Desktop chat apps (MCP)
 
 `gdoc mcp` runs gdoc as a [Model Context Protocol](https://modelcontextprotocol.io)
-server on stdio, so chat clients that launch a local server — Claude
-Desktop, ChatGPT desktop, and others — can use gdoc without shell access.
+server on stdio, so clients that launch a local server — Claude Desktop,
+the Codex CLI, and others — can use gdoc without shell access.
 Each supported subcommand becomes a tool (`gdoc_cat`, `gdoc_edit`, …),
 with its parameters derived from the CLI itself.
 
@@ -289,13 +289,16 @@ Developer → Edit Config), then restart the app:
 If the app can't find `gdoc` on its PATH, use the absolute path from
 `which gdoc`.
 
-**ChatGPT desktop** — add to `~/.codex/config.toml`:
+**Codex CLI** — add to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.gdoc]
 command = "gdoc"
 args = ["mcp"]
 ```
+
+ChatGPT desktop itself only connects to *remote* MCP servers over HTTPS,
+so it cannot launch `gdoc mcp` directly.
 
 Useful flags:
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,68 @@ expired auth, still do).
 | `mkdir TITLE` | Create a Drive folder (`--parent FOLDER`) |
 | `mv DOC FOLDER` | Move a file into a folder (alias: `move`) |
 | `rename DOC TITLE` | Rename a file |
+| `mcp` | Serve gdoc to desktop chat apps over MCP (`--read-only`, `--allow`) |
 | `update` | Update gdoc to the latest release |
+
+## Desktop chat apps (MCP)
+
+`gdoc mcp` runs gdoc as a [Model Context Protocol](https://modelcontextprotocol.io)
+server on stdio, so chat clients that launch a local server — Claude
+Desktop, ChatGPT desktop, and others — can use gdoc without shell access.
+Each supported subcommand becomes a tool (`gdoc_cat`, `gdoc_edit`, …),
+with its parameters derived from the CLI itself.
+
+Authenticate first — the server cannot open a browser for the OAuth flow:
+
+```bash
+gdoc auth
+```
+
+**Claude Desktop** — add to `claude_desktop_config.json` (Settings →
+Developer → Edit Config), then restart the app:
+
+```json
+{
+  "mcpServers": {
+    "gdoc": {
+      "command": "gdoc",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+If the app can't find `gdoc` on its PATH, use the absolute path from
+`which gdoc`.
+
+**ChatGPT desktop** — add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.gdoc]
+command = "gdoc"
+args = ["mcp"]
+```
+
+Useful flags:
+
+```bash
+# Reading only — nothing that can modify a Doc or Drive is exposed
+gdoc mcp --read-only
+
+# Expose a specific subset
+gdoc mcp --allow cat,find,comments,comment
+
+# Pin every tool call to one account
+gdoc mcp --account work
+```
+
+Two ways the tools differ from the CLI:
+
+- `write` and `insert` also accept inline `text`, since a chat client has
+  no filesystem to put a markdown file on.
+- `auth`, `update`, `config`, `pull`, `push`, and `export` are not
+  exposed: they need a browser, change the install, or read and write
+  local paths the client cannot see.
 
 ## Output modes
 

--- a/README.md
+++ b/README.md
@@ -306,17 +306,28 @@ gdoc mcp --read-only
 # Expose a specific subset
 gdoc mcp --allow cat,find,comments,comment
 
-# Pin every tool call to one account
+# Default account for every tool call (an explicit `account`
+# argument on a call still wins)
 gdoc mcp --account work
 ```
 
-Two ways the tools differ from the CLI:
+If `GDOC_ALLOW_COMMANDS` is set in the environment the client launches
+the server with, it restricts the tool surface too — and must include
+`mcp` for the server to start at all.
 
-- `write` and `insert` also accept inline `text`, since a chat client has
-  no filesystem to put a markdown file on.
-- `auth`, `update`, `config`, `pull`, `push`, and `export` are not
-  exposed: they need a browser, change the install, or read and write
-  local paths the client cannot see.
+How the tools differ from the CLI:
+
+- `write`, `insert`, and `new` take markdown content as inline `text`
+  instead of a local file path.
+- Parameters that name local files (`edit --old-file/--new-file`,
+  `diff FILE`/`--out`, `images --download`, …) are not exposed: a chat
+  client cannot see the server's filesystem, and hiding them keeps a
+  prompt-injected model from reading or writing files on the host.
+- `auth`, `update`, `config`, `pull`, `push`, `export`, `insert-image`,
+  and `replace-image` are not exposed: they need a browser, change the
+  install, or only work on local paths.
+- `diff` reporting "differences found" (exit code 1 in the CLI,
+  diff-style) is a normal result, not an error.
 
 ## Output modes
 

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/gdoc/api/__init__.py
+++ b/gdoc/api/__init__.py
@@ -30,3 +30,19 @@ def get_sheets_service():
 
     creds = get_credentials()
     return build("sheets", "v4", credentials=creds)
+
+
+def clear_service_caches() -> None:
+    """Forget every cached, account-specific service object.
+
+    A long-lived process (`gdoc mcp`) calls this when the active account
+    changes. Keep it in sync with any new cached service: one missed here
+    keeps serving the previous account's credentials.
+    """
+    from gdoc.api.docs import get_docs_service
+    from gdoc.api.revisions import _get_session
+
+    get_drive_service.cache_clear()
+    get_sheets_service.cache_clear()
+    get_docs_service.cache_clear()
+    _get_session.cache_clear()

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3453,6 +3453,22 @@ def cmd_update(args) -> int:
     return run_update()
 
 
+def cmd_mcp(args) -> int:
+    """Handler for `gdoc mcp`: serve gdoc over MCP on stdio."""
+    from gdoc.mcp import MCPServer
+
+    allow = None
+    if getattr(args, "allow", None):
+        allow = {c.strip().lower() for c in args.allow.split(",") if c.strip()}
+
+    server = MCPServer(
+        read_only=getattr(args, "read_only", False),
+        allow=allow,
+        account=getattr(args, "account", None),
+    )
+    return server.serve()
+
+
 def build_parser() -> GdocArgumentParser:
     """Build the CLI argument parser with all subcommands."""
     parser = GdocArgumentParser(
@@ -3506,6 +3522,35 @@ def build_parser() -> GdocArgumentParser:
     # update
     update_p = sub.add_parser("update", help="Update gdoc to the latest version")
     update_p.set_defaults(func=cmd_update)
+
+    # mcp
+    mcp_p = sub.add_parser(
+        "mcp",
+        help="Serve gdoc to desktop chat clients over MCP (stdio)",
+        description=(
+            "Run gdoc as a Model Context Protocol server on stdin/stdout, so "
+            "clients that launch a local stdio server — Claude Desktop, "
+            "ChatGPT desktop, and others — can read and edit Google Docs "
+            "without shell access. Authenticate first with `gdoc auth`; the "
+            "server cannot open a browser for the OAuth flow."
+        ),
+    )
+    mcp_p.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Expose only commands that cannot modify Docs or Drive",
+    )
+    mcp_p.add_argument(
+        "--allow",
+        metavar="COMMANDS",
+        help="Comma-separated subcommands to expose (default: all supported)",
+    )
+    mcp_p.add_argument(
+        "--account",
+        default=os.environ.get("GDOC_ACCOUNT"),
+        help="Google account to use for every tool call",
+    )
+    mcp_p.set_defaults(func=cmd_mcp)
 
     # auth
     auth_p = sub.add_parser("auth", parents=[output_parent], help="Authenticate with Google")
@@ -4272,14 +4317,14 @@ def _is_top_level_help_invocation(argv: list[str]) -> bool:
     return rest[0] in ("--help", "-h")
 
 
-def main() -> int:
-    """Entry point for the gdoc CLI."""
-    if _is_top_level_help_invocation(sys.argv):
-        from gdoc.update import auto_update_for_help
-        auto_update_for_help()
+def run_argv(argv: list[str] | None = None, *, check_updates: bool = True) -> int:
+    """Parse an argv list and run the matching subcommand.
 
+    Shared by `main()` and by the MCP server (`gdoc mcp`), which dispatches
+    tool calls in-process rather than shelling out to a new interpreter.
+    """
     parser = build_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.command is None:
         parser.print_help(sys.stderr)
@@ -4310,7 +4355,9 @@ def main() -> int:
             set_active_account(account)
 
         # Check for updates (skip for the update command itself and internal hooks)
-        if args.command not in ("update", "_sync-hook", "_pull-hook"):
+        if check_updates and args.command not in (
+            "update", "_sync-hook", "_pull-hook", "mcp",
+        ):
             from gdoc.update import check_for_update
             check_for_update()
 
@@ -4324,3 +4371,12 @@ def main() -> int:
     except Exception as e:
         print(f"ERR: unexpected error: {e}", file=sys.stderr)
         return 1
+
+
+def main() -> int:
+    """Entry point for the gdoc CLI."""
+    if _is_top_level_help_invocation(sys.argv):
+        from gdoc.update import auto_update_for_help
+        auto_update_for_help()
+
+    return run_argv()

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3529,8 +3529,8 @@ def build_parser() -> GdocArgumentParser:
         help="Serve gdoc to desktop chat clients over MCP (stdio)",
         description=(
             "Run gdoc as a Model Context Protocol server on stdin/stdout, so "
-            "clients that launch a local stdio server — Claude Desktop, "
-            "ChatGPT desktop, and others — can read and edit Google Docs "
+            "clients that launch a local stdio server — Claude Desktop, the "
+            "Codex CLI, and others — can read and edit Google Docs "
             "without shell access. Authenticate first with `gdoc auth`; the "
             "server cannot open a browser for the OAuth flow."
         ),

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -686,7 +686,7 @@ def cmd_insert(args) -> int:
     if not os.path.isfile(file_path):
         raise GdocError(f"file not found: {file_path}", exit_code=3)
     try:
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
     except OSError as e:
         raise GdocError(f"cannot read file: {e}", exit_code=3) from e
@@ -1326,7 +1326,7 @@ def cmd_write(args) -> int:
     if not os.path.isfile(file_path):
         raise GdocError(f"file not found: {file_path}", exit_code=3)
     try:
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
     except OSError as e:
         raise GdocError(f"cannot read file: {e}", exit_code=3) from e
@@ -1440,7 +1440,7 @@ def cmd_pull(args) -> int:
     content = add_frontmatter(markdown, front)
 
     try:
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(content)
     except OSError as e:
         raise GdocError(f"cannot write file: {e}", exit_code=3)
@@ -1500,7 +1500,7 @@ def cmd_push(args) -> int:
     if not os.path.isfile(file_path):
         raise GdocError(f"file not found: {file_path}", exit_code=3)
     try:
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
     except OSError as e:
         raise GdocError(f"cannot read file: {e}", exit_code=3)
@@ -1595,7 +1595,7 @@ def cmd_sync_hook(args) -> int:
         if not os.path.isfile(file_path):
             return 0
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         from gdoc.frontmatter import parse_frontmatter
@@ -1664,7 +1664,7 @@ def cmd_pull_hook(args) -> int:
         if not os.path.isfile(file_path):
             return 0
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         from gdoc.frontmatter import parse_frontmatter
@@ -1700,7 +1700,7 @@ def cmd_pull_hook(args) -> int:
 
         new_content = add_frontmatter(markdown, {"gdoc": doc_id, "title": title})
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(new_content)
 
         print(
@@ -2942,7 +2942,7 @@ def _cmd_new_from_file(args) -> int:
     if not os.path.isfile(file_path):
         raise GdocError(f"file not found: {file_path}", exit_code=3)
     try:
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
     except OSError as e:
         raise GdocError(f"cannot read file: {e}", exit_code=3)

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -113,6 +113,16 @@ _LOCAL_PATH_CHOICES: dict[str, dict[str, frozenset[str]]] = {
 # not failure. Real errors still print an ERR: line to stderr.
 _DIFF_EXIT_COMMANDS = frozenset({"diff"})
 
+# MCP-only schema tightenings: parameters the CLI can satisfy another way
+# (an alternative flag, an interactive prompt) that MCP cannot, so a
+# schema-valid call would otherwise be guaranteed to fail at runtime.
+_EXTRA_REQUIRED: dict[str, tuple[str, ...]] = {
+    # -v/--value is the only data source left once --file/--stdin are hidden
+    "cells": ("value",),
+    # confirm_destructive() cannot prompt over MCP (stdin is detached)
+    "delete-comment": ("force",),
+}
+
 # Parser-level plumbing that must not become a tool parameter.
 _SKIP_DESTS = frozenset({
     "help",
@@ -178,6 +188,7 @@ def _schema_for(command: str, parser: argparse.ArgumentParser) -> dict[str, Any]
     required: list[str] = []
     hidden = _LOCAL_PATH_PARAMS.get(command, frozenset())
     hidden_choices = _LOCAL_PATH_CHOICES.get(command, {})
+    extra_required = _EXTRA_REQUIRED.get(command, ())
 
     for action in parser._actions:
         if action.dest in _SKIP_DESTS or action.dest in hidden:
@@ -191,12 +202,14 @@ def _schema_for(command: str, parser: argparse.ArgumentParser) -> dict[str, Any]
         removed = hidden_choices.get(action.dest)
         if removed and "enum" in prop:
             prop["enum"] = [c for c in prop["enum"] if c not in removed]
+        if action.dest in extra_required and prop.get("type") == "array":
+            prop["minItems"] = 1
         properties[action.dest] = prop
 
         is_positional = not action.option_strings
         if is_positional and action.nargs not in ("?", "*"):
             required.append(action.dest)
-        elif action.required:  # e.g. `insert --tab`
+        elif action.required or action.dest in extra_required:
             required.append(action.dest)
 
     schema: dict[str, Any] = {"type": "object", "properties": properties}
@@ -389,6 +402,14 @@ def call_command(
         raise ValueError(f"unknown command: {command}")
 
     _reject_local_paths(command, arguments)
+
+    # Schema `required` cannot force a boolean to be true, so guard here:
+    # with stdin detached, confirm_destructive() can never prompt.
+    if command == "delete-comment" and not arguments.get("force"):
+        raise ValueError(
+            "`force: true` is required: deletion cannot prompt for "
+            "confirmation over MCP"
+        )
 
     file_arg = _TEXT_TO_FILE.get(command)
     if (

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -27,6 +27,7 @@ import contextlib
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 from typing import Any
@@ -126,6 +127,25 @@ _EXTRA_REQUIRED: dict[str, tuple[str, ...]] = {
     # confirm_destructive() cannot prompt over MCP (stdin is detached)
     "delete-comment": ("force",),
 }
+
+# Cross-parameter requirements JSON Schema could only express with a
+# root-level oneOf/anyOf, which several MCP clients reject or ignore.
+# Stated in the tool description instead; the CLI repeats the same
+# constraint in its error message at call time.
+_DESCRIPTION_NOTES: dict[str, str] = {
+    "diff": "Exactly one of `rev` or `since` is required over MCP.",
+    "share": "Exactly one of `email`, `domain`, or `anyone` is required.",
+    "edit": (
+        "Text replacement needs `old_text` and `new_text`; `cell` mode "
+        "addresses a table cell instead."
+    ),
+}
+
+# `new` imports markdown images: extract_images() resolves non-http(s)
+# references against the materialised temp file's directory and uploads
+# what it finds, so inline text could still read server files that the
+# hidden path parameters no longer can.
+_IMAGE_REF = re.compile(r"!\[[^\]]*\]\(\s*([^)\s]+)")
 
 # Parser-level plumbing that must not become a tool parameter.
 _SKIP_DESTS = frozenset({
@@ -233,6 +253,9 @@ def _description_for(command: str, parser: argparse.ArgumentParser) -> str:
     text = (parser.description or "").strip()
     if not text:
         text = (getattr(parser, "_gdoc_help", "") or "").strip()
+    note = _DESCRIPTION_NOTES.get(command)
+    if note:
+        text = f"{text}\n\n{note}" if text else note
     if not EXPOSED_COMMANDS[command]:
         warning = "Writes to Google Docs/Drive."
         text = f"{text}\n\n{warning}" if text else warning
@@ -414,6 +437,14 @@ def call_command(
             "`force: true` is required: deletion cannot prompt for "
             "confirmation over MCP"
         )
+
+    if command == "new" and arguments.get("text"):
+        for target in _IMAGE_REF.findall(arguments["text"]):
+            if not target.startswith(("http://", "https://")):
+                raise ValueError(
+                    f"local image reference in text: {target!r} — over MCP, "
+                    "images must be http(s) URLs"
+                )
 
     file_arg = _TEXT_TO_FILE.get(command)
     if (

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -1,0 +1,537 @@
+"""Model Context Protocol server exposing gdoc subcommands as MCP tools.
+
+`gdoc mcp` speaks MCP over stdio so desktop chat clients (Claude Desktop,
+ChatGPT desktop, and anything else that launches a local stdio server) can
+drive gdoc directly, instead of gdoc only being reachable from a coding
+agent with shell access.
+
+Design notes:
+
+- **No new dependencies.** MCP's stdio transport is newline-delimited
+  JSON-RPC 2.0, which is short enough to implement here. Adding an SDK
+  would pull a web stack into a CLI whose dependency list is deliberately
+  four entries long.
+- **Schemas are derived from argparse**, not hand-written, so a new flag on
+  `gdoc edit` becomes an MCP tool parameter with no work here. Only the
+  command allowlist and the read/write classification below are manual.
+- **Commands run in-process** via the same dispatch the CLI uses, with
+  stdout captured. Nothing shells out.
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import sys
+import tempfile
+from typing import Any
+
+from gdoc import __version__
+
+# MCP revisions this server has been checked against. An unknown version
+# from the client falls back to the newest one we know.
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
+DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+TOOL_PREFIX = "gdoc_"
+
+# Subcommands exposed as tools, and whether each one only reads.
+# Anything absent is deliberately not exposed: `auth` needs an interactive
+# browser, `update` mutates the install, `config` is machine-wide, and
+# `pull`/`push`/`export` work on local file paths a chat client cannot see.
+EXPOSED_COMMANDS: dict[str, bool] = {
+    # read-only
+    "ls": True,
+    "find": True,
+    "cat": True,
+    "info": True,
+    "tabs": True,
+    "toc": True,
+    "cells": True,
+    "revisions": True,
+    "comments": True,
+    "comment-info": True,
+    "diff": True,
+    "images": True,
+    "structure": True,
+    "drives": True,
+    # writes
+    "edit": False,
+    "insert": False,
+    "write": False,
+    "add-tab": False,
+    "insert-image": False,
+    "replace-image": False,
+    "comment": False,
+    "reply": False,
+    "resolve": False,
+    "reopen": False,
+    "delete-comment": False,
+    "new": False,
+    "cp": False,
+    "mkdir": False,
+    "mv": False,
+    "rename": False,
+    "share": False,
+}
+
+# Commands whose content argument is a local markdown file. A chat client
+# has no filesystem to write one to, so these tools also accept inline
+# `text`, which the server materialises to a temp file for the duration of
+# the call. The CLI itself is unchanged.
+_TEXT_TO_FILE: dict[str, str] = {
+    "write": "file",
+    "insert": "file",
+}
+
+_TEXT_DESCRIPTION = (
+    "Markdown content, supplied inline. Use this instead of `file` when you "
+    "have no local filesystem. Exactly one of `text` or `file` is required."
+)
+
+# Parser-level plumbing that must not become a tool parameter.
+_SKIP_DESTS = frozenset({
+    "help",
+    "func",
+    "command",
+    "allow_commands",
+    "verbose",
+    "plain",
+})
+
+
+def _tool_name(command: str) -> str:
+    return TOOL_PREFIX + command.replace("-", "_")
+
+
+def _command_name(tool: str) -> str:
+    if not tool.startswith(TOOL_PREFIX):
+        raise KeyError(tool)
+    return tool[len(TOOL_PREFIX):].replace("_", "-")
+
+
+def _help_text(action: argparse.Action) -> str:
+    """Render an action's help, tolerating argparse's %(default)s syntax."""
+    help_str = action.help or ""
+    if "%" not in help_str:
+        return help_str
+    try:
+        return help_str % {"default": action.default, "prog": "gdoc"}
+    except (KeyError, TypeError, ValueError):
+        return help_str
+
+
+def _property_for(action: argparse.Action) -> dict[str, Any]:
+    """Map one argparse action onto a JSON Schema property."""
+    prop: dict[str, Any] = {}
+    description = _help_text(action)
+
+    if isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction)):
+        prop["type"] = "boolean"
+    elif action.choices:
+        prop["type"] = "string"
+        prop["enum"] = [str(c) for c in action.choices]
+    elif action.nargs in ("+", "*") or isinstance(action, argparse._AppendAction):
+        prop["type"] = "array"
+        prop["items"] = {"type": "integer" if action.type is int else "string"}
+    elif action.type is int:
+        prop["type"] = "integer"
+    elif action.type is float:
+        prop["type"] = "number"
+    else:
+        prop["type"] = "string"
+
+    if description:
+        prop["description"] = description
+    return prop
+
+
+def _schema_for(parser: argparse.ArgumentParser) -> dict[str, Any]:
+    """Derive a JSON Schema for a subparser's arguments."""
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for action in parser._actions:
+        if action.dest in _SKIP_DESTS:
+            continue
+        if isinstance(action, (argparse._HelpAction, argparse._VersionAction)):
+            continue
+        if isinstance(action, argparse._SubParsersAction):
+            continue
+
+        properties[action.dest] = _property_for(action)
+        is_positional = not action.option_strings
+        if is_positional and action.nargs not in ("?", "*"):
+            required.append(action.dest)
+
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _description_for(command: str, parser: argparse.ArgumentParser) -> str:
+    """Prefer the subparser's long description, falling back to its help."""
+    text = (parser.description or "").strip()
+    if not text:
+        text = (getattr(parser, "_gdoc_help", "") or "").strip()
+    if not EXPOSED_COMMANDS[command]:
+        warning = "Writes to Google Docs/Drive."
+        text = f"{text}\n\n{warning}" if text else warning
+    return text
+
+
+def _subparsers(parser: argparse.ArgumentParser) -> dict[str, argparse.ArgumentParser]:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return dict(action.choices)
+    return {}
+
+
+def build_tools(
+    *, read_only: bool = False, allow: set[str] | None = None
+) -> dict[str, dict[str, Any]]:
+    """Build the MCP tool list by introspecting the gdoc CLI parser.
+
+    Returns a mapping of tool name -> tool definition, in the order the
+    commands are listed in EXPOSED_COMMANDS.
+    """
+    from gdoc.cli import build_parser
+
+    parser = build_parser()
+    subparsers = _subparsers(parser)
+    help_by_command = _help_by_command(parser)
+
+    tools: dict[str, dict[str, Any]] = {}
+    for command, is_read_only in EXPOSED_COMMANDS.items():
+        if command not in subparsers:
+            continue  # command retired upstream; skip rather than crash
+        if read_only and not is_read_only:
+            continue
+        if allow is not None and command not in allow:
+            continue
+
+        sub = subparsers[command]
+        sub._gdoc_help = help_by_command.get(command, "")
+        schema = _schema_for(sub)
+
+        file_arg = _TEXT_TO_FILE.get(command)
+        if file_arg and file_arg in schema["properties"]:
+            schema["properties"]["text"] = {
+                "type": "string",
+                "description": _TEXT_DESCRIPTION,
+            }
+            schema["required"] = [
+                r for r in schema.get("required", []) if r != file_arg
+            ]
+            if not schema["required"]:
+                del schema["required"]
+
+        tools[_tool_name(command)] = {
+            "name": _tool_name(command),
+            "description": _description_for(command, sub),
+            "inputSchema": schema,
+        }
+    return tools
+
+
+def _help_by_command(parser: argparse.ArgumentParser) -> dict[str, str]:
+    """Recover each subcommand's one-line help from the subparsers action."""
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return {
+                choice.dest: (choice.help or "")
+                for choice in action._choices_actions
+            }
+    return {}
+
+
+def _argv_for(
+    command: str, arguments: dict[str, Any], parser: argparse.ArgumentParser
+) -> list[str]:
+    """Turn a tool-call argument dict back into a gdoc argv list."""
+    actions = {
+        a.dest: a
+        for a in parser._actions
+        if a.dest not in _SKIP_DESTS
+        and not isinstance(a, (argparse._HelpAction, argparse._VersionAction))
+    }
+
+    unknown = set(arguments) - set(actions)
+    if unknown:
+        raise ValueError(f"unknown argument(s): {', '.join(sorted(unknown))}")
+
+    positionals: list[str] = []
+    options: list[str] = []
+
+    for dest, action in actions.items():
+        if dest not in arguments:
+            continue
+        value = arguments[dest]
+        if value is None:
+            continue
+
+        if not action.option_strings:
+            if isinstance(value, list):
+                positionals.extend(str(v) for v in value)
+            else:
+                positionals.append(str(value))
+            continue
+
+        flag = max(action.option_strings, key=len)
+        if isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction)):
+            if value:
+                options.append(flag)
+        elif isinstance(action, argparse._AppendAction) and isinstance(value, list):
+            for item in value:
+                options.extend([flag, str(item)])
+        elif isinstance(value, list):
+            options.append(flag)
+            options.extend(str(v) for v in value)
+        else:
+            options.extend([flag, str(value)])
+
+    return [command, *options, *positionals]
+
+
+def call_command(
+    command: str, arguments: dict[str, Any]
+) -> tuple[str, str, int]:
+    """Run a gdoc subcommand in-process, capturing its output.
+
+    Returns (stdout, stderr, exit_code).
+    """
+    from gdoc.cli import build_parser, run_argv
+
+    parser = build_parser()
+    subparser = _subparsers(parser).get(command)
+    if subparser is None:
+        raise ValueError(f"unknown command: {command}")
+
+    _reset_account_state(arguments.get("account"))
+
+    with _materialised_text(command, arguments) as prepared:
+        argv = _argv_for(command, prepared, subparser)
+
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            try:
+                code = run_argv(argv, check_updates=False)
+            except SystemExit as e:  # argparse usage errors exit, not raise
+                code = e.code if isinstance(e.code, int) else 1
+    return out.getvalue(), err.getvalue(), code
+
+
+def _reset_account_state(account: str | None) -> None:
+    """Make each tool call behave like a fresh CLI invocation.
+
+    `set_active_account()` is process-global and the API service objects
+    are `lru_cache`d on the assumption of one account per process — true
+    for the CLI, false for a long-lived server. Without this, a call that
+    names an account would leak into every later call, and cached service
+    objects would keep using the first account's credentials.
+    """
+    from gdoc.util import get_active_account, set_active_account
+
+    if account == get_active_account():
+        return
+
+    from gdoc.api import get_drive_service, get_sheets_service
+    from gdoc.api.docs import get_docs_service
+    from gdoc.api.revisions import _get_session
+
+    for cached in (
+        get_drive_service, get_sheets_service, get_docs_service, _get_session,
+    ):
+        cached.cache_clear()
+    set_active_account(account)
+
+
+@contextlib.contextmanager
+def _materialised_text(command: str, arguments: dict[str, Any]):
+    """Swap an inline `text` argument for a temp file the CLI can read."""
+    file_arg = _TEXT_TO_FILE.get(command)
+    if file_arg is None or "text" not in arguments:
+        yield arguments
+        return
+
+    if arguments.get(file_arg):
+        raise ValueError(f"pass either `text` or `{file_arg}`, not both")
+
+    prepared = {k: v for k, v in arguments.items() if k != "text"}
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".md", encoding="utf-8", delete=True
+    ) as handle:
+        handle.write(arguments["text"])
+        handle.flush()
+        prepared[file_arg] = handle.name
+        yield prepared
+
+
+def _clean_notes(stderr: str) -> str:
+    """Drop pre-flight banners that say nothing happened.
+
+    `pre_flight()` writes a change summary to stderr before most commands.
+    Real changes are worth relaying to the model; "no changes" is noise on
+    every single tool call.
+    """
+    lines = [
+        line for line in stderr.splitlines()
+        if line.strip() not in ("--- no changes ---", "---", "")
+    ]
+    return "\n".join(lines).strip()
+
+
+class MCPServer:
+    """Minimal MCP server over newline-delimited JSON-RPC on stdio."""
+
+    def __init__(
+        self,
+        *,
+        read_only: bool = False,
+        allow: set[str] | None = None,
+        account: str | None = None,
+    ) -> None:
+        self.tools = build_tools(read_only=read_only, allow=allow)
+        self.account = account
+        self.protocol_version = DEFAULT_PROTOCOL_VERSION
+
+    # -- request handlers ------------------------------------------------
+
+    def handle_initialize(self, params: dict[str, Any]) -> dict[str, Any]:
+        requested = params.get("protocolVersion")
+        if requested in SUPPORTED_PROTOCOL_VERSIONS:
+            self.protocol_version = requested
+        return {
+            "protocolVersion": self.protocol_version,
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": "gdoc", "version": __version__},
+            "instructions": (
+                "gdoc reads and edits Google Docs and Drive files. Pass a "
+                "document URL or bare ID as `doc`. Output is terse by design; "
+                "set `json` for machine-readable output."
+            ),
+        }
+
+    def handle_tools_list(self, params: dict[str, Any]) -> dict[str, Any]:
+        return {"tools": list(self.tools.values())}
+
+    def handle_tools_call(self, params: dict[str, Any]) -> dict[str, Any]:
+        name = params.get("name", "")
+        arguments = params.get("arguments") or {}
+
+        if name not in self.tools:
+            return self._text_result(f"ERR: no such tool: {name}", is_error=True)
+
+        if self.account and "account" not in arguments:
+            arguments = {**arguments, "account": self.account}
+
+        try:
+            stdout, stderr, code = call_command(_command_name(name), arguments)
+        except Exception as e:  # surface as a tool error, never kill the server
+            return self._text_result(f"ERR: {e}", is_error=True)
+
+        if code != 0:
+            body = (stderr or stdout).strip() or f"exit code {code}"
+            return self._text_result(body, is_error=True)
+
+        text = stdout.strip()
+        notes = _clean_notes(stderr)
+        if notes:
+            text = f"{text}\n\n--- notes ---\n{notes}" if text else notes
+        return self._text_result(text or "OK")
+
+    @staticmethod
+    def _text_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
+        return {
+            "content": [{"type": "text", "text": text}],
+            "isError": is_error,
+        }
+
+    # -- dispatch --------------------------------------------------------
+
+    def dispatch(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        method = message.get("method")
+        params = message.get("params") or {}
+        msg_id = message.get("id")
+        is_notification = "id" not in message
+
+        handlers = {
+            "initialize": self.handle_initialize,
+            "tools/list": self.handle_tools_list,
+            "tools/call": self.handle_tools_call,
+            "ping": lambda _params: {},
+        }
+
+        if method in ("notifications/initialized", "notifications/cancelled"):
+            return None
+
+        handler = handlers.get(method)
+        if handler is None:
+            if is_notification:
+                return None
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32601, "message": f"method not found: {method}"},
+            }
+
+        try:
+            result = handler(params)
+        except Exception as e:
+            if is_notification:
+                return None
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32603, "message": str(e)},
+            }
+
+        if is_notification:
+            return None
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+    # -- transport -------------------------------------------------------
+
+    def serve(self, stdin=None, stdout=None) -> int:
+        stdin = stdin or sys.stdin
+        protocol_out = stdout or sys.stdout
+
+        # Anything that slips a print() past the per-call capture must not
+        # corrupt the JSON-RPC stream.
+        real_stdout, sys.stdout = sys.stdout, sys.stderr
+        try:
+            for line in stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    self._write(
+                        protocol_out,
+                        {
+                            "jsonrpc": "2.0",
+                            "id": None,
+                            "error": {"code": -32700, "message": "parse error"},
+                        },
+                    )
+                    continue
+
+                messages = message if isinstance(message, list) else [message]
+                for item in messages:
+                    if not isinstance(item, dict):
+                        continue
+                    response = self.dispatch(item)
+                    if response is not None:
+                        self._write(protocol_out, response)
+        except (BrokenPipeError, KeyboardInterrupt):
+            pass
+        finally:
+            sys.stdout = real_stdout
+        return 0
+
+    @staticmethod
+    def _write(stream, payload: dict[str, Any]) -> None:
+        stream.write(json.dumps(payload) + "\n")
+        stream.flush()

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -395,6 +395,10 @@ def _argv_for(
 
         flag = max(action.option_strings, key=len)
         if isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction)):
+            # Strict: a truthy string like "false" must not enable an
+            # opt-in flag — several of them guard destructive behavior.
+            if not isinstance(value, bool):
+                raise ValueError(f"`{dest}` must be a boolean")
             if value:
                 options.append(flag)
         elif isinstance(action, argparse._AppendAction) and isinstance(value, list):
@@ -497,6 +501,12 @@ def _reject_local_paths(command: str, arguments: dict[str, Any]) -> None:
             )
 
 
+# The configured default account the cached services were built under.
+# Unpinned calls must notice `gdoc auth --set-default` happening in
+# another terminal while the server is running.
+_serving_default: str | None = None
+
+
 def _reset_account_state(account: str | None) -> None:
     """Make each tool call behave like a fresh CLI invocation.
 
@@ -506,10 +516,25 @@ def _reset_account_state(account: str | None) -> None:
     names an account would leak into every later call, and cached service
     objects would keep using the first account's credentials.
     """
-    from gdoc.util import get_active_account, set_active_account
+    global _serving_default
+    from gdoc.util import (
+        get_active_account,
+        get_default_account,
+        set_active_account,
+    )
 
     if account == get_active_account():
-        return
+        if account is not None:
+            return
+        # No explicit account: credentials resolve through the configured
+        # default at call time, so a changed default must also drop the
+        # cached services.
+        default = get_default_account()
+        if default == _serving_default:
+            return
+        _serving_default = default
+    elif account is None:
+        _serving_default = get_default_account()
 
     from gdoc.api import clear_service_caches
 

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -1,9 +1,9 @@
 """Model Context Protocol server exposing gdoc subcommands as MCP tools.
 
-`gdoc mcp` speaks MCP over stdio so desktop chat clients (Claude Desktop,
-ChatGPT desktop, and anything else that launches a local stdio server) can
-drive gdoc directly, instead of gdoc only being reachable from a coding
-agent with shell access.
+`gdoc mcp` speaks MCP over stdio so clients that launch a local stdio
+server (Claude Desktop, the Codex CLI, and others) can drive gdoc
+directly, instead of gdoc only being reachable from a coding agent with
+shell access.
 
 Design notes:
 
@@ -16,6 +16,10 @@ Design notes:
   command allowlist and the read/write classification below are manual.
 - **Commands run in-process** via the same dispatch the CLI uses, with
   stdout captured. Nothing shells out.
+- **Validation errors here are deliberately not `GdocError`s.** Everything
+  raised in this module surfaces as a JSON-RPC error or an `isError` tool
+  result; nothing reaches a process exit path, so the CLI's
+  exit-code-carrying exception convention does not apply.
 """
 
 import argparse
@@ -476,14 +480,9 @@ def _reset_account_state(account: str | None) -> None:
     if account == get_active_account():
         return
 
-    from gdoc.api import get_drive_service, get_sheets_service
-    from gdoc.api.docs import get_docs_service
-    from gdoc.api.revisions import _get_session
+    from gdoc.api import clear_service_caches
 
-    for cached in (
-        get_drive_service, get_sheets_service, get_docs_service, _get_session,
-    ):
-        cached.cache_clear()
+    clear_service_caches()
     set_active_account(account)
 
 

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -22,6 +22,7 @@ import argparse
 import contextlib
 import io
 import json
+import os
 import sys
 import tempfile
 from typing import Any
@@ -38,7 +39,8 @@ TOOL_PREFIX = "gdoc_"
 # Subcommands exposed as tools, and whether each one only reads.
 # Anything absent is deliberately not exposed: `auth` needs an interactive
 # browser, `update` mutates the install, `config` is machine-wide, and
-# `pull`/`push`/`export` work on local file paths a chat client cannot see.
+# `pull`/`push`/`export`/`insert-image`/`replace-image` work on local file
+# paths a chat client cannot see.
 EXPOSED_COMMANDS: dict[str, bool] = {
     # read-only
     "ls": True,
@@ -47,7 +49,6 @@ EXPOSED_COMMANDS: dict[str, bool] = {
     "info": True,
     "tabs": True,
     "toc": True,
-    "cells": True,
     "revisions": True,
     "comments": True,
     "comment-info": True,
@@ -59,9 +60,8 @@ EXPOSED_COMMANDS: dict[str, bool] = {
     "edit": False,
     "insert": False,
     "write": False,
+    "cells": False,
     "add-tab": False,
-    "insert-image": False,
-    "replace-image": False,
     "comment": False,
     "reply": False,
     "resolve": False,
@@ -76,18 +76,42 @@ EXPOSED_COMMANDS: dict[str, bool] = {
 }
 
 # Commands whose content argument is a local markdown file. A chat client
-# has no filesystem to write one to, so these tools also accept inline
-# `text`, which the server materialises to a temp file for the duration of
-# the call. The CLI itself is unchanged.
+# has no filesystem to write one to, so over MCP the file parameter is
+# replaced by inline `text`, which the server materialises to a temp file
+# for the duration of the call. The CLI itself is unchanged.
 _TEXT_TO_FILE: dict[str, str] = {
     "write": "file",
     "insert": "file",
+    "new": "file_path",
 }
 
-_TEXT_DESCRIPTION = (
-    "Markdown content, supplied inline. Use this instead of `file` when you "
-    "have no local filesystem. Exactly one of `text` or `file` is required."
-)
+_TEXT_DESCRIPTION = "Markdown content, supplied inline."
+
+# Parameters that name paths on the server's filesystem. A chat client
+# cannot see that filesystem, so they are useless to legitimate callers —
+# and they would let a prompt-injected model read host files into a doc
+# (`edit --new-file ~/.ssh/id_rsa`) or write files onto the host
+# (`images --download`). Stripped from the schemas and rejected at call
+# time.
+_LOCAL_PATH_PARAMS: dict[str, frozenset[str]] = {
+    "edit": frozenset({"old_file", "new_file"}),
+    "write": frozenset({"file"}),
+    "insert": frozenset({"file"}),
+    "new": frozenset({"file_path"}),
+    "cells": frozenset({"file"}),
+    "diff": frozenset({"file", "out"}),
+    "images": frozenset({"download"}),
+}
+
+# Choice values that would write to the server's filesystem: `diff
+# --format html` renders to --out (default gdoc-diff.html in the cwd).
+_LOCAL_PATH_CHOICES: dict[str, dict[str, frozenset[str]]] = {
+    "diff": {"format": frozenset({"html"})},
+}
+
+# Commands that use diff-style exit codes: 1 means "differences found",
+# not failure. Real errors still print an ERR: line to stderr.
+_DIFF_EXIT_COMMANDS = frozenset({"diff"})
 
 # Parser-level plumbing that must not become a tool parameter.
 _SKIP_DESTS = frozenset({
@@ -97,6 +121,8 @@ _SKIP_DESTS = frozenset({
     "allow_commands",
     "verbose",
     "plain",
+    # `cells --stdin` reads the server's stdin — the JSON-RPC stream
+    "stdin",
 })
 
 
@@ -146,28 +172,43 @@ def _property_for(action: argparse.Action) -> dict[str, Any]:
     return prop
 
 
-def _schema_for(parser: argparse.ArgumentParser) -> dict[str, Any]:
+def _schema_for(command: str, parser: argparse.ArgumentParser) -> dict[str, Any]:
     """Derive a JSON Schema for a subparser's arguments."""
     properties: dict[str, Any] = {}
     required: list[str] = []
+    hidden = _LOCAL_PATH_PARAMS.get(command, frozenset())
+    hidden_choices = _LOCAL_PATH_CHOICES.get(command, {})
 
     for action in parser._actions:
-        if action.dest in _SKIP_DESTS:
+        if action.dest in _SKIP_DESTS or action.dest in hidden:
             continue
         if isinstance(action, (argparse._HelpAction, argparse._VersionAction)):
             continue
         if isinstance(action, argparse._SubParsersAction):
             continue
 
-        properties[action.dest] = _property_for(action)
+        prop = _property_for(action)
+        removed = hidden_choices.get(action.dest)
+        if removed and "enum" in prop:
+            prop["enum"] = [c for c in prop["enum"] if c not in removed]
+        properties[action.dest] = prop
+
         is_positional = not action.option_strings
         if is_positional and action.nargs not in ("?", "*"):
+            required.append(action.dest)
+        elif action.required:  # e.g. `insert --tab`
             required.append(action.dest)
 
     schema: dict[str, Any] = {"type": "object", "properties": properties}
     if required:
         schema["required"] = required
     return schema
+
+
+def _file_arg_required(parser: argparse.ArgumentParser, file_arg: str) -> bool:
+    """Whether the file argument that `text` replaces is mandatory."""
+    action = next((a for a in parser._actions if a.dest == file_arg), None)
+    return action is not None and action.required
 
 
 def _description_for(command: str, parser: argparse.ArgumentParser) -> str:
@@ -203,6 +244,14 @@ def build_tools(
     help_by_command = _help_by_command(parser)
 
     tools: dict[str, dict[str, Any]] = {}
+    env_allow = os.environ.get("GDOC_ALLOW_COMMANDS", "")
+    env_set = None
+    if env_allow:
+        # run_argv enforces this env allowlist on every in-process call;
+        # mirror it here so tools/list never advertises a tool that can
+        # only fail.
+        env_set = {c.strip().lower() for c in env_allow.split(",") if c.strip()}
+
     for command, is_read_only in EXPOSED_COMMANDS.items():
         if command not in subparsers:
             continue  # command retired upstream; skip rather than crash
@@ -210,22 +259,21 @@ def build_tools(
             continue
         if allow is not None and command not in allow:
             continue
+        if env_set is not None and command not in env_set:
+            continue
 
         sub = subparsers[command]
         sub._gdoc_help = help_by_command.get(command, "")
-        schema = _schema_for(sub)
+        schema = _schema_for(command, sub)
 
         file_arg = _TEXT_TO_FILE.get(command)
-        if file_arg and file_arg in schema["properties"]:
+        if file_arg:
             schema["properties"]["text"] = {
                 "type": "string",
                 "description": _TEXT_DESCRIPTION,
             }
-            schema["required"] = [
-                r for r in schema.get("required", []) if r != file_arg
-            ]
-            if not schema["required"]:
-                del schema["required"]
+            if _file_arg_required(sub, file_arg):
+                schema.setdefault("required", []).append("text")
 
         tools[_tool_name(command)] = {
             "name": _tool_name(command),
@@ -246,10 +294,23 @@ def _help_by_command(parser: argparse.ArgumentParser) -> dict[str, str]:
     return {}
 
 
+def _option_token(flag: str, value: Any) -> str:
+    """Render an option and its value as one token, so a value starting
+    with `-` cannot be re-parsed as a flag."""
+    if flag.startswith("--"):
+        return f"{flag}={value}"
+    return f"{flag}{value}"  # short options take attached values
+
+
 def _argv_for(
     command: str, arguments: dict[str, Any], parser: argparse.ArgumentParser
 ) -> list[str]:
-    """Turn a tool-call argument dict back into a gdoc argv list."""
+    """Turn a tool-call argument dict back into a gdoc argv list.
+
+    Option values are rendered as `--flag=value` and positionals follow a
+    `--` separator, so user text that begins with `-` cannot be re-parsed
+    as a flag.
+    """
     actions = {
         a.dest: a
         for a in parser._actions
@@ -263,20 +324,34 @@ def _argv_for(
 
     positionals: list[str] = []
     options: list[str] = []
+    skipped_positional: str | None = None
 
     for dest, action in actions.items():
-        if dest not in arguments:
-            continue
-        value = arguments[dest]
-        if value is None:
-            continue
+        provided = dest in arguments and arguments[dest] is not None
 
         if not action.option_strings:
+            # Positionals are matched by position, so a gap cannot be
+            # expressed: a later value would silently shift into the
+            # earlier slot (for `edit`, turning a replacement into a
+            # deletion).
+            if not provided:
+                if skipped_positional is None:
+                    skipped_positional = dest
+                continue
+            if skipped_positional is not None:
+                raise ValueError(
+                    f"`{dest}` requires `{skipped_positional}` to be set too"
+                )
+            value = arguments[dest]
             if isinstance(value, list):
                 positionals.extend(str(v) for v in value)
             else:
                 positionals.append(str(value))
             continue
+
+        if not provided:
+            continue
+        value = arguments[dest]
 
         flag = max(action.option_strings, key=len)
         if isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction)):
@@ -284,14 +359,19 @@ def _argv_for(
                 options.append(flag)
         elif isinstance(action, argparse._AppendAction) and isinstance(value, list):
             for item in value:
-                options.extend([flag, str(item)])
+                options.append(_option_token(flag, item))
         elif isinstance(value, list):
+            # nargs="+"/"*" options have no per-value `=` form
             options.append(flag)
             options.extend(str(v) for v in value)
         else:
-            options.extend([flag, str(value)])
+            options.append(_option_token(flag, value))
 
-    return [command, *options, *positionals]
+    argv = [command, *options]
+    if positionals:
+        argv.append("--")
+        argv.extend(positionals)
+    return argv
 
 
 def call_command(
@@ -308,18 +388,57 @@ def call_command(
     if subparser is None:
         raise ValueError(f"unknown command: {command}")
 
+    _reject_local_paths(command, arguments)
+
+    file_arg = _TEXT_TO_FILE.get(command)
+    if (
+        file_arg
+        and arguments.get("text") is None
+        and _file_arg_required(subparser, file_arg)
+    ):
+        raise ValueError("`text` is required: the markdown content, inline")
+
     _reset_account_state(arguments.get("account"))
 
     with _materialised_text(command, arguments) as prepared:
         argv = _argv_for(command, prepared, subparser)
 
         out, err = io.StringIO(), io.StringIO()
-        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-            try:
-                code = run_argv(argv, check_updates=False)
-            except SystemExit as e:  # argparse usage errors exit, not raise
-                code = e.code if isinstance(e.code, int) else 1
+        # A tool call must never read the server's stdin — that is the
+        # JSON-RPC protocol stream, and commands that read it (`edit`
+        # with "-", `cells --stdin`) would swallow queued messages and
+        # then hang until the client hangs up.
+        real_stdin, sys.stdin = sys.stdin, io.StringIO("")
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                try:
+                    code = run_argv(argv, check_updates=False)
+                except SystemExit as e:  # argparse usage errors exit, not raise
+                    code = e.code if isinstance(e.code, int) else 1
+        finally:
+            sys.stdin = real_stdin
     return out.getvalue(), err.getvalue(), code
+
+
+def _reject_local_paths(command: str, arguments: dict[str, Any]) -> None:
+    """Refuse parameters that name files on the server's machine."""
+    used = {
+        p for p in _LOCAL_PATH_PARAMS.get(command, frozenset())
+        if arguments.get(p) is not None
+    }
+    if used:
+        hint = " — use `text` for inline content" if command in _TEXT_TO_FILE else ""
+        raise ValueError(
+            f"{', '.join(sorted(used))}: local file paths are not available "
+            f"over MCP{hint}"
+        )
+    for dest, removed in _LOCAL_PATH_CHOICES.get(command, {}).items():
+        value = arguments.get(dest)
+        if isinstance(value, str) and value in removed:
+            raise ValueError(
+                f"{dest}={value} writes a local file and is not available "
+                "over MCP"
+            )
 
 
 def _reset_account_state(account: str | None) -> None:
@@ -351,21 +470,39 @@ def _reset_account_state(account: str | None) -> None:
 def _materialised_text(command: str, arguments: dict[str, Any]):
     """Swap an inline `text` argument for a temp file the CLI can read."""
     file_arg = _TEXT_TO_FILE.get(command)
-    if file_arg is None or "text" not in arguments:
+    if file_arg is None:
         yield arguments
         return
-
-    if arguments.get(file_arg):
-        raise ValueError(f"pass either `text` or `{file_arg}`, not both")
+    if arguments.get("text") is None:
+        yield {k: v for k, v in arguments.items() if k != "text"}
+        return
 
     prepared = {k: v for k, v in arguments.items() if k != "text"}
-    with tempfile.NamedTemporaryFile(
-        "w", suffix=".md", encoding="utf-8", delete=True
-    ) as handle:
-        handle.write(arguments["text"])
-        handle.flush()
+    # delete=False so the CLI can reopen the path by name — Windows locks
+    # a NamedTemporaryFile that is still open.
+    handle = tempfile.NamedTemporaryFile(
+        "w", suffix=".md", encoding="utf-8", delete=False
+    )
+    try:
+        with handle:
+            handle.write(arguments["text"])
         prepared[file_arg] = handle.name
         yield prepared
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(handle.name)
+
+
+# stderr lines that are noise on every call rather than news.
+_NOTE_NOISE = frozenset({
+    "--- no changes ---",
+    "---",
+    "",
+    # auth.py prints this hint when no default account is configured;
+    # relaying it invites the model to pass account="default", which is
+    # not a real account name.
+    "account: default (use --account to switch)",
+})
 
 
 def _clean_notes(stderr: str) -> str:
@@ -377,9 +514,20 @@ def _clean_notes(stderr: str) -> str:
     """
     lines = [
         line for line in stderr.splitlines()
-        if line.strip() not in ("--- no changes ---", "---", "")
+        if line.strip() not in _NOTE_NOISE
     ]
     return "\n".join(lines).strip()
+
+
+def _err_lines(stderr: str) -> list[str]:
+    """The ERR: lines — the CLI's actual error messages — from stderr."""
+    return [
+        line for line in stderr.splitlines() if line.startswith("ERR:")
+    ]
+
+
+class _InvalidParamsError(Exception):
+    """Maps to JSON-RPC error -32602 (invalid params)."""
 
 
 class MCPServer:
@@ -421,25 +569,40 @@ class MCPServer:
         arguments = params.get("arguments") or {}
 
         if name not in self.tools:
-            return self._text_result(f"ERR: no such tool: {name}", is_error=True)
+            # an unknown tool is a protocol error (-32602), not a tool result
+            raise _InvalidParamsError(f"no such tool: {name}")
 
-        if self.account and "account" not in arguments:
+        # `is None` rather than `not in`: a client that serializes unset
+        # optionals as null must not bypass the server-wide account.
+        if self.account and arguments.get("account") is None:
             arguments = {**arguments, "account": self.account}
 
+        command = _command_name(name)
         try:
-            stdout, stderr, code = call_command(_command_name(name), arguments)
+            stdout, stderr, code = call_command(command, arguments)
         except Exception as e:  # surface as a tool error, never kill the server
             return self._text_result(f"ERR: {e}", is_error=True)
 
-        if code != 0:
-            body = (stderr or stdout).strip() or f"exit code {code}"
+        ok = code == 0 or (
+            command in _DIFF_EXIT_COMMANDS and code == 1 and not _err_lines(stderr)
+        )
+        if not ok:
+            errs = _err_lines(stderr)
+            body = (
+                "\n".join(errs)
+                or _clean_notes(stderr)
+                or stdout.strip()
+                or f"exit code {code}"
+            )
             return self._text_result(body, is_error=True)
 
-        text = stdout.strip()
+        # Notes travel as a second content item so machine-readable stdout
+        # (e.g. `json: true`) stays parseable on its own.
+        content = [{"type": "text", "text": stdout.strip() or "OK"}]
         notes = _clean_notes(stderr)
         if notes:
-            text = f"{text}\n\n--- notes ---\n{notes}" if text else notes
-        return self._text_result(text or "OK")
+            content.append({"type": "text", "text": f"--- notes ---\n{notes}"})
+        return {"content": content, "isError": False}
 
     @staticmethod
     def _text_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
@@ -478,6 +641,14 @@ class MCPServer:
 
         try:
             result = handler(params)
+        except _InvalidParamsError as e:
+            if is_notification:
+                return None
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32602, "message": str(e)},
+            }
         except Exception as e:
             if is_notification:
                 return None
@@ -518,13 +689,28 @@ class MCPServer:
                     )
                     continue
 
-                messages = message if isinstance(message, list) else [message]
-                for item in messages:
-                    if not isinstance(item, dict):
-                        continue
-                    response = self.dispatch(item)
-                    if response is not None:
-                        self._write(protocol_out, response)
+                if isinstance(message, list):
+                    # JSON-RPC batch (protocol revisions before 2025-06-18):
+                    # one request array gets one response array.
+                    responses = [
+                        self.dispatch(item) if isinstance(item, dict)
+                        else self._invalid_request()
+                        for item in message
+                    ]
+                    responses = [r for r in responses if r is not None]
+                    if not message:
+                        self._write(protocol_out, self._invalid_request())
+                    elif responses:
+                        self._write(protocol_out, responses)
+                    continue
+
+                if not isinstance(message, dict):
+                    self._write(protocol_out, self._invalid_request())
+                    continue
+
+                response = self.dispatch(message)
+                if response is not None:
+                    self._write(protocol_out, response)
         except (BrokenPipeError, KeyboardInterrupt):
             pass
         finally:
@@ -532,6 +718,14 @@ class MCPServer:
         return 0
 
     @staticmethod
-    def _write(stream, payload: dict[str, Any]) -> None:
+    def _invalid_request() -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "invalid request"},
+        }
+
+    @staticmethod
+    def _write(stream, payload: dict[str, Any] | list[dict[str, Any]]) -> None:
         stream.write(json.dumps(payload) + "\n")
         stream.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.19.0"
+version = "0.20.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,9 +11,12 @@ from gdoc import mcp
 
 @pytest.fixture(autouse=True)
 def _clean_gdoc_env(monkeypatch):
-    """Ambient GDOC_* settings must not change tool construction."""
+    """Ambient GDOC_* settings and the machine's configured default
+    account must not change tool construction or account tracking."""
     monkeypatch.delenv("GDOC_ALLOW_COMMANDS", raising=False)
     monkeypatch.delenv("GDOC_ACCOUNT", raising=False)
+    monkeypatch.setattr(mcp, "_serving_default", None)
+    monkeypatch.setattr("gdoc.util.get_default_account", lambda: None)
 
 
 # -- tool construction ---------------------------------------------------
@@ -201,6 +204,23 @@ def test_argv_rejects_skipped_middle_positional():
         )
 
 
+def test_boolean_flags_require_real_booleans():
+    """A truthy string like "false" must not enable an opt-in flag —
+    some of them (write --force-collapse-tabs) guard destructive paths."""
+    with pytest.raises(ValueError, match="must be a boolean"):
+        mcp._argv_for(
+            "write",
+            {"doc": "D", "file": "f", "force_collapse_tabs": "false"},
+            _subparser("write"),
+        )
+    argv = mcp._argv_for(
+        "write",
+        {"doc": "D", "file": "f", "force_collapse_tabs": True},
+        _subparser("write"),
+    )
+    assert "--force-collapse-tabs" in argv
+
+
 def test_argv_omits_false_booleans():
     argv = mcp._argv_for("edit", {"doc": "D", "all": False}, _subparser("edit"))
     assert "--all" not in argv
@@ -334,6 +354,26 @@ def test_account_state_reset_is_skipped_when_unchanged(mocker):
         clear = mocker.patch("gdoc.api.get_drive_service.cache_clear")
         mcp.call_command("cat", {"doc": "D", "account": "work"})
         assert not clear.called
+    finally:
+        util.set_active_account(None)
+
+
+def test_default_account_change_invalidates_caches(mocker):
+    """`gdoc auth --set-default` in another terminal must not leave a
+    running server on the old default's cached credentials."""
+    from gdoc import util
+
+    mocker.patch("gdoc.cli.run_argv", return_value=0)
+    default = mocker.patch("gdoc.util.get_default_account", return_value="a")
+    try:
+        mcp.call_command("cat", {"doc": "D"})  # caches built under "a"
+        clear = mocker.patch("gdoc.api.clear_service_caches")
+        mcp.call_command("cat", {"doc": "D"})
+        assert not clear.called  # default unchanged: keep the caches
+
+        default.return_value = "b"
+        mcp.call_command("cat", {"doc": "D"})
+        assert clear.called  # default changed: drop them
     finally:
         util.set_active_account(None)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -112,6 +112,22 @@ def test_required_options_are_marked_required():
     assert "tab" in schema["required"]
 
 
+def test_cells_requires_a_value():
+    schema = mcp.build_tools(allow={"cells"})["gdoc_cells"]["inputSchema"]
+    # With --file/--stdin hidden, -v/--value is the only data source; a
+    # call without it would always fail at runtime.
+    assert "value" in schema["required"]
+    assert schema["properties"]["value"]["minItems"] == 1
+
+
+def test_delete_comment_requires_force():
+    schema = mcp.build_tools(allow={"delete-comment"})[
+        "gdoc_delete_comment"
+    ]["inputSchema"]
+    # With stdin detached there is no confirmation prompt to answer.
+    assert "force" in schema["required"]
+
+
 def test_env_allowlist_filters_tools(monkeypatch):
     monkeypatch.setenv("GDOC_ALLOW_COMMANDS", "mcp,cat,ls")
     tools = mcp.build_tools()
@@ -213,6 +229,21 @@ def test_html_diff_choice_is_rejected():
 def test_write_requires_inline_text():
     with pytest.raises(ValueError, match="`text` is required"):
         mcp.call_command("write", {"doc": "D"})
+
+
+def test_delete_comment_without_true_force_is_rejected(mocker):
+    # Schema `required` cannot force a boolean to be true.
+    with pytest.raises(ValueError, match="`force: true` is required"):
+        mcp.call_command("delete-comment", {"doc": "D", "comment_id": "c1"})
+    with pytest.raises(ValueError, match="`force: true` is required"):
+        mcp.call_command(
+            "delete-comment", {"doc": "D", "comment_id": "c1", "force": False},
+        )
+    run = mocker.patch("gdoc.cli.run_argv", return_value=0)
+    mcp.call_command(
+        "delete-comment", {"doc": "D", "comment_id": "c1", "force": True},
+    )
+    assert run.called
 
 
 # -- command execution ---------------------------------------------------

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -57,8 +57,66 @@ def test_choices_become_enum():
 def test_write_tools_accept_inline_text():
     schema = mcp.build_tools(allow={"write"})["gdoc_write"]["inputSchema"]
     assert "text" in schema["properties"]
-    # `file` must stop being required once `text` is an option.
-    assert schema["required"] == ["doc"]
+    # The local `file` path is replaced by `text`, which inherits its
+    # requiredness (write's file positional was mandatory).
+    assert "file" not in schema["properties"]
+    assert schema["required"] == ["doc", "text"]
+
+
+def test_new_accepts_optional_inline_text():
+    schema = mcp.build_tools(allow={"new"})["gdoc_new"]["inputSchema"]
+    # `new --file` was optional, so inline text is too.
+    assert "text" in schema["properties"]
+    assert "file_path" not in schema["properties"]
+    assert "text" not in schema.get("required", [])
+
+
+def test_cells_is_classified_as_write():
+    assert "gdoc_cells" not in mcp.build_tools(read_only=True)
+    tool = mcp.build_tools(allow={"cells"})["gdoc_cells"]
+    assert "Writes to Google Docs/Drive." in tool["description"]
+
+
+def test_image_commands_are_not_exposed():
+    tools = mcp.build_tools()
+    # Both require a local image path a chat client cannot provide.
+    assert "gdoc_insert_image" not in tools
+    assert "gdoc_replace_image" not in tools
+
+
+def test_local_path_params_are_stripped_from_schemas():
+    tools = mcp.build_tools()
+    props = lambda name: tools[name]["inputSchema"]["properties"]  # noqa: E731
+    assert "old_file" not in props("gdoc_edit")
+    assert "new_file" not in props("gdoc_edit")
+    assert "file" not in props("gdoc_insert")
+    assert "file" not in props("gdoc_cells")
+    assert "stdin" not in props("gdoc_cells")
+    assert "file" not in props("gdoc_diff")
+    assert "out" not in props("gdoc_diff")
+    assert "download" not in props("gdoc_images")
+
+
+def test_html_diff_format_is_not_offered():
+    props = mcp.build_tools(allow={"diff"})["gdoc_diff"]["inputSchema"][
+        "properties"
+    ]
+    # html renders to a local file the client cannot see.
+    assert "html" not in props["format"]["enum"]
+    assert "color" in props["format"]["enum"]
+
+
+def test_required_options_are_marked_required():
+    schema = mcp.build_tools(allow={"insert"})["gdoc_insert"]["inputSchema"]
+    # `insert --tab` is required=True in the CLI parser.
+    assert "tab" in schema["required"]
+
+
+def test_env_allowlist_filters_tools(monkeypatch):
+    monkeypatch.setenv("GDOC_ALLOW_COMMANDS", "mcp,cat,ls")
+    tools = mcp.build_tools()
+    # run_argv enforces the env allowlist per call; tools/list must agree.
+    assert set(tools) == {"gdoc_cat", "gdoc_ls"}
 
 
 def test_write_command_description_flags_mutation():
@@ -92,7 +150,31 @@ def test_argv_passes_option_values():
     argv = mcp._argv_for(
         "cat", {"doc": "DOC1", "tab": "Notes"}, _subparser("cat"),
     )
-    assert argv[argv.index("--tab") + 1] == "Notes"
+    # Attached form, so a value starting with "-" cannot become a flag.
+    assert "--tab=Notes" in argv
+
+
+def test_argv_shields_dash_prefixed_text():
+    """User text like "--all" must survive the round trip as data."""
+    from gdoc.cli import build_parser
+
+    argv = mcp._argv_for(
+        "edit",
+        {"doc": "DOC1", "old_text": "--all", "new_text": "-x"},
+        _subparser("edit"),
+    )
+    args = build_parser().parse_args(argv)
+    assert args.old_text == "--all"
+    assert args.new_text == "-x"
+    assert args.all is False
+
+
+def test_argv_rejects_skipped_middle_positional():
+    """A gap in positionals must error, not silently shift values."""
+    with pytest.raises(ValueError, match="requires `old_text`"):
+        mcp._argv_for(
+            "edit", {"doc": "D", "new_text": "b"}, _subparser("edit"),
+        )
 
 
 def test_argv_omits_false_booleans():
@@ -114,10 +196,23 @@ def test_inline_text_is_written_to_a_temp_file():
     assert not os.path.exists(path)  # cleaned up after the call
 
 
-def test_inline_text_and_file_conflict():
-    with pytest.raises(ValueError, match="not both"):
-        with mcp._materialised_text("write", {"doc": "D", "text": "x", "file": "f"}):
-            pass
+def test_local_file_params_are_rejected():
+    with pytest.raises(ValueError, match="local file paths"):
+        mcp.call_command("write", {"doc": "D", "text": "x", "file": "f"})
+    with pytest.raises(ValueError, match="local file paths"):
+        mcp.call_command(
+            "edit", {"doc": "D", "old_text": "a", "new_file": "/etc/passwd"},
+        )
+
+
+def test_html_diff_choice_is_rejected():
+    with pytest.raises(ValueError, match="writes a local file"):
+        mcp.call_command("diff", {"doc": "D", "rev": "prev", "format": "html"})
+
+
+def test_write_requires_inline_text():
+    with pytest.raises(ValueError, match="`text` is required"):
+        mcp.call_command("write", {"doc": "D"})
 
 
 # -- command execution ---------------------------------------------------
@@ -177,11 +272,42 @@ def test_account_state_reset_is_skipped_when_unchanged(mocker):
         util.set_active_account(None)
 
 
+def test_stdin_is_shielded_from_tool_calls(mocker):
+    """A command that reads stdin must not consume the protocol stream."""
+    import sys
+
+    seen = {}
+
+    def fake_run(argv, check_updates=True):
+        seen["stdin"] = sys.stdin.read()
+        return 0
+
+    mocker.patch("gdoc.cli.run_argv", side_effect=fake_run)
+    real_stdin = sys.stdin
+    protocol_stream = io.StringIO('{"jsonrpc": "2.0", "id": 9}\n')
+    sys.stdin = protocol_stream
+    try:
+        mcp.call_command("cat", {"doc": "D"})
+    finally:
+        sys.stdin = real_stdin
+    assert seen["stdin"] == ""
+    # The protocol stream was left untouched for the transport loop.
+    assert protocol_stream.tell() == 0
+
+
 def test_clean_notes_drops_no_change_banner():
     assert mcp._clean_notes("---\n--- no changes ---\n") == ""
     assert "doc edited" in mcp._clean_notes(
         "--- since last interaction ---\n ✎ doc edited by A\n---\n"
     )
+
+
+def test_clean_notes_drops_account_hint():
+    # Relaying this hint teaches the model to pass account="default",
+    # which is not a real account name.
+    assert mcp._clean_notes(
+        "account: default (use --account to switch)\n"
+    ) == ""
 
 
 # -- protocol ------------------------------------------------------------
@@ -220,14 +346,15 @@ def test_unknown_method_returns_method_not_found():
     assert response["error"]["code"] == -32601
 
 
-def test_tools_call_unknown_tool_is_a_tool_error():
+def test_tools_call_unknown_tool_is_invalid_params():
     server = mcp.MCPServer()
-    result = server.dispatch({
+    response = server.dispatch({
         "jsonrpc": "2.0", "id": 2, "method": "tools/call",
         "params": {"name": "gdoc_nope", "arguments": {}},
-    })["result"]
-    assert result["isError"] is True
-    assert "no such tool" in result["content"][0]["text"]
+    })
+    # The MCP spec treats an unknown tool as a protocol error.
+    assert response["error"]["code"] == -32602
+    assert "no such tool" in response["error"]["message"]
 
 
 def test_tools_call_returns_stdout(mocker):
@@ -256,6 +383,64 @@ def test_tools_call_surfaces_failure(mocker):
     assert "Document not found" in result["content"][0]["text"]
 
 
+def test_error_body_is_the_err_line_not_the_banner(mocker):
+    mocker.patch(
+        "gdoc.mcp.call_command",
+        return_value=("", "--- no changes ---\nERR: Document not found", 1),
+    )
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D"}},
+    })["result"]
+    assert result["content"][0]["text"] == "ERR: Document not found"
+
+
+def test_diff_exit_one_means_differences_not_failure(mocker):
+    mocker.patch(
+        "gdoc.mcp.call_command",
+        return_value=("- old\n+ new", "--- no changes ---\n", 1),
+    )
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {"name": "gdoc_diff", "arguments": {"doc": "D", "rev": "prev"}},
+    })["result"]
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "- old\n+ new"
+
+
+def test_diff_exit_one_with_err_line_is_still_a_failure(mocker):
+    mocker.patch(
+        "gdoc.mcp.call_command", return_value=("", "ERR: boom", 1),
+    )
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {"name": "gdoc_diff", "arguments": {"doc": "D", "rev": "prev"}},
+    })["result"]
+    assert result["isError"] is True
+
+
+def test_notes_travel_as_a_separate_content_item(mocker):
+    """Machine-readable stdout must stay parseable on its own."""
+    mocker.patch(
+        "gdoc.mcp.call_command",
+        return_value=(
+            '{"title": "Doc"}',
+            "--- since last interaction ---\n ✎ doc edited by A\n---\n",
+            0,
+        ),
+    )
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {"name": "gdoc_info", "arguments": {"doc": "D", "json": True}},
+    })["result"]
+    assert json.loads(result["content"][0]["text"]) == {"title": "Doc"}
+    assert result["content"][1]["text"].startswith("--- notes ---")
+
+
 def test_account_default_is_applied(mocker):
     call = mocker.patch("gdoc.mcp.call_command", return_value=("ok", "", 0))
     server = mcp.MCPServer(account="work")
@@ -274,6 +459,17 @@ def test_explicit_account_wins_over_default(mocker):
         "params": {"name": "gdoc_cat", "arguments": {"doc": "D", "account": "home"}},
     })
     assert call.call_args[0][1]["account"] == "home"
+
+
+def test_null_account_does_not_bypass_the_default(mocker):
+    """Clients that serialize unset optionals as null keep the pin."""
+    call = mocker.patch("gdoc.mcp.call_command", return_value=("ok", "", 0))
+    server = mcp.MCPServer(account="work")
+    server.dispatch({
+        "jsonrpc": "2.0", "id": 6, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D", "account": None}},
+    })
+    assert call.call_args[0][1]["account"] == "work"
 
 
 # -- transport -----------------------------------------------------------
@@ -304,6 +500,24 @@ def test_serve_reports_malformed_json():
     stdout = io.StringIO()
     mcp.MCPServer().serve(stdin=io.StringIO("not json\n"), stdout=stdout)
     assert json.loads(stdout.getvalue())["error"]["code"] == -32700
+
+
+def test_serve_answers_batches_with_an_array():
+    stdin = io.StringIO(json.dumps([
+        {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        {"jsonrpc": "2.0", "id": 2, "method": "ping"},
+    ]) + "\n")
+    stdout = io.StringIO()
+    mcp.MCPServer().serve(stdin=stdin, stdout=stdout)
+    response = json.loads(stdout.getvalue())
+    assert isinstance(response, list)
+    assert [r["id"] for r in response] == [1, 2]
+
+
+def test_serve_rejects_non_object_frames():
+    stdout = io.StringIO()
+    mcp.MCPServer().serve(stdin=io.StringIO("42\n"), stdout=stdout)
+    assert json.loads(stdout.getvalue())["error"]["code"] == -32600
 
 
 def test_serve_protects_the_protocol_stream_from_stray_prints(mocker):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,6 +8,14 @@ import pytest
 
 from gdoc import mcp
 
+
+@pytest.fixture(autouse=True)
+def _clean_gdoc_env(monkeypatch):
+    """Ambient GDOC_* settings must not change tool construction."""
+    monkeypatch.delenv("GDOC_ALLOW_COMMANDS", raising=False)
+    monkeypatch.delenv("GDOC_ACCOUNT", raising=False)
+
+
 # -- tool construction ---------------------------------------------------
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,327 @@
+"""Tests for the MCP server (`gdoc mcp`)."""
+
+import io
+import json
+import os
+
+import pytest
+
+from gdoc import mcp
+
+# -- tool construction ---------------------------------------------------
+
+
+def test_build_tools_exposes_prefixed_names():
+    tools = mcp.build_tools()
+    assert "gdoc_cat" in tools
+    assert "gdoc_comment_info" in tools
+    # Not exposed: interactive, machine-wide, or local-path commands.
+    assert "gdoc_auth" not in tools
+    assert "gdoc_update" not in tools
+    assert "gdoc_pull" not in tools
+
+
+def test_read_only_drops_write_commands():
+    tools = mcp.build_tools(read_only=True)
+    assert "gdoc_cat" in tools
+    assert "gdoc_edit" not in tools
+    assert "gdoc_share" not in tools
+
+
+def test_allow_list_restricts_surface():
+    tools = mcp.build_tools(allow={"cat", "ls"})
+    assert set(tools) == {"gdoc_cat", "gdoc_ls"}
+
+
+def test_schema_derived_from_argparse():
+    schema = mcp.build_tools(allow={"edit"})["gdoc_edit"]["inputSchema"]
+    props = schema["properties"]
+
+    assert schema["required"] == ["doc"]
+    assert props["doc"]["type"] == "string"
+    assert props["old_text"]["type"] == "string"
+    assert props["all"]["type"] == "boolean"  # store_true
+    assert props["table"]["type"] == "integer"  # type=int
+    # Output plumbing is not a tool parameter.
+    assert "verbose" not in props
+    assert "func" not in props
+
+
+def test_choices_become_enum():
+    props = mcp.build_tools(allow={"insert"})["gdoc_insert"]["inputSchema"][
+        "properties"
+    ]
+    assert props["position"]["enum"] == ["start", "end"]
+
+
+def test_write_tools_accept_inline_text():
+    schema = mcp.build_tools(allow={"write"})["gdoc_write"]["inputSchema"]
+    assert "text" in schema["properties"]
+    # `file` must stop being required once `text` is an option.
+    assert schema["required"] == ["doc"]
+
+
+def test_write_command_description_flags_mutation():
+    tool = mcp.build_tools(allow={"share"})["gdoc_share"]
+    assert "Writes to Google Docs/Drive." in tool["description"]
+
+
+# -- argv construction ---------------------------------------------------
+
+
+def _subparser(command):
+    from gdoc.cli import build_parser
+
+    return mcp._subparsers(build_parser())[command]
+
+
+def test_argv_orders_options_before_positionals():
+    argv = mcp._argv_for(
+        "edit",
+        {"doc": "DOC1", "old_text": "a", "new_text": "b", "all": True},
+        _subparser("edit"),
+    )
+    assert argv[0] == "edit"
+    assert "--all" in argv
+    # Positionals keep parser declaration order and follow every option.
+    assert argv[-3:] == ["DOC1", "a", "b"]
+    assert argv.index("--all") < argv.index("DOC1")
+
+
+def test_argv_passes_option_values():
+    argv = mcp._argv_for(
+        "cat", {"doc": "DOC1", "tab": "Notes"}, _subparser("cat"),
+    )
+    assert argv[argv.index("--tab") + 1] == "Notes"
+
+
+def test_argv_omits_false_booleans():
+    argv = mcp._argv_for("edit", {"doc": "D", "all": False}, _subparser("edit"))
+    assert "--all" not in argv
+
+
+def test_argv_rejects_unknown_arguments():
+    with pytest.raises(ValueError, match="unknown argument"):
+        mcp._argv_for("cat", {"doc": "D", "nope": 1}, _subparser("cat"))
+
+
+def test_inline_text_is_written_to_a_temp_file():
+    with mcp._materialised_text("write", {"doc": "D", "text": "# Hi"}) as prepared:
+        assert "text" not in prepared
+        path = prepared["file"]
+        with open(path, encoding="utf-8") as handle:
+            assert handle.read() == "# Hi"
+    assert not os.path.exists(path)  # cleaned up after the call
+
+
+def test_inline_text_and_file_conflict():
+    with pytest.raises(ValueError, match="not both"):
+        with mcp._materialised_text("write", {"doc": "D", "text": "x", "file": "f"}):
+            pass
+
+
+# -- command execution ---------------------------------------------------
+
+
+def test_call_command_captures_stdout(mocker):
+    def fake_run(argv, check_updates=True):
+        print("hello from gdoc")
+        return 0
+
+    mocker.patch("gdoc.cli.run_argv", side_effect=fake_run)
+    stdout, stderr, code = mcp.call_command("cat", {"doc": "DOC1"})
+    assert stdout.strip() == "hello from gdoc"
+    assert code == 0
+
+
+def test_call_command_reports_exit_code(mocker):
+    def fake_run(argv, check_updates=True):
+        print("ERR: nope", file=__import__("sys").stderr)
+        return 3
+
+    mocker.patch("gdoc.cli.run_argv", side_effect=fake_run)
+    _, stderr, code = mcp.call_command("cat", {"doc": "DOC1"})
+    assert code == 3
+    assert "nope" in stderr
+
+
+def test_account_state_is_reset_between_calls(mocker):
+    """A named account must not leak into the next tool call."""
+    from gdoc import util
+
+    mocker.patch("gdoc.cli.run_argv", return_value=0)
+    clear = mocker.patch("gdoc.api.get_drive_service.cache_clear")
+
+    try:
+        mcp.call_command("cat", {"doc": "D", "account": "work"})
+        assert util.get_active_account() == "work"
+        assert clear.called
+
+        mcp.call_command("cat", {"doc": "D"})
+        assert util.get_active_account() is None
+    finally:
+        util.set_active_account(None)
+
+
+def test_account_state_reset_is_skipped_when_unchanged(mocker):
+    """Repeat calls on one account keep their cached service objects."""
+    from gdoc import util
+
+    mocker.patch("gdoc.cli.run_argv", return_value=0)
+    try:
+        mcp.call_command("cat", {"doc": "D", "account": "work"})
+        clear = mocker.patch("gdoc.api.get_drive_service.cache_clear")
+        mcp.call_command("cat", {"doc": "D", "account": "work"})
+        assert not clear.called
+    finally:
+        util.set_active_account(None)
+
+
+def test_clean_notes_drops_no_change_banner():
+    assert mcp._clean_notes("---\n--- no changes ---\n") == ""
+    assert "doc edited" in mcp._clean_notes(
+        "--- since last interaction ---\n ✎ doc edited by A\n---\n"
+    )
+
+
+# -- protocol ------------------------------------------------------------
+
+
+def test_initialize_echoes_known_protocol_version():
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05"},
+    })["result"]
+    assert result["protocolVersion"] == "2024-11-05"
+    assert result["serverInfo"]["name"] == "gdoc"
+    assert "tools" in result["capabilities"]
+
+
+def test_initialize_falls_back_for_unknown_version():
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "1999-01-01"},
+    })["result"]
+    assert result["protocolVersion"] == mcp.DEFAULT_PROTOCOL_VERSION
+
+
+def test_notifications_get_no_response():
+    server = mcp.MCPServer()
+    assert server.dispatch({
+        "jsonrpc": "2.0", "method": "notifications/initialized",
+    }) is None
+
+
+def test_unknown_method_returns_method_not_found():
+    server = mcp.MCPServer()
+    response = server.dispatch({"jsonrpc": "2.0", "id": 7, "method": "nope"})
+    assert response["error"]["code"] == -32601
+
+
+def test_tools_call_unknown_tool_is_a_tool_error():
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {"name": "gdoc_nope", "arguments": {}},
+    })["result"]
+    assert result["isError"] is True
+    assert "no such tool" in result["content"][0]["text"]
+
+
+def test_tools_call_returns_stdout(mocker):
+    mocker.patch(
+        "gdoc.mcp.call_command", return_value=("doc body", "", 0),
+    )
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D"}},
+    })["result"]
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "doc body"
+
+
+def test_tools_call_surfaces_failure(mocker):
+    mocker.patch(
+        "gdoc.mcp.call_command", return_value=("", "ERR: Document not found", 1),
+    )
+    server = mcp.MCPServer()
+    result = server.dispatch({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D"}},
+    })["result"]
+    assert result["isError"] is True
+    assert "Document not found" in result["content"][0]["text"]
+
+
+def test_account_default_is_applied(mocker):
+    call = mocker.patch("gdoc.mcp.call_command", return_value=("ok", "", 0))
+    server = mcp.MCPServer(account="work")
+    server.dispatch({
+        "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D"}},
+    })
+    assert call.call_args[0][1]["account"] == "work"
+
+
+def test_explicit_account_wins_over_default(mocker):
+    call = mocker.patch("gdoc.mcp.call_command", return_value=("ok", "", 0))
+    server = mcp.MCPServer(account="work")
+    server.dispatch({
+        "jsonrpc": "2.0", "id": 6, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D", "account": "home"}},
+    })
+    assert call.call_args[0][1]["account"] == "home"
+
+
+# -- transport -----------------------------------------------------------
+
+
+def test_serve_round_trip(mocker):
+    mocker.patch("gdoc.mcp.call_command", return_value=("body", "", 0))
+    stdin = io.StringIO(
+        json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {},
+        }) + "\n"
+        + json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
+        + json.dumps({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+        }) + "\n"
+    )
+    stdout = io.StringIO()
+
+    assert mcp.MCPServer().serve(stdin=stdin, stdout=stdout) == 0
+
+    responses = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    # The notification must not produce a response.
+    assert [r["id"] for r in responses] == [1, 2]
+    assert len(responses[1]["result"]["tools"]) > 10
+
+
+def test_serve_reports_malformed_json():
+    stdout = io.StringIO()
+    mcp.MCPServer().serve(stdin=io.StringIO("not json\n"), stdout=stdout)
+    assert json.loads(stdout.getvalue())["error"]["code"] == -32700
+
+
+def test_serve_protects_the_protocol_stream_from_stray_prints(mocker):
+    """A print() outside the per-call capture must not corrupt stdout."""
+    import sys
+
+    def leaky(*args, **kwargs):
+        print("stray output", file=sys.stdout)
+        return ("body", "", 0)
+
+    mocker.patch("gdoc.mcp.call_command", side_effect=leaky)
+    stdin = io.StringIO(json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "gdoc_cat", "arguments": {"doc": "D"}},
+    }) + "\n")
+    stdout = io.StringIO()
+
+    mcp.MCPServer().serve(stdin=stdin, stdout=stdout)
+    # Every line on the protocol stream is still valid JSON-RPC.
+    for line in stdout.getvalue().splitlines():
+        assert json.loads(line)["jsonrpc"] == "2.0"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -239,6 +239,33 @@ def test_write_requires_inline_text():
         mcp.call_command("write", {"doc": "D"})
 
 
+def test_new_rejects_local_image_references(mocker):
+    """`new` imports images relative to the materialised temp file, so a
+    local path in inline text could still read server files."""
+    with pytest.raises(ValueError, match="local image reference"):
+        mcp.call_command(
+            "new", {"title": "T", "text": "hi ![x](/tmp/private.png)"},
+        )
+    with pytest.raises(ValueError, match="local image reference"):
+        mcp.call_command(
+            "new", {"title": "T", "text": "![x](../secret.png)"},
+        )
+    run = mocker.patch("gdoc.cli.run_argv", return_value=0)
+    mcp.call_command(
+        "new", {"title": "T", "text": "![x](https://example.com/i.png)"},
+    )
+    assert run.called
+
+
+def test_alternative_requirements_are_stated_in_descriptions():
+    tools = mcp.build_tools()
+    assert "Exactly one of `rev` or `since`" in tools["gdoc_diff"]["description"]
+    assert (
+        "Exactly one of `email`, `domain`, or `anyone`"
+        in tools["gdoc_share"]["description"]
+    )
+
+
 def test_delete_comment_without_true_force_is_rejected(mocker):
     # Schema `required` cannot force a boolean to be true.
     with pytest.raises(ValueError, match="`force: true` is required"):


### PR DESCRIPTION
## PH comment

It'd be nice to enable gdoc in Claude Cowork and ChatGPT desktop. Especially now that agents can leave comments.

Just sharing this as a quick proof of concept—only tested briefly. Claude's comments below.

![gdoc anchoring a comment from Claude Desktop](https://raw.githubusercontent.com/peterhartree/gdoc/assets/docs/img/mcp-claude-desktop.jpg)

*Claude Desktop anchoring a comment to the last word of a doc, via `gdoc mcp`.*

---


## Testing status

**Draft — this has had minimal testing.** It works end to end for me, but it has been exercised by one person, on one machine (macOS, Python 3.12), against one Google account pair, in one client. Please treat the surface as unproven. Specifically untested: Windows and Linux, ChatGPT desktop (the `~/.codex/config.toml` route is written from the docs, not verified), shared drives, spreadsheets via `cells`, and most of the 31 tools individually — I drove `ls`, `find`, `cat`, `new`, `write`, `edit`, `comment`, and `comments` by hand and trusted schema derivation for the rest.

Happy to iterate, cut the tool surface right down, or split this up if you'd rather take it in smaller pieces.

## What and why

`gdoc` is currently only reachable from an agent with shell access. `gdoc mcp` runs it as an [MCP](https://modelcontextprotocol.io) server on stdio, so clients that launch a local server — Claude Desktop, ChatGPT desktop — can read and edit Docs directly. That covers the people who want gdoc's ergonomics but don't use a coding agent.

```json
{
  "mcpServers": {
    "gdoc": { "command": "gdoc", "args": ["mcp"] }
  }
}
```

## Approach

**Schemas are derived from argparse, not hand-written.** Each exposed subparser is walked and turned into a JSON Schema: positionals become required properties, `store_true` becomes boolean, `choices` becomes an enum, `type=int` becomes integer. A new flag on `gdoc edit` becomes a tool parameter with no work in `mcp.py`. Only two things are hand-maintained: the `EXPOSED_COMMANDS` allowlist and its read/write classification.

**No new dependencies.** The stdio transport is newline-delimited JSON-RPC 2.0, which is short enough to implement directly — an SDK would pull a web stack into a CLI whose dependency list is deliberately four entries long. `gdoc/mcp.py` is ~380 lines including docstrings.

**Commands run in-process** through the same dispatch as the CLI, with stdout captured. That meant factoring `run_argv(argv, check_updates=...)` out of `main()`; `main()` is now a three-line wrapper. No behaviour change to the CLI.

## Bounding the surface

31 subcommands are exposed. Not exposed: `auth` (needs a browser), `update` (mutates the install), `config` (machine-wide), `pull`/`push`/`export` (local file paths the client can't see).

```bash
gdoc mcp --read-only                     # nothing that can modify a Doc or Drive
gdoc mcp --allow cat,find,comments       # explicit subset
gdoc mcp --account work                  # pin every call to one account
```

`--read-only` and `--allow` exist mainly for org rollouts, where someone may want to hand out reading without writing.

## Two things worth your attention

**1. `write` and `insert` gained an inline `text` parameter (MCP-only).** Both require a local markdown file, and a chat client has no filesystem to write one to — without this the server can create documents but never put anything in them. The server materialises `text` to a temp file for the duration of the call, so the CLI itself is unchanged. If you'd rather have `--text` on the CLI proper, say so and I'll move it.

**2. Cached service objects are not safe in a long-lived process.** `get_drive_service()` and friends are `lru_cache`d, documented as "a single service instance per CLI invocation", and `set_active_account()` is a module global. Both hold for the CLI and break for a server: a call naming an account leaked into every later call, and cached services kept using the first account's credentials — silently reading and writing the wrong account. `_reset_account_state()` now clears the caches and resets the account whenever it changes between calls. This is the part I'd most like a second pair of eyes on, since it reaches into module internals (including `revisions._get_session`) and a miss means wrong-account writes rather than an error.

## Tests

30 new tests in `tests/test_mcp.py` covering schema derivation, argv reconstruction, the temp-file path, account-state reset, protocol dispatch, and the transport (including that a stray `print()` can't corrupt the JSON-RPC stream). 1381 pass overall. `ruff check` is clean on both new files; `gdoc/cli.py` reports the same 44 pre-existing errors before and after.

Docs are in the README under "Desktop chat apps (MCP)", plus a CHANGELOG entry under Unreleased. I didn't bump the version — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

