### PR TITLE
feat: `gdoc suggest` — find/replace as a suggested edit (Docs API preview, 0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ All notable changes to `gdoc` are documented here. This project follows
   Success is verified, not assumed: HTTP 200 plus `commentUpdateState:
   ALL_SAVED`, at least one suggestion ID in `suggestionResponses`, and a
   `SUGGESTIONS_INLINE` read-back that shows every ID — anything less is an
-  error, and there is deliberately no fallback to a direct edit (an
-  unenrolled project fails with `suggest mode not available`). The document
+  error, and there is deliberately no fallback to a direct edit: a
+  non-mutating preview-only read proves the project is enrolled *before*
+  the write (an unenrolled project fails with `suggest mode not
+  available`). Inline style ranges in the replacement are converted to
+  UTF-16 (`to_docs_requests`, also fixing `edit`/`insert` with emoji in
+  formatted replacement text). The document
   is read with suggestions inline before matching and a match that touches
   an existing suggested insertion, deletion, or style change is refused, so
   another reviewer's thread is never modified by accident. Replacement text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@ All notable changes to `gdoc` are documented here. This project follows
   `_prepare_text_replacement`) and one request builder
   (`_build_replacement_requests`); `edit` behaviour is unchanged.
 
+### Fixed
+- **`edit --all` with a self-overlapping anchor** (`aa` matching twice in
+  `aaa`) is refused before any write (exit 3) instead of corrupting the
+  document — the last-to-first delete/insert plan would land on
+  already-shifted text. The same guard `suggest` ships with.
+- **`edit --cell` on a cell containing characters outside the Basic
+  Multilingual Plane** (emoji) computed the cell's editable end in code
+  points instead of UTF-16 units, so the replacement range could split a
+  surrogate pair (a 400 from the API) or leave the cell's last character
+  behind.
+- **MCP: a literal `-` in `old_text`/`new_text` of `gdoc_edit` and
+  `gdoc_suggest` is rejected.** The CLI reads `-` from stdin, but over MCP
+  stdin is the JSON-RPC stream (shielded to empty for the call), so
+  `new_text: "-"` silently became an empty replacement — deleting the
+  matched text instead of erroring.
+- **MCP: an unpinned tool call resolves the configured default account
+  once at call entry** instead of per service access, so a
+  `gdoc auth --set-default` made while a command runs can no longer hand
+  the same command's read and write to different accounts.
+
 ## [0.20.1] — 2026-08-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] — 2026-08-26
+
+### Added
+- **Suggested edits: `gdoc suggest DOC OLD NEW`.** The same find-and-replace
+  as `edit` (`--all`, `--case-sensitive`, `--normalize`, `--tab`,
+  `--old-file`/`--new-file`, `-` for stdin), but the batchUpdate runs with
+  `writeControl.writeMode: SUGGEST` (Docs API Developer Preview), so the
+  change lands as a pending suggestion with an accept/reject control and
+  the original text stays until a reviewer accepts it. Output names the
+  review object (`OK suggested 1 occurrence (#suggest.abc)`; `--json`
+  reports `suggestionIds`, `createdSuggestionIds`, `updatedSuggestionIds`).
+  Success is verified, not assumed: HTTP 200 plus `commentUpdateState:
+  ALL_SAVED`, at least one suggestion ID in `suggestionResponses`, and a
+  `SUGGESTIONS_INLINE` read-back that shows every ID — anything less is an
+  error, and there is deliberately no fallback to a direct edit (an
+  unenrolled project fails with `suggest mode not available`). The document
+  is read with suggestions inline before matching and a match that touches
+  an existing suggested insertion, deletion, or style change is refused, so
+  another reviewer's thread is never modified by accident. Replacement text
+  may use inline Markdown only (bold, italic, strikethrough, code, links);
+  headings, lists, blockquotes, horizontal rules, tables, and `--cell` are
+  rejected before any API call. Needs comment or edit access on the doc.
+  Exposed over MCP as `gdoc_suggest` (a write tool). `edit` and `suggest`
+  share one text-resolution/matching front half (`_resolve_replacement_text`,
+  `_prepare_text_replacement`) and one request builder
+  (`_build_replacement_requests`); `edit` behaviour is unchanged.
+
 ## [0.20.1] — 2026-08-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ gdoc info DOC_ID
 # Find and replace text (supports markdown formatting)
 gdoc edit DOC_ID "old text" "**new bold text**"
 
+# Same replacement, but as a suggested edit for a human to accept
+gdoc suggest DOC_ID "old text" "new text"
+
 # Overwrite a document from a local file
 gdoc write DOC_ID draft.md
 
@@ -198,6 +201,7 @@ gdoc cat 1aBcDeFg...
 |---------|-------------|
 | `edit DOC OLD NEW` | Find and replace text with Markdown formatting, including text inside tables (`--all` for all; `--normalize` to match through smart quotes/dashes; `-` reads an argument from stdin) |
 | `edit DOC --cell ADDR NEW` | Replace a table cell by label or `ROW,COL` coordinates (`--col`, `--table`) |
+| `suggest DOC OLD NEW` | Same find-and-replace as `edit`, made as a **suggested edit** the doc's reviewers accept or reject (same `--all`/`--normalize`/`--case-sensitive`/`--tab`/`--old-file`/`--new-file`/`-` flags; inline Markdown only — see below) |
 | `write DOC FILE` | Overwrite document from a local markdown file |
 | `cells SHEET RANGE` | Write values into a spreadsheet range (`-v VALUE` per cell, `--file rows.csv`, `--stdin` for TSV; `--append` adds rows, `--user-entered` parses formulas/dates) |
 | `new TITLE` | Create a blank document (`--folder` to specify location, `--file` to import markdown with images) |
@@ -542,6 +546,59 @@ Pass `-` for the old or new argument to read it from stdin (one stream, so at mo
 ```bash
 printf 'line one\nline two' | gdoc edit DOC --cell "Notes" -
 ```
+
+## Suggesting edits
+
+`suggest` is `edit` in suggest mode: the same anchor matching, but the change is
+written with the Docs API's `writeControl.writeMode: SUGGEST`, so the original
+text stays in place and the replacement appears as a pending suggestion with an
+accept/reject control — exactly as if a reviewer had typed it in *Suggesting*
+mode.
+
+```bash
+gdoc suggest DOC "ship in Q3" "ship in Q4"
+gdoc suggest DOC "colour" "color" --all --case-sensitive
+gdoc suggest DOC "old wording" "**bold** with a [link](https://example.com)"
+gdoc suggest DOC --tab "Draft" "old" "new"
+gdoc suggest DOC --old-file before.txt --new-file after.txt
+gdoc suggest DOC "old" "new" --json
+# → {"ok": true, "suggested": 1, "suggestionIds": ["suggest.abc"],
+#    "createdSuggestionIds": ["suggest.abc"], "updatedSuggestionIds": []}
+```
+
+Terse output names the review object: `OK suggested 1 occurrence (#suggest.abc)`.
+`--plain` prints `id`, `status suggested`, `suggested N`, and `suggestion_ids`.
+Google may fold an edit adjacent to your own open suggestion into it instead of
+creating a new one; those IDs are reported under `updatedSuggestionIds`.
+
+Requirements and limits:
+
+- **Developer Preview.** Suggest mode is a Docs API
+  [Workspace Developer Preview](https://developers.google.com/workspace/preview)
+  feature gated by the OAuth client's Cloud project. With an unenrolled project
+  the command fails with `suggest mode not available` and nothing is written.
+  Unlike `comment --quote`, there is **no fallback**: `suggest` never degrades to
+  a direct edit.
+- **Comment or edit access.** The write is pinned to the revision the text was
+  matched at (`requiredRevisionId`) and the document is read with suggestions
+  inline; both editors and commenters get that view and the revision ID, while
+  a reader is refused (`Permission denied`). If a read ever comes back without
+  a `revisionId`, the command refuses rather than write unpinned.
+- **Inline Markdown only.** Bold, italic, strikethrough, inline code, and links
+  are suggested along with the text. Headings, lists, blockquotes, horizontal
+  rules, tables, and `--cell` are rejected before any API call — use `edit` for
+  those.
+- **No overlap with existing suggestions.** The document is read with
+  suggestions inline; a match that touches text someone else has already
+  suggested inserting, deleting, or restyling is refused, so a review thread is
+  never silently modified.
+- **Verified, not assumed.** Success requires `commentUpdateState: ALL_SAVED`,
+  at least one suggestion ID in the response, and a read-back showing every ID
+  as a pending suggestion. Any other outcome is an error that tells you to
+  inspect the document.
+
+Like `edit`, a suggestion is a partial write: the awareness state records the
+new document version but does not advance the read baseline.
 
 ## Import from file
 

--- a/README.md
+++ b/README.md
@@ -587,7 +587,10 @@ Requirements and limits:
 - **Inline Markdown only.** Bold, italic, strikethrough, inline code, and links
   are suggested along with the text. Headings, lists, blockquotes, horizontal
   rules, tables, and `--cell` are rejected before any API call — use `edit` for
-  those.
+  those. Newlines are fine: they become suggested paragraph breaks, and the new
+  paragraphs inherit the anchor paragraph's style (unlike `edit`, which resets
+  inserted paragraphs to normal text). Fenced code blocks are accepted as
+  code-font paragraphs.
 - **No overlap with existing suggestions.** The document is read with
   suggestions inline; a match that touches text someone else has already
   suggested inserting, deleting, or restyling is refused, so a review thread is

--- a/README.md
+++ b/README.md
@@ -575,8 +575,11 @@ Requirements and limits:
 
 - **Developer Preview.** Suggest mode is a Docs API
   [Workspace Developer Preview](https://developers.google.com/workspace/preview)
-  feature gated by the OAuth client's Cloud project. With an unenrolled project
-  the command fails with `suggest mode not available` and nothing is written.
+  feature gated by the OAuth client's Cloud project. Because an unenrolled
+  backend has been seen silently applying `writeMode: SUGGEST` as a direct
+  edit, `suggest` first proves enrollment with a non-mutating preview-only
+  read (`commentsViewMode`); with an unenrolled project that read is rejected,
+  the command fails with `suggest mode not available`, and nothing is written.
   Unlike `comment --quote`, there is **no fallback**: `suggest` never degrades to
   a direct edit.
 - **Comment or edit access.** The write is pinned to the revision the text was

--- a/gdoc.md
+++ b/gdoc.md
@@ -26,6 +26,7 @@ gdoc edit DOC_ID "old" "new" --normalize     # Match through smart quotes/dashes
 gdoc edit DOC_ID --cell "Label" "new value"  # Replace the table cell right of a label
 gdoc edit DOC_ID --cell 7,1 "new value"      # Replace cell by ROW,COL (--table N, default 0)
 printf 'multi\nline' | gdoc edit DOC_ID --cell "Notes" -  # '-' reads an arg from stdin
+gdoc suggest DOC_ID "old text" "new text"    # Same as edit, but as a suggested edit to review
 gdoc write DOC_ID FILE.md                    # Overwrite doc body from local markdown
 
 gdoc comments DOC_ID                         # List open comments
@@ -373,5 +374,4 @@ No other dependencies. Intentionally minimal.
 - `gdoc diff DOC_ID FILE.md` — show diff between remote and local
 - `gdoc pull DOC_ID FILE.md` — alias for `cat DOC_ID > FILE.md`  
 - `gdoc watch DOC_ID` — poll for changes / new comments
-- `gdoc suggest DOC_ID "old" "new"` — make a suggestion instead of direct edit (Docs API supports `suggestInsertText` etc.)
 - `gdoc export DOC_ID --format pdf|docx|html`

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.20.1"
+__version__ = "0.21.0"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2051,7 +2051,14 @@ def suggest_replacement(
     if not requests:
         return SuggestionResult(occurrences=0)
 
-    # Prove enrollment with a read before the write (see the gate's doc).
+    # Prove enrollment with a read before the write (see the gate's doc),
+    # pinning one credential identity across both: `gdoc auth` rewriting
+    # the token file between them could swap the OAuth client project, so
+    # the gate would prove enrollment for one project while the batch goes
+    # through another — which an unenrolled backend may apply as a direct
+    # edit. The key carries the token file's identity; if it is unchanged
+    # once the service is in hand, gate and write share one credential.
+    gate_key = account_cache_key()
     check_suggest_preview_access(doc_id)
 
     body = {
@@ -2062,6 +2069,13 @@ def suggest_replacement(
         },
     }
     service = get_docs_service()
+    if account_cache_key() != gate_key:
+        raise GdocError(
+            "credentials changed while preparing the suggest write (the "
+            "account's token was rewritten between the enrollment check "
+            "and the write, so they may belong to different OAuth client "
+            "projects). No change was made — rerun the command."
+        )
     try:
         result = (
             service.documents()

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1,6 +1,7 @@
 """Google Docs API v1 wrapper functions with error translation."""
 
 import re
+from dataclasses import dataclass, field
 from functools import lru_cache
 
 from googleapiclient.discovery import build
@@ -1490,6 +1491,44 @@ def insert_markdown_into_tab(
     }
 
 
+def _build_replacement_requests(
+    parsed, matches: list[dict], tab_id: str | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """Build the delete+insert requests for a find/replace, last-to-first.
+
+    Pure function shared by ``replace_formatted`` (EDIT) and
+    ``suggest_replacement`` (SUGGEST). Matches are processed in descending
+    startIndex order so earlier ranges are unaffected by the length change
+    of later replacements within the one batch.
+
+    Returns (sorted_matches, requests).
+    """
+    from gdoc.mdparse import to_docs_requests
+
+    sorted_matches = sorted(
+        matches, key=lambda m: m["startIndex"], reverse=True,
+    )
+    all_requests: list[dict] = []
+    for match in sorted_matches:
+        # Delete the matched range (skip empty ranges — Docs API rejects
+        # them with "The range should not be empty", and a zero-width
+        # match is a pure insert).
+        if match["endIndex"] > match["startIndex"]:
+            delete_range = {
+                "startIndex": match["startIndex"],
+                "endIndex": match["endIndex"],
+            }
+            if tab_id:
+                delete_range["tabId"] = tab_id
+            all_requests.append({
+                "deleteContentRange": {"range": delete_range}
+            })
+        all_requests.extend(
+            to_docs_requests(parsed, match["startIndex"], tab_id=tab_id)
+        )
+    return sorted_matches, all_requests
+
+
 def replace_formatted(
     doc_id: str,
     matches: list[dict],
@@ -1513,41 +1552,15 @@ def replace_formatted(
     Returns:
         Number of replacements made.
     """
-    from gdoc.mdparse import parse_markdown, to_docs_requests
+    from gdoc.mdparse import parse_markdown
 
     parsed = parse_markdown(new_markdown)
 
     _strip_trailing_newline_unless_hr(parsed)
 
-    # Sort matches by startIndex descending (last-to-first)
-    sorted_matches = sorted(
-        matches, key=lambda m: m["startIndex"], reverse=True,
+    sorted_matches, all_requests = _build_replacement_requests(
+        parsed, matches, tab_id=tab_id,
     )
-
-    all_requests: list[dict] = []
-
-    for match in sorted_matches:
-        # Delete the matched range (skip empty ranges \u2014 Docs API rejects
-        # them with "The range should not be empty", and a zero-width
-        # match is a pure insert).
-        if match["endIndex"] > match["startIndex"]:
-            delete_range = {
-                "startIndex": match["startIndex"],
-                "endIndex": match["endIndex"],
-            }
-            if tab_id:
-                delete_range["tabId"] = tab_id
-            all_requests.append({
-                "deleteContentRange": {
-                    "range": delete_range,
-                }
-            })
-
-        # Insert formatted replacement
-        insert_requests = to_docs_requests(
-            parsed, match["startIndex"], tab_id=tab_id,
-        )
-        all_requests.extend(insert_requests)
 
     if not all_requests:
         return 0
@@ -1620,3 +1633,305 @@ def replace_formatted(
         return len(sorted_matches)
     except HttpError as e:
         _translate_http_error(e, doc_id)
+
+
+# ---------------------------------------------------------------------------
+# Suggested edits (Docs API Developer Preview: writeControl.writeMode=SUGGEST)
+# ---------------------------------------------------------------------------
+
+SUGGESTIONS_INLINE = "SUGGESTIONS_INLINE"
+
+_SUGGEST_UNSUPPORTED_HINT = (
+    "suggest supports plain text and inline formatting (bold, italic, "
+    "strikethrough, code, links); headings, lists, blockquotes, horizontal "
+    "rules, and tables are not supported yet. Use `gdoc edit` to apply "
+    "structural Markdown directly."
+)
+
+
+@dataclass
+class SuggestionResult:
+    """Outcome of a suggest-mode batchUpdate.
+
+    ``created_suggestion_ids`` come from ``suggestionResponses[].
+    createdSuggestionIds``; ``updated_suggestion_ids`` from
+    ``updatedSummarySuggestionIds`` minus anything created in the same batch
+    (Google merges an edit adjacent to the same author's open suggestion
+    into it instead of creating a new one, and also echoes new IDs under
+    "updated"). Both are flattened across responses and de-duplicated in
+    order.
+    """
+
+    occurrences: int
+    created_suggestion_ids: list[str] = field(default_factory=list)
+    updated_suggestion_ids: list[str] = field(default_factory=list)
+    comment_update_state: str = ""
+
+    @property
+    def suggestion_ids(self) -> list[str]:
+        """Every affected suggestion ID, created first, no duplicates."""
+        return _dedupe(self.created_suggestion_ids + self.updated_suggestion_ids)
+
+
+def _dedupe(ids: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for i in ids:
+        if i and i not in seen:
+            seen.add(i)
+            out.append(i)
+    return out
+
+
+def check_inline_only_markdown(parsed) -> None:
+    """Reject replacement Markdown that suggest mode can't represent yet.
+
+    Suggest mode runs one batch only — no read-back cleanup or table
+    insertion phases (those would each have to stay in SUGGEST mode and
+    Google's suggested-structure shapes are unverified). So anything that
+    is not plain text or an inline text style fails here, before any API
+    call, with a usage error (exit 3).
+    """
+    if parsed.tables:
+        raise GdocError(_SUGGEST_UNSUPPORTED_HINT, exit_code=3)
+    for sr in parsed.styles:
+        if sr.type == "text_style":
+            continue
+        if sr.type == "paragraph_style" and sr.style == {
+            "namedStyleType": "NORMAL_TEXT",
+        }:
+            # Plain paragraphs carry an explicit NORMAL_TEXT; harmless.
+            continue
+        raise GdocError(_SUGGEST_UNSUPPORTED_HINT, exit_code=3)
+
+
+def _inline_only(parsed):
+    """Copy of *parsed* keeping only text styles.
+
+    The NORMAL_TEXT paragraph-style requests ``edit`` sends would become
+    suggested paragraph-style changes on the surrounding paragraph — noise
+    in the review thread. Suggested text inherits the paragraph's style.
+    """
+    from gdoc.mdparse import ParsedMarkdown
+
+    return ParsedMarkdown(
+        plain_text=parsed.plain_text,
+        styles=[s for s in parsed.styles if s.type == "text_style"],
+        tables=[],
+        removed_tabs=0,
+    )
+
+
+def _walk_suggestion_ids(node, out: set[str]) -> None:
+    """Collect every suggestion ID referenced anywhere under *node*.
+
+    Schema-tolerant: any ``suggested*Ids`` list contributes its values and
+    any ``suggested*Changes`` map contributes its keys, so new suggestion
+    kinds are picked up without a code change.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key.startswith("suggested"):
+                if key.endswith("Ids") and isinstance(value, list):
+                    out.update(v for v in value if isinstance(v, str))
+                    continue
+                if key.endswith("Changes") and isinstance(value, dict):
+                    out.update(value.keys())
+                    continue
+            _walk_suggestion_ids(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_suggestion_ids(item, out)
+
+
+def collect_suggestion_ids(doc: dict) -> set[str]:
+    """All suggestion IDs present in a SUGGESTIONS_INLINE document read."""
+    out: set[str] = set()
+    _walk_suggestion_ids(doc, out)
+    return out
+
+
+def _overlaps(elem: dict, start: int, end: int) -> bool:
+    e_start = elem.get("startIndex", 0)
+    e_end = elem.get("endIndex", e_start)
+    if start == end:
+        # zero-width match: an insertion point inside (or at the end of)
+        # the element
+        return e_start <= start < e_end or (e_start < start <= e_end)
+    return e_start < end and start < e_end
+
+
+def find_suggestions_in_range(body: dict, start: int, end: int) -> set[str]:
+    """Suggestion IDs whose inline content or style map touches [start, end).
+
+    Walks paragraphs (recursing into table cells) read with
+    SUGGESTIONS_INLINE. For an overlapping paragraph, its paragraph-level
+    ``suggested*`` fields count, plus every overlapping element's
+    (``suggestedInsertionIds``, ``suggestedDeletionIds``,
+    ``suggestedTextStyleChanges``, ...). Table-row/cell style suggestions are
+    not inspected.
+    """
+    found: set[str] = set()
+    for elem in body.get("content", []):
+        if not _overlaps(elem, start, end):
+            continue
+        paragraph = elem.get("paragraph")
+        if paragraph is not None:
+            for key, value in paragraph.items():
+                if key.startswith("suggested"):
+                    _walk_suggestion_ids({key: value}, found)
+            for pe in paragraph.get("elements", []):
+                if _overlaps(pe, start, end):
+                    _walk_suggestion_ids(pe, found)
+            continue
+        table = elem.get("table")
+        if table is not None:
+            for row in table.get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    found |= find_suggestions_in_range(cell, start, end)
+    return found
+
+
+def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
+    """Translate a suggest-mode batchUpdate HttpError, preserving the reason.
+
+    Never falls back: a suggestion that cannot be made must not become a
+    direct edit.
+    """
+    status = int(e.resp.status)
+    detail = str(e)
+    lowered = detail.lower()
+    if status == 400 and "revision" in lowered:
+        raise GdocError(
+            "document changed while the command was running; re-run it"
+        )
+    if status == 400 and (
+        "unknown name" in lowered
+        or "cannot find field" in lowered
+        or "no request set" in lowered
+        or "write_mode" in lowered
+        or "writemode" in lowered
+    ):
+        raise GdocError(
+            "suggest mode not available: the OAuth client's Cloud project "
+            "is not enrolled in the Google Workspace Developer Preview "
+            f"(server rejected the request: {e.reason}). No change was made."
+        )
+    if status == 403:
+        raise GdocError(
+            f"Permission denied: {doc_id} (suggesting through the API needs "
+            "comment or edit access on the document, or the project lacks "
+            "Developer Preview access)"
+        )
+    _translate_http_error(e, doc_id)
+
+
+def suggest_replacement(
+    doc_id: str,
+    matches: list[dict],
+    new_markdown: str,
+    revision_id: str,
+    tab_id: str | None = None,
+) -> SuggestionResult:
+    """Replace matched ranges as *suggested* edits (writeMode=SUGGEST).
+
+    One batchUpdate carries the delete + insert + inline-style requests for
+    every match, with ``writeControl.requiredRevisionId`` pinned to the
+    revision the matches were computed against. Success requires all of:
+    HTTP 200, ``commentUpdateState == ALL_SAVED``, at least one created or
+    updated suggestion ID in ``suggestionResponses``, and a SUGGESTIONS_INLINE
+    read-back containing every one of those IDs. Anything less raises —
+    there is deliberately no fallback to a direct edit.
+
+    Args:
+        doc_id: The document ID.
+        matches: ``{"startIndex", "endIndex"}`` ranges in the
+            SUGGESTIONS_INLINE index space of *tab_id*.
+        new_markdown: Replacement text; plain or inline Markdown only
+            (see ``check_inline_only_markdown``).
+        revision_id: Non-empty revision the ranges were read at.
+        tab_id: Tab holding the ranges (omitted → first tab).
+    """
+    from gdoc.mdparse import parse_markdown
+
+    if not revision_id:
+        raise GdocError(
+            "cannot suggest: the document read did not include a revision "
+            "ID, so the write cannot be pinned to the text that was "
+            "matched. Google withholds revisionId from users without "
+            "comment or edit access; suggesting through the API needs at "
+            "least commenter permission on the document."
+        )
+
+    parsed = parse_markdown(new_markdown)
+    check_inline_only_markdown(parsed)
+    _strip_trailing_newline_unless_hr(parsed)
+    sorted_matches, requests = _build_replacement_requests(
+        _inline_only(parsed), matches, tab_id=tab_id,
+    )
+    if not requests:
+        return SuggestionResult(occurrences=0)
+
+    body = {
+        "requests": requests,
+        "writeControl": {
+            "requiredRevisionId": revision_id,
+            "writeMode": "SUGGEST",
+        },
+    }
+    try:
+        service = get_docs_service()
+        result = (
+            service.documents()
+            .batchUpdate(documentId=doc_id, body=body)
+            .execute()
+        )
+    except HttpError as e:
+        _classify_suggest_error(e, doc_id)
+
+    state = result.get("commentUpdateState", "")
+    created: list[str] = []
+    updated: list[str] = []
+    for resp in result.get("suggestionResponses", []) or []:
+        created.extend(resp.get("createdSuggestionIds", []) or [])
+        updated.extend(resp.get("updatedSummarySuggestionIds", []) or [])
+    created = _dedupe(created)
+    # Google echoes a just-created ID under updatedSummarySuggestionIds as
+    # well; report as "updated" only threads that existed before this batch
+    # (i.e. the edit was merged into the author's open suggestion).
+    updated = [sid for sid in _dedupe(updated) if sid not in created]
+    outcome = SuggestionResult(
+        occurrences=len(sorted_matches),
+        created_suggestion_ids=created,
+        updated_suggestion_ids=updated,
+        comment_update_state=state,
+    )
+
+    if state != "ALL_SAVED" or not outcome.suggestion_ids:
+        # The server answered 200 but produced no durable review object:
+        # either it ignored writeMode (an unenrolled backend has been seen
+        # applying the change directly) or the suggestion thread failed to
+        # save. Say so loudly; the caller must inspect the document.
+        raise GdocError(
+            "suggest mode was not applied: the server returned "
+            f"commentUpdateState={state or 'none'} and "
+            f"{len(outcome.suggestion_ids)} suggestion ID(s). The Cloud "
+            "project may lack Developer Preview access. Check the document "
+            "— the text may have been edited directly."
+        )
+
+    readback = get_document_structure(
+        doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
+    )
+    missing = [
+        sid for sid in outcome.suggestion_ids
+        if sid not in collect_suggestion_ids(readback)
+    ]
+    if missing:
+        raise GdocError(
+            "suggestion not found on read-back: "
+            + ", ".join(missing)
+            + ". The server reported it but the document does not show "
+            "it as a pending suggestion; inspect the document."
+        )
+    return outcome

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -640,7 +640,8 @@ def _cell_text_range(cell: dict) -> dict | None:
         content = cell.get("content", [])
         fs = content[0].get("startIndex") if content else None
         return {"startIndex": fs, "endIndex": fs} if fs is not None else None
-    end = last_start + len(last_content)
+    # Doc indexes are UTF-16 code units: an emoji in the cell counts as 2.
+    end = last_start + sum(_utf16_len(ch) for ch in last_content)
     if last_content.endswith("\n"):
         end -= 1  # keep the cell's final paragraph mark
     if end < first_start:
@@ -1565,6 +1566,11 @@ def replace_formatted(
 
     parsed = parse_markdown(new_markdown)
 
+    # Same guard as suggest_replacement: overlapping matches ("aa" in
+    # "aaa" with --all) would make the last-to-first delete/insert plan
+    # land on already-shifted text and corrupt the document.
+    _reject_overlapping_matches(matches)
+
     _strip_trailing_newline_unless_hr(parsed)
 
     sorted_matches, all_requests = _build_replacement_requests(
@@ -1633,11 +1639,15 @@ def replace_formatted(
         # Insert tables if any (after main batchUpdate + cleanup)
         if parsed.tables:
             for table in reversed(parsed.tables):
+                # UTF-16 offset of the table placeholder; invariant per
+                # table, so hoisted out of the per-match loop.
+                offset16 = utf16_len(
+                    parsed.plain_text[:table.plain_text_offset],
+                )
                 for j, match in enumerate(sorted_matches):
                     shift = (n - 1 - j) * delta
                     idx = (
-                        match["startIndex"]
-                        + utf16_len(parsed.plain_text[:table.plain_text_offset])
+                        match["startIndex"] + offset16
                         - table.removed_tabs_before + shift
                     )
                     _insert_table(doc_id, idx, table, tab_id=tab_id)
@@ -1792,6 +1802,9 @@ def find_suggestions_in_range(body: dict, start: int, end: int) -> set[str]:
     table's, each overlapping row's, and each overlapping cell's own
     ``suggested*`` fields count too (suggested table/row/cell insertions,
     deletions, and style changes), before recursing into the cell content.
+    Any other overlapping structural element (a section break, a table of
+    contents) has no index-aware model here, so every suggestion anywhere
+    under it counts — conservative, like ``_container_overlaps``.
     """
     found: set[str] = set()
     for elem in body.get("content", []):
@@ -1799,9 +1812,7 @@ def find_suggestions_in_range(body: dict, start: int, end: int) -> set[str]:
             continue
         paragraph = elem.get("paragraph")
         if paragraph is not None:
-            for key, value in paragraph.items():
-                if key.startswith("suggested"):
-                    _walk_suggestion_ids({key: value}, found)
+            _walk_container_suggestions(paragraph, found)
             for pe in paragraph.get("elements", []):
                 if _overlaps(pe, start, end):
                     _walk_suggestion_ids(pe, found)
@@ -1821,6 +1832,11 @@ def find_suggestions_in_range(body: dict, start: int, end: int) -> set[str]:
                         continue
                     _walk_container_suggestions(cell, found)
                     found |= find_suggestions_in_range(cell, start, end)
+            continue
+        # sectionBreak, tableOfContents, or a future element type: a match
+        # can span one (segments concatenate across them), and a suggested
+        # section break / TOC entry is someone's review thread too.
+        _walk_suggestion_ids(elem, found)
     return found
 
 
@@ -1894,12 +1910,11 @@ def check_suggest_preview_access(doc_id: str) -> None:
     Sent as a raw authorized GET because the bundled discovery document
     predates the field and the generated client refuses unknown parameters.
     """
+    from google.auth.exceptions import GoogleAuthError, TransportError
     from google.auth.transport.requests import AuthorizedSession
+    from requests.exceptions import RequestException
 
     from gdoc.auth import get_credentials
-
-    from google.auth.exceptions import GoogleAuthError
-    from requests.exceptions import RequestException
 
     account, _stamp = account_cache_key()
     try:
@@ -1917,6 +1932,15 @@ def check_suggest_preview_access(doc_id: str) -> None:
                 "fields": "documentId,commentsViewMode",
             },
             timeout=60,
+        )
+    except TransportError as e:
+        # google-auth wraps a network failure during token refresh in
+        # TransportError (a GoogleAuthError subclass) — it is a transport
+        # problem, not bad credentials, so it must not become "run
+        # `gdoc auth`". Fail closed — nothing has been written.
+        raise GdocError(
+            "suggest mode check failed before any write "
+            f"(network error: {e}). No change was made."
         )
     except GoogleAuthError as e:
         # Credentials that could not be refreshed (revoked, expired).
@@ -2004,6 +2028,8 @@ def suggest_replacement(
         revision_id: Non-empty revision the ranges were read at.
         tab_id: Tab holding the ranges (omitted → first tab).
     """
+    from google.auth.exceptions import GoogleAuthError, TransportError
+
     from gdoc.mdparse import parse_markdown
 
     if not revision_id:
@@ -2044,6 +2070,17 @@ def suggest_replacement(
         )
     except HttpError as e:
         _classify_suggest_error(e, doc_id)
+    except TransportError as e:
+        # Raised only while refreshing the access token, which happens
+        # before the request is sent — nothing reached Google.
+        raise GdocError(
+            "the suggest write failed before it was sent (network error "
+            f"during token refresh: {e}). No change was made."
+        )
+    except GoogleAuthError as e:
+        # Credential failure (revoked/expired beyond refresh) — also
+        # pre-send, and an auth problem, not an indeterminate write.
+        raise AuthError(f"Authentication expired ({e}). Run `gdoc auth`.")
     except Exception as e:  # noqa: BLE001 — .execute() is the network call;
         # a timeout or reset here can land after Google has accepted the
         # write, so the outcome is genuinely indeterminate. A generic
@@ -2101,9 +2138,9 @@ def suggest_replacement(
             f"({str(e) or type(e).__name__}); inspect the document",
             exit_code=getattr(e, "exit_code", 1),
         )
+    present = collect_suggestion_ids(readback)
     missing = [
-        sid for sid in outcome.suggestion_ids
-        if sid not in collect_suggestion_ids(readback)
+        sid for sid in outcome.suggestion_ids if sid not in present
     ]
     if missing:
         raise GdocError(

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1794,10 +1794,34 @@ def find_suggestions_in_range(body: dict, start: int, end: int) -> set[str]:
             continue
         table = elem.get("table")
         if table is not None:
+            # Container-level suggestions (a suggested table, row, or cell
+            # insertion/deletion/style) are recorded on the container, not
+            # on the text runs inside it.
+            _walk_container_suggestions(table, found)
             for row in table.get("tableRows", []):
+                if not _container_overlaps(row, start, end):
+                    continue
+                _walk_container_suggestions(row, found)
                 for cell in row.get("tableCells", []):
+                    if not _container_overlaps(cell, start, end):
+                        continue
+                    _walk_container_suggestions(cell, found)
                     found |= find_suggestions_in_range(cell, start, end)
     return found
+
+
+def _container_overlaps(node: dict, start: int, end: int) -> bool:
+    """Rows/cells without index fields are not skipped (be conservative)."""
+    if "startIndex" not in node or "endIndex" not in node:
+        return True
+    return _overlaps(node, start, end)
+
+
+def _walk_container_suggestions(node: dict, out: set[str]) -> None:
+    """Collect this node's own ``suggested*`` fields (no recursion)."""
+    for key, value in node.items():
+        if key.startswith("suggested"):
+            _walk_suggestion_ids({key: value}, out)
 
 
 def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
@@ -1842,6 +1866,87 @@ def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
     _translate_http_error(e, doc_id)
 
 
+def check_suggest_preview_access(doc_id: str) -> None:
+    """Non-mutating gate: is this OAuth client's project preview-enrolled?
+
+    An unenrolled backend has been observed *ignoring* ``writeMode: SUGGEST``
+    and applying the batch as a direct edit, so enrollment must be proven
+    before the write, not inferred from its response. The decisive probe
+    is a ``documents.get`` with the preview-only ``commentsViewMode`` field:
+    a registered project echoes it (HTTP 200), an unregistered one rejects
+    it (400 ``Unknown name "comments_view_mode"``). Same account, document,
+    and scopes — only the client project changes the answer.
+
+    Sent as a raw authorized GET because the bundled discovery document
+    predates the field and the generated client refuses unknown parameters.
+    """
+    from google.auth.transport.requests import AuthorizedSession
+
+    from gdoc.auth import get_credentials
+
+    account, _stamp = account_cache_key()
+    session = AuthorizedSession(get_credentials(account))
+    resp = session.get(
+        f"https://docs.googleapis.com/v1/documents/{doc_id}",
+        params={
+            # Google requires the two companions ("Comments view mode may
+            # only be specified if tabs content is also requested" /
+            # "... if inline suggestions are also explicitly requested").
+            "includeTabsContent": "true",
+            "suggestionsViewMode": "SUGGESTIONS_INLINE",
+            "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+            "fields": "documentId,commentsViewMode",
+        },
+        timeout=60,
+    )
+    status = resp.status_code
+    if status == 200:
+        try:
+            mode = resp.json().get("commentsViewMode", "")
+        except ValueError:
+            mode = ""
+        if mode != "COMMENTS_VIEW_MODE_INCLUDED":
+            raise GdocError(
+                "suggest mode not available: the server accepted but did "
+                "not apply the Developer Preview read field, so suggest "
+                "mode cannot be trusted. No change was made."
+            )
+        return
+    detail = resp.text.lower()
+    if status == 400 and (
+        "unknown name" in detail or "cannot find field" in detail
+    ):
+        raise GdocError(
+            "suggest mode not available: the OAuth client's Cloud project "
+            "is not enrolled in the Google Workspace Developer Preview "
+            "(preview read field rejected). No change was made."
+        )
+    if status == 401:
+        raise AuthError("Authentication expired. Run `gdoc auth`.")
+    if status == 403:
+        raise GdocError(
+            f"Permission denied: {doc_id} (reading suggestions needs comment "
+            "or edit access on the document)"
+        )
+    if status == 404:
+        raise GdocError(f"Document not found: {doc_id}")
+    raise GdocError(f"API error ({status}): {resp.reason}")
+
+
+def _reject_overlapping_matches(matches: list[dict]) -> None:
+    """Two matches sharing text (``aa`` in ``aaa``) can't both be replaced:
+    the last-to-first delete/insert plan would land on shifted text."""
+    ordered = sorted(matches, key=lambda m: m["startIndex"])
+    for prev, cur in zip(ordered, ordered[1:]):
+        if cur["startIndex"] < prev["endIndex"]:
+            raise GdocError(
+                "matches overlap each other (the anchor repeats within "
+                f"itself around index {cur['startIndex']}); use a longer "
+                "anchor or drop --all",
+                exit_code=3,
+            )
+
+
 def suggest_replacement(
     doc_id: str,
     matches: list[dict],
@@ -1853,7 +1958,10 @@ def suggest_replacement(
 
     One batchUpdate carries the delete + insert + inline-style requests for
     every match, with ``writeControl.requiredRevisionId`` pinned to the
-    revision the matches were computed against. Success requires all of:
+    revision the matches were computed against. Before it, a non-mutating
+    preview read (``check_suggest_preview_access``) proves the project is
+    enrolled, because an unenrolled backend may silently apply the batch as
+    a direct edit. Success requires all of:
     HTTP 200, ``commentUpdateState == ALL_SAVED``, at least one created or
     updated suggestion ID in ``suggestionResponses``, and a SUGGESTIONS_INLINE
     read-back containing every one of those IDs. Anything less raises —
@@ -1881,12 +1989,16 @@ def suggest_replacement(
 
     parsed = parse_markdown(new_markdown)
     check_inline_only_markdown(parsed)
+    _reject_overlapping_matches(matches)
     _strip_trailing_newline_unless_hr(parsed)
     sorted_matches, requests = _build_replacement_requests(
         _inline_only(parsed), matches, tab_id=tab_id,
     )
     if not requests:
         return SuggestionResult(occurrences=0)
+
+    # Prove enrollment with a read before the write (see the gate's doc).
+    check_suggest_preview_access(doc_id)
 
     body = {
         "requests": requests,

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2182,9 +2182,18 @@ def suggest_replacement(
             raise GdocError(
                 "suggest mode was not applied: the server returned "
                 f"commentUpdateState={state or 'none'} and "
-                f"{len(outcome.suggestion_ids)} suggestion ID(s). The Cloud "
-                "project may lack Developer Preview access. Check the "
-                "document — the text may have been edited directly."
+                f"{len(outcome.suggestion_ids)} suggestion ID(s)"
+                + (
+                    # Name any IDs that did come back: some review objects
+                    # may exist, and a caller deciding whether to retry
+                    # must be able to find them.
+                    " (" + ", ".join(outcome.suggestion_ids) + ")"
+                    if outcome.suggestion_ids
+                    else ""
+                )
+                + ". The Cloud project may lack Developer Preview access. "
+                "Check the document — the text may have been edited "
+                "directly."
             )
 
         try:

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1691,6 +1691,11 @@ def check_inline_only_markdown(parsed) -> None:
     Google's suggested-structure shapes are unverified). So anything that
     is not plain text or an inline text style fails here, before any API
     call, with a usage error (exit 3).
+
+    Newlines are allowed: they become suggested paragraph breaks, and the
+    new paragraphs inherit the anchor paragraph's style (no paragraph-style
+    requests are sent in suggest mode). Fenced code blocks pass too — they
+    parse to plain NORMAL_TEXT paragraphs in the code font.
     """
     if parsed.tables:
         raise GdocError(_SUGGEST_UNSUPPORTED_HINT, exit_code=3)
@@ -1725,17 +1730,20 @@ def _inline_only(parsed):
 def _walk_suggestion_ids(node, out: set[str]) -> None:
     """Collect every suggestion ID referenced anywhere under *node*.
 
-    Schema-tolerant: any ``suggested*Ids`` list contributes its values and
-    any ``suggested*Changes`` map contributes its keys, so new suggestion
-    kinds are picked up without a code change.
+    Schema-tolerant: any ``suggested*`` list contributes its string values
+    (``suggestedInsertionIds``) and any ``suggested*`` map contributes its
+    keys (``suggestedTextStyleChanges``, and also
+    ``suggestedPositionedObjectIds``, which is a map keyed by suggestion ID
+    despite its name), so new suggestion kinds are picked up without a
+    code change.
     """
     if isinstance(node, dict):
         for key, value in node.items():
             if key.startswith("suggested"):
-                if key.endswith("Ids") and isinstance(value, list):
+                if isinstance(value, list):
                     out.update(v for v in value if isinstance(v, str))
                     continue
-                if key.endswith("Changes") and isinstance(value, dict):
+                if isinstance(value, dict):
                     out.update(value.keys())
                     continue
             _walk_suggestion_ids(value, out)
@@ -1801,9 +1809,17 @@ def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
     status = int(e.resp.status)
     detail = str(e)
     lowered = detail.lower()
-    if status == 400 and "revision" in lowered:
+    if (
+        status == 400
+        and "revision" in lowered
+        and "invalid value" not in lowered
+    ):
+        # A stale requiredRevisionId. A malformed one ("Invalid value at
+        # 'write_control.required_revision_id'") is a bug, not a race, and
+        # must not be reported as "re-run it".
         raise GdocError(
-            "document changed while the command was running; re-run it"
+            "document changed while the command was running; re-run it "
+            f"(server: {e.reason})"
         )
     if status == 400 and (
         "unknown name" in lowered
@@ -1920,9 +1936,19 @@ def suggest_replacement(
             "— the text may have been edited directly."
         )
 
-    readback = get_document_structure(
-        doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
-    )
+    try:
+        readback = get_document_structure(
+            doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
+        )
+    except GdocError as e:
+        # The write succeeded; only the verification read failed. Say so —
+        # a bare "API error (503)" would hide that a suggestion very likely
+        # exists now.
+        raise GdocError(
+            "suggestion(s) " + ", ".join(outcome.suggestion_ids)
+            + " were reported saved but could not be verified "
+            f"({e}); inspect the document", exit_code=e.exit_code,
+        )
     missing = [
         sid for sid in outcome.suggestion_ids
         if sid not in collect_suggestion_ids(readback)

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1896,13 +1896,15 @@ def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
     _translate_http_error(e, doc_id)
 
 
-def _token_client_id(account: str | None) -> str | None:
-    """The OAuth client_id recorded in the account's token file.
+def _token_identity(account: str | None) -> tuple[str | None, str | None]:
+    """The (client_id, refresh_token) pair in the account's token file.
 
-    Developer Preview enrollment belongs to the OAuth client project, so
-    this is the identity that must hold still between the enrollment gate
-    and the write. A routine token refresh rewrites the file but keeps it;
-    only re-authenticating with a different client config changes it.
+    The identity that must hold still between the enrollment gate and the
+    write: Developer Preview enrollment belongs to the OAuth client
+    project (client_id), and the suggestion's author is the granted user
+    (refresh_token — any new grant mints a new one, whether the client or
+    the Google user changed). A routine access-token refresh rewrites the
+    file but keeps both. Missing or unreadable token reads as (None, None).
     """
     import json
 
@@ -1912,8 +1914,10 @@ def _token_client_id(account: str | None) -> str | None:
         with token_path_for(account).open() as f:
             data = json.load(f)
     except (OSError, ValueError):
-        return None
-    return data.get("client_id") if isinstance(data, dict) else None
+        return (None, None)
+    if not isinstance(data, dict):
+        return (None, None)
+    return (data.get("client_id"), data.get("refresh_token"))
 
 
 def check_suggest_preview_access(doc_id: str) -> None:
@@ -2072,16 +2076,18 @@ def suggest_replacement(
         return SuggestionResult(occurrences=0)
 
     # Prove enrollment with a read before the write (see the gate's doc),
-    # pinning one OAuth client identity across both: a re-auth with a
-    # different client config landing between them could otherwise prove
-    # enrollment for one project while the batch goes through another —
-    # which an unenrolled backend may apply as a direct edit. The pin is
-    # the token's client_id, not the file's identity: a routine
+    # pinning one OAuth identity across both: a re-auth landing between
+    # them could otherwise swap the client project (proving enrollment for
+    # one project while the batch goes through another — which an
+    # unenrolled backend may apply as a direct edit) or the granted user
+    # (authoring the suggestion as someone else). The pin is the token's
+    # (client_id, refresh_token) pair, not the file's identity: a routine
     # access-token refresh (the gate's own get_credentials persists one
     # when a long-lived process refreshed only in memory) rewrites the
-    # file without changing the client project, and must not abort.
+    # file but keeps both, and must not abort; any new grant mints a new
+    # refresh_token.
     account, _stamp = account_cache_key()
-    gate_client = _token_client_id(account)
+    gate_identity = _token_identity(account)
     check_suggest_preview_access(doc_id)
 
     body = {
@@ -2092,13 +2098,13 @@ def suggest_replacement(
         },
     }
     service = get_docs_service()
-    if _token_client_id(account) != gate_client:
+    if _token_identity(account) != gate_identity:
         raise GdocError(
             "credentials changed while preparing the suggest write (the "
-            "account's OAuth client was replaced between the enrollment "
-            "check and the write, so enrollment was proven for a "
-            "different client project). No change was made — rerun the "
-            "command."
+            "account was re-authenticated between the enrollment check "
+            "and the write, so the check may have proven a different "
+            "OAuth client project or user). No change was made — rerun "
+            "the command."
         )
     try:
         result = (

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1776,8 +1776,10 @@ def find_suggestions_in_range(body: dict, start: int, end: int) -> set[str]:
     SUGGESTIONS_INLINE. For an overlapping paragraph, its paragraph-level
     ``suggested*`` fields count, plus every overlapping element's
     (``suggestedInsertionIds``, ``suggestedDeletionIds``,
-    ``suggestedTextStyleChanges``, ...). Table-row/cell style suggestions are
-    not inspected.
+    ``suggestedTextStyleChanges``, ...). For an overlapping table, the
+    table's, each overlapping row's, and each overlapping cell's own
+    ``suggested*`` fields count too (suggested table/row/cell insertions,
+    deletions, and style changes), before recursing into the cell content.
     """
     found: set[str] = set()
     for elem in body.get("content", []):

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -812,7 +812,13 @@ def _insert_table(
             return
 
         # Parse each cell's markdown to plain text + inline styles, once.
-        from gdoc.mdparse import StyleRange, parse_inline, text_style_fields
+        from gdoc.mdparse import (
+            StyleRange,
+            _utf16_prefix,
+            parse_inline,
+            text_style_fields,
+            utf16_len,
+        )
 
         parsed_cells: dict[tuple[int, int], tuple[str, list]] = {}
         for r_idx, row in enumerate(cell_indices):
@@ -857,10 +863,12 @@ def _insert_table(
                         0, len(plain), {"bold": True}, "text_style",
                     ))
                 base = row[c_idx] + shift
+                # Style offsets are code points; Docs indexes are UTF-16.
+                utf16 = _utf16_prefix(plain)
                 for s in cell_styles:
                     style_range = {
-                        "startIndex": base + s.start,
-                        "endIndex": base + s.end,
+                        "startIndex": base + utf16[s.start],
+                        "endIndex": base + utf16[s.end],
                     }
                     if tab_id:
                         style_range["tabId"] = tab_id
@@ -871,7 +879,7 @@ def _insert_table(
                             "fields": text_style_fields(s.style),
                         }
                     })
-                shift += len(plain)
+                shift += utf16_len(plain)
 
         if text_requests:
             service.documents().batchUpdate(
@@ -1423,7 +1431,7 @@ def insert_markdown_into_tab(
     Returns:
         Dict with "tab_id", "tab_title", "insert_index".
     """
-    from gdoc.mdparse import parse_markdown, to_docs_requests
+    from gdoc.mdparse import parse_markdown, to_docs_requests, utf16_len
 
     doc = get_document_with_tabs(doc_id)
     revision_id = doc.get("revisionId", "")
@@ -1478,7 +1486,8 @@ def insert_markdown_into_tab(
             # removed before this table, shifting its real position left.
             _insert_table(
                 doc_id,
-                insert_index + table.plain_text_offset
+                insert_index
+                + utf16_len(parsed.plain_text[:table.plain_text_offset])
                 - table.removed_tabs_before,
                 table,
                 tab_id=tab_id,
@@ -1552,7 +1561,7 @@ def replace_formatted(
     Returns:
         Number of replacements made.
     """
-    from gdoc.mdparse import parse_markdown
+    from gdoc.mdparse import parse_markdown, utf16_len
 
     parsed = parse_markdown(new_markdown)
 
@@ -1597,7 +1606,9 @@ def replace_formatted(
         # createParagraphBullets removes the nested-list indent tabs during
         # the main batch, so each match grows the doc by the post-removal
         # length, not len(plain_text).
-        effective_len = len(parsed.plain_text) - parsed.removed_tabs
+        # Lengths in UTF-16 units: an emoji in the replacement grows the
+        # doc by 2, not 1.
+        effective_len = utf16_len(parsed.plain_text) - parsed.removed_tabs
         delta = effective_len - match_len
         # Matches are sorted descending by startIndex; iterate in
         # that same order so higher positions are cleaned first.
@@ -1625,7 +1636,8 @@ def replace_formatted(
                 for j, match in enumerate(sorted_matches):
                     shift = (n - 1 - j) * delta
                     idx = (
-                        match["startIndex"] + table.plain_text_offset
+                        match["startIndex"]
+                        + utf16_len(parsed.plain_text[:table.plain_text_offset])
                         - table.removed_tabs_before + shift
                     )
                     _insert_table(doc_id, idx, table, tab_id=tab_id)
@@ -1886,21 +1898,35 @@ def check_suggest_preview_access(doc_id: str) -> None:
 
     from gdoc.auth import get_credentials
 
+    from google.auth.exceptions import GoogleAuthError
+    from requests.exceptions import RequestException
+
     account, _stamp = account_cache_key()
-    session = AuthorizedSession(get_credentials(account))
-    resp = session.get(
-        f"https://docs.googleapis.com/v1/documents/{doc_id}",
-        params={
-            # Google requires the two companions ("Comments view mode may
-            # only be specified if tabs content is also requested" /
-            # "... if inline suggestions are also explicitly requested").
-            "includeTabsContent": "true",
-            "suggestionsViewMode": "SUGGESTIONS_INLINE",
-            "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
-            "fields": "documentId,commentsViewMode",
-        },
-        timeout=60,
-    )
+    try:
+        session = AuthorizedSession(get_credentials(account))
+        resp = session.get(
+            f"https://docs.googleapis.com/v1/documents/{doc_id}",
+            params={
+                # Google requires the two companions ("Comments view mode
+                # may only be specified if tabs content is also requested"
+                # / "... if inline suggestions are also explicitly
+                # requested").
+                "includeTabsContent": "true",
+                "suggestionsViewMode": "SUGGESTIONS_INLINE",
+                "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+                "fields": "documentId,commentsViewMode",
+            },
+            timeout=60,
+        )
+    except GoogleAuthError as e:
+        # Credentials that could not be refreshed (revoked, expired).
+        raise AuthError(f"Authentication expired ({e}). Run `gdoc auth`.")
+    except RequestException as e:
+        # Transport failure: fail closed — nothing has been written.
+        raise GdocError(
+            "suggest mode check failed before any write "
+            f"(network error: {e}). No change was made."
+        )
     status = resp.status_code
     if status == 200:
         try:

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2098,109 +2098,119 @@ def suggest_replacement(
         if expected_token_identity is not None
         else _token_identity(account)
     )
-    check_suggest_preview_access(doc_id)
+    # The gate, the service lookup, and the verification read each resolve
+    # the active account themselves; pin the one captured above so an
+    # unpinned direct call cannot have a concurrent default-account change
+    # split them across two accounts (the CLI and MCP already pin — they
+    # re-enter the same value).
+    from gdoc.util import account_context
 
-    body = {
-        "requests": requests,
-        "writeControl": {
-            "requiredRevisionId": revision_id,
-            "writeMode": "SUGGEST",
-        },
-    }
-    service = get_docs_service()
-    if _token_identity(account) != gate_identity:
-        raise GdocError(
-            "credentials changed while preparing the suggest write (the "
-            "account was re-authenticated between the enrollment check "
-            "and the write, so the check may have proven a different "
-            "OAuth client project or user). No change was made — rerun "
-            "the command."
-        )
-    try:
-        result = (
-            service.documents()
-            .batchUpdate(documentId=doc_id, body=body)
-            .execute()
-        )
-    except HttpError as e:
-        _classify_suggest_error(e, doc_id)
-    except TransportError as e:
-        # Raised only while refreshing the access token, which happens
-        # before the request is sent — nothing reached Google.
-        raise GdocError(
-            "the suggest write failed before it was sent (network error "
-            f"during token refresh: {e}). No change was made."
-        )
-    except GoogleAuthError as e:
-        # Credential failure (revoked/expired beyond refresh) — also
-        # pre-send, and an auth problem, not an indeterminate write.
-        raise AuthError(f"Authentication expired ({e}). Run `gdoc auth`.")
-    except Exception as e:  # noqa: BLE001 — .execute() is the network call;
-        # a timeout or reset here can land after Google has accepted the
-        # write, so the outcome is genuinely indeterminate. A generic
-        # unexpected error would let the caller retry blindly.
-        raise GdocError(
-            "the suggest write failed in transit "
-            f"({str(e) or type(e).__name__}). The outcome is unknown — "
-            "the suggestion may or may not have been saved. Inspect the "
-            "document before retrying."
-        )
+    with account_context(account):
+        check_suggest_preview_access(doc_id)
 
-    state = result.get("commentUpdateState", "")
-    created: list[str] = []
-    updated: list[str] = []
-    for resp in result.get("suggestionResponses", []) or []:
-        created.extend(resp.get("createdSuggestionIds", []) or [])
-        updated.extend(resp.get("updatedSummarySuggestionIds", []) or [])
-    created = _dedupe(created)
-    # Google echoes a just-created ID under updatedSummarySuggestionIds as
-    # well; report as "updated" only threads that existed before this batch
-    # (i.e. the edit was merged into the author's open suggestion).
-    updated = [sid for sid in _dedupe(updated) if sid not in created]
-    outcome = SuggestionResult(
-        occurrences=len(sorted_matches),
-        created_suggestion_ids=created,
-        updated_suggestion_ids=updated,
-        comment_update_state=state,
-    )
+        body = {
+            "requests": requests,
+            "writeControl": {
+                "requiredRevisionId": revision_id,
+                "writeMode": "SUGGEST",
+            },
+        }
+        service = get_docs_service()
+        if _token_identity(account) != gate_identity:
+            raise GdocError(
+                "credentials changed while preparing the suggest write "
+                "(the account was re-authenticated between the enrollment "
+                "check and the write, so the check may have proven a "
+                "different OAuth client project or user). No change was "
+                "made — rerun the command."
+            )
+        try:
+            result = (
+                service.documents()
+                .batchUpdate(documentId=doc_id, body=body)
+                .execute()
+            )
+        except HttpError as e:
+            _classify_suggest_error(e, doc_id)
+        except TransportError as e:
+            # Raised only while refreshing the access token, which happens
+            # before the request is sent — nothing reached Google.
+            raise GdocError(
+                "the suggest write failed before it was sent (network "
+                f"error during token refresh: {e}). No change was made."
+            )
+        except GoogleAuthError as e:
+            # Credential failure (revoked/expired beyond refresh) — also
+            # pre-send, and an auth problem, not an indeterminate write.
+            raise AuthError(f"Authentication expired ({e}). Run `gdoc auth`.")
+        except Exception as e:  # noqa: BLE001 — .execute() is the network
+            # call; a timeout or reset here can land after Google has
+            # accepted the write, so the outcome is genuinely
+            # indeterminate. A generic unexpected error would let the
+            # caller retry blindly.
+            raise GdocError(
+                "the suggest write failed in transit "
+                f"({str(e) or type(e).__name__}). The outcome is unknown — "
+                "the suggestion may or may not have been saved. Inspect "
+                "the document before retrying."
+            )
 
-    if state != "ALL_SAVED" or not outcome.suggestion_ids:
-        # The server answered 200 but produced no durable review object:
-        # either it ignored writeMode (an unenrolled backend has been seen
-        # applying the change directly) or the suggestion thread failed to
-        # save. Say so loudly; the caller must inspect the document.
-        raise GdocError(
-            "suggest mode was not applied: the server returned "
-            f"commentUpdateState={state or 'none'} and "
-            f"{len(outcome.suggestion_ids)} suggestion ID(s). The Cloud "
-            "project may lack Developer Preview access. Check the document "
-            "— the text may have been edited directly."
+        state = result.get("commentUpdateState", "")
+        created: list[str] = []
+        updated: list[str] = []
+        for resp in result.get("suggestionResponses", []) or []:
+            created.extend(resp.get("createdSuggestionIds", []) or [])
+            updated.extend(resp.get("updatedSummarySuggestionIds", []) or [])
+        created = _dedupe(created)
+        # Google echoes a just-created ID under updatedSummarySuggestionIds
+        # as well; report as "updated" only threads that existed before this
+        # batch (i.e. the edit was merged into the author's open suggestion).
+        updated = [sid for sid in _dedupe(updated) if sid not in created]
+        outcome = SuggestionResult(
+            occurrences=len(sorted_matches),
+            created_suggestion_ids=created,
+            updated_suggestion_ids=updated,
+            comment_update_state=state,
         )
 
-    try:
-        readback = get_document_structure(
-            doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
-        )
-    except Exception as e:  # noqa: BLE001 — the write succeeded; only the
-        # verification read failed, either as a GdocError from the API
-        # layer or as an untranslated transport error (timeout, reset).
-        # A bare "API error (503)" — or a naked ConnectionError — would
-        # hide that a suggestion very likely exists now.
-        raise GdocError(
-            "suggestion(s) " + ", ".join(outcome.suggestion_ids)
-            + " were reported saved but could not be verified "
-            f"({str(e) or type(e).__name__}); inspect the document",
-            exit_code=getattr(e, "exit_code", 1),
-        )
-    present = collect_suggestion_ids(readback)
-    missing = [
-        sid for sid in outcome.suggestion_ids if sid not in present
-    ]
-    if missing:
-        raise GdocError(
-            "suggestion not found on read-back: "
-            + ", ".join(missing)
-            + ". The server reported it but the document does not show "
-            "it as a pending suggestion; inspect the document."
-        )
-    return outcome
+        if state != "ALL_SAVED" or not outcome.suggestion_ids:
+            # The server answered 200 but produced no durable review object:
+            # either it ignored writeMode (an unenrolled backend has been
+            # seen applying the change directly) or the suggestion thread
+            # failed to save. Say so loudly; the caller must inspect the
+            # document.
+            raise GdocError(
+                "suggest mode was not applied: the server returned "
+                f"commentUpdateState={state or 'none'} and "
+                f"{len(outcome.suggestion_ids)} suggestion ID(s). The Cloud "
+                "project may lack Developer Preview access. Check the "
+                "document — the text may have been edited directly."
+            )
+
+        try:
+            readback = get_document_structure(
+                doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
+            )
+        except Exception as e:  # noqa: BLE001 — the write succeeded; only
+            # the verification read failed, either as a GdocError from the
+            # API layer or as an untranslated transport error (timeout,
+            # reset). A bare "API error (503)" — or a naked ConnectionError
+            # — would hide that a suggestion very likely exists now.
+            raise GdocError(
+                "suggestion(s) " + ", ".join(outcome.suggestion_ids)
+                + " were reported saved but could not be verified "
+                f"({str(e) or type(e).__name__}); inspect the document",
+                exit_code=getattr(e, "exit_code", 1),
+            )
+        present = collect_suggestion_ids(readback)
+        missing = [
+            sid for sid in outcome.suggestion_ids if sid not in present
+        ]
+        if missing:
+            raise GdocError(
+                "suggestion not found on read-back: "
+                + ", ".join(missing)
+                + ". The server reported it but the document does not show "
+                "it as a pending suggestion; inspect the document."
+            )
+        return outcome

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2029,6 +2029,7 @@ def suggest_replacement(
     new_markdown: str,
     revision_id: str,
     tab_id: str | None = None,
+    expected_token_identity: tuple[str | None, str | None] | None = None,
 ) -> SuggestionResult:
     """Replace matched ranges as *suggested* edits (writeMode=SUGGEST).
 
@@ -2051,6 +2052,11 @@ def suggest_replacement(
             (see ``check_inline_only_markdown``).
         revision_id: Non-empty revision the ranges were read at.
         tab_id: Tab holding the ranges (omitted → first tab).
+        expected_token_identity: ``_token_identity()`` captured before the
+            document read; when given, the pre-write identity check uses it
+            as the baseline, extending the re-auth guard across the read
+            (the CLI passes it). Omitted → the baseline is captured here,
+            guarding the gate→write pair only.
     """
     from google.auth.exceptions import GoogleAuthError, TransportError
 
@@ -2087,7 +2093,11 @@ def suggest_replacement(
     # file but keeps both, and must not abort; any new grant mints a new
     # refresh_token.
     account, _stamp = account_cache_key()
-    gate_identity = _token_identity(account)
+    gate_identity = (
+        expected_token_identity
+        if expected_token_identity is not None
+        else _token_identity(account)
+    )
     check_suggest_preview_access(doc_id)
 
     body = {

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2035,8 +2035,8 @@ def suggest_replacement(
             "writeMode": "SUGGEST",
         },
     }
+    service = get_docs_service()
     try:
-        service = get_docs_service()
         result = (
             service.documents()
             .batchUpdate(documentId=doc_id, body=body)
@@ -2044,6 +2044,16 @@ def suggest_replacement(
         )
     except HttpError as e:
         _classify_suggest_error(e, doc_id)
+    except Exception as e:  # noqa: BLE001 — .execute() is the network call;
+        # a timeout or reset here can land after Google has accepted the
+        # write, so the outcome is genuinely indeterminate. A generic
+        # unexpected error would let the caller retry blindly.
+        raise GdocError(
+            "the suggest write failed in transit "
+            f"({str(e) or type(e).__name__}). The outcome is unknown — "
+            "the suggestion may or may not have been saved. Inspect the "
+            "document before retrying."
+        )
 
     state = result.get("commentUpdateState", "")
     created: list[str] = []
@@ -2080,14 +2090,16 @@ def suggest_replacement(
         readback = get_document_structure(
             doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
         )
-    except GdocError as e:
-        # The write succeeded; only the verification read failed. Say so —
-        # a bare "API error (503)" would hide that a suggestion very likely
-        # exists now.
+    except Exception as e:  # noqa: BLE001 — the write succeeded; only the
+        # verification read failed, either as a GdocError from the API
+        # layer or as an untranslated transport error (timeout, reset).
+        # A bare "API error (503)" — or a naked ConnectionError — would
+        # hide that a suggestion very likely exists now.
         raise GdocError(
             "suggestion(s) " + ", ".join(outcome.suggestion_ids)
             + " were reported saved but could not be verified "
-            f"({e}); inspect the document", exit_code=e.exit_code,
+            f"({str(e) or type(e).__name__}); inspect the document",
+            exit_code=getattr(e, "exit_code", 1),
         )
     missing = [
         sid for sid in outcome.suggestion_ids

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1893,6 +1893,15 @@ def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
             "comment or edit access on the document, or the project lacks "
             "Developer Preview access)"
         )
+    if status >= 500:
+        # A 5xx can arrive after Google applied the mutation: like a
+        # transport failure, the outcome is unknown and a blind retry may
+        # create a duplicate suggestion.
+        raise GdocError(
+            f"the suggest write returned a server error ({status}: "
+            f"{e.reason}). The outcome is unknown — the suggestion may or "
+            "may not have been saved. Inspect the document before retrying."
+        )
     _translate_http_error(e, doc_id)
 
 

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1896,6 +1896,26 @@ def _classify_suggest_error(e: HttpError, doc_id: str) -> None:
     _translate_http_error(e, doc_id)
 
 
+def _token_client_id(account: str | None) -> str | None:
+    """The OAuth client_id recorded in the account's token file.
+
+    Developer Preview enrollment belongs to the OAuth client project, so
+    this is the identity that must hold still between the enrollment gate
+    and the write. A routine token refresh rewrites the file but keeps it;
+    only re-authenticating with a different client config changes it.
+    """
+    import json
+
+    from gdoc.util import token_path_for
+
+    try:
+        with token_path_for(account).open() as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    return data.get("client_id") if isinstance(data, dict) else None
+
+
 def check_suggest_preview_access(doc_id: str) -> None:
     """Non-mutating gate: is this OAuth client's project preview-enrolled?
 
@@ -2052,13 +2072,16 @@ def suggest_replacement(
         return SuggestionResult(occurrences=0)
 
     # Prove enrollment with a read before the write (see the gate's doc),
-    # pinning one credential identity across both: `gdoc auth` rewriting
-    # the token file between them could swap the OAuth client project, so
-    # the gate would prove enrollment for one project while the batch goes
-    # through another — which an unenrolled backend may apply as a direct
-    # edit. The key carries the token file's identity; if it is unchanged
-    # once the service is in hand, gate and write share one credential.
-    gate_key = account_cache_key()
+    # pinning one OAuth client identity across both: a re-auth with a
+    # different client config landing between them could otherwise prove
+    # enrollment for one project while the batch goes through another —
+    # which an unenrolled backend may apply as a direct edit. The pin is
+    # the token's client_id, not the file's identity: a routine
+    # access-token refresh (the gate's own get_credentials persists one
+    # when a long-lived process refreshed only in memory) rewrites the
+    # file without changing the client project, and must not abort.
+    account, _stamp = account_cache_key()
+    gate_client = _token_client_id(account)
     check_suggest_preview_access(doc_id)
 
     body = {
@@ -2069,12 +2092,13 @@ def suggest_replacement(
         },
     }
     service = get_docs_service()
-    if account_cache_key() != gate_key:
+    if _token_client_id(account) != gate_client:
         raise GdocError(
             "credentials changed while preparing the suggest write (the "
-            "account's token was rewritten between the enrollment check "
-            "and the write, so they may belong to different OAuth client "
-            "projects). No change was made — rerun the command."
+            "account's OAuth client was replaced between the enrollment "
+            "check and the write, so enrollment was proven for a "
+            "different client project). No change was made — rerun the "
+            "command."
         )
     try:
         result = (

--- a/gdoc/auth.py
+++ b/gdoc/auth.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+from google.auth.exceptions import TransportError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -15,6 +16,7 @@ from gdoc.util import (
     CREDS_PATH,
     TOKEN_PATH,
     AuthError,
+    GdocError,
     get_default_account,
     get_token_path,
     set_default_account,
@@ -57,6 +59,13 @@ def get_credentials(account=_RESOLVE) -> Credentials:
             creds.refresh(Request())
             _save_token(creds, token_path)
             return creds
+        except TransportError as e:
+            # A network failure during refresh is not bad credentials —
+            # "run `gdoc auth`" would be wrong advice for a Wi-Fi blip.
+            raise GdocError(
+                f"network error while refreshing credentials ({e}); "
+                "check the connection and try again"
+            )
         except Exception:
             pass
 

--- a/gdoc/auth.py
+++ b/gdoc/auth.py
@@ -36,7 +36,12 @@ _RESOLVE = object()
 
 
 def get_credentials(account=_RESOLVE) -> Credentials:
-    """Load or refresh credentials. Returns valid Credentials or raises AuthError.
+    """Load or refresh credentials. Returns valid Credentials.
+
+    Raises AuthError when there are no usable credentials (missing token,
+    revoked or invalid grant — re-authenticating is the fix) and GdocError
+    when a network failure prevents the token refresh (retrying is the
+    fix; the stored credentials are fine).
 
     `account` is a *resolved* account name (None = legacy token) — the
     per-account service caches pass their cache key here so the credentials

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1030,11 +1030,8 @@ def _read_file(path: str) -> str:
 class _ReplacementPlan:
     """Front half of a find/replace shared by `edit` and `suggest`."""
 
-    doc_id: str
     quiet: bool
     change_info: object  # ChangeInfo | None
-    old_text: str | None
-    new_text: str
     matches: list
     revision_id: str
     tab_id: str | None
@@ -1112,7 +1109,7 @@ def _resolve_replacement_text(args, cell) -> tuple[str | None, str | None]:
 
 
 def _prepare_text_replacement(
-    args, doc_id: str, old_text: str | None, new_text: str,
+    args, doc_id: str, old_text: str | None,
     *, suggest: bool = False,
 ) -> _ReplacementPlan:
     """Pre-flight, read the document, and locate the ranges to replace.
@@ -1216,8 +1213,7 @@ def _prepare_text_replacement(
             )
 
     return _ReplacementPlan(
-        doc_id=doc_id, quiet=quiet, change_info=change_info,
-        old_text=old_text, new_text=new_text, matches=matches,
+        quiet=quiet, change_info=change_info, matches=matches,
         revision_id=revision_id, tab_id=tab_id, search_body=search_body,
     )
 
@@ -1230,7 +1226,7 @@ def cmd_edit(args) -> int:
     # Resolve text from args or files (fail fast before API calls)
     old_text, new_text = _resolve_replacement_text(args, cell)
 
-    plan = _prepare_text_replacement(args, doc_id, old_text, new_text)
+    plan = _prepare_text_replacement(args, doc_id, old_text)
     matches = plan.matches
 
     # Check if replacement contains tables — not supported with --all
@@ -1301,7 +1297,7 @@ def cmd_suggest(args) -> int:
     check_inline_only_markdown(parse_markdown(new_text))
 
     plan = _prepare_text_replacement(
-        args, doc_id, old_text, new_text, suggest=True,
+        args, doc_id, old_text, suggest=True,
     )
 
     # Never touch an existing review thread by accident: Google may merge a

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3988,9 +3988,9 @@ def build_parser() -> GdocArgumentParser:
                "Developer Preview): the original text stays until a reviewer "
                "accepts it. Replacement text supports inline markdown only "
                "(bold, italic, strikethrough, code, links); headings, lists, "
-               "and tables are rejected. Needs edit access on the doc and an "
-               "OAuth client from a preview-enrolled Cloud project; never "
-               "falls back to a direct edit.",
+               "and tables are rejected. Needs comment or edit access on the "
+               "doc and an OAuth client from a preview-enrolled Cloud "
+               "project; never falls back to a direct edit.",
     )
     suggest_p.add_argument("doc", help="Document ID or URL")
     suggest_p.add_argument(

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1328,9 +1328,18 @@ def cmd_suggest(args) -> int:
         doc_id, plan.matches, new_text, plan.revision_id, tab_id=plan.tab_id,
     )
 
+    # The suggestion is saved and verified at this point. A failure of the
+    # follow-up version lookup must not turn that into an ordinary error
+    # that hides the IDs — report success, then warn that state was not
+    # refreshed.
     from gdoc.api.drive import get_file_version
 
-    command_version = get_file_version(doc_id).get("version")
+    version_error = None
+    command_version = None
+    try:
+        command_version = get_file_version(doc_id).get("version")
+    except GdocError as e:
+        version_error = e
 
     from gdoc.format import format_json, get_output_mode
 
@@ -1352,6 +1361,16 @@ def cmd_suggest(args) -> int:
         label = "occurrence" if result.occurrences == 1 else "occurrences"
         tags = ", ".join(f"#{i}" for i in ids)
         print(f"OK suggested {result.occurrences} {label} ({tags})")
+
+    if version_error is not None:
+        print(
+            "WARN: suggestion saved ("
+            + ", ".join(f"#{i}" for i in ids)
+            + f") but the document version could not be refreshed: "
+            f"{version_error}; awareness state not updated",
+            file=sys.stderr,
+        )
+        return 0
 
     # A suggestion is a partial write like `edit`: record the new version
     # but do not advance the read baseline (update_state_after_command

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+from dataclasses import dataclass
 
 from gdoc import __version__
 from gdoc.revdiff import DEFAULT_CONTEXT, DEFAULT_MIN_COMMON
@@ -1025,18 +1026,26 @@ def _read_file(path: str) -> str:
     return content
 
 
-def cmd_edit(args) -> int:
-    """Handler for `gdoc edit`."""
-    doc_id = _resolve_doc_id(args.doc)
-    quiet = getattr(args, "quiet", False)
-    replace_all = getattr(args, "all", False)
-    case_sensitive = getattr(args, "case_sensitive", False)
-    normalize = getattr(args, "normalize", False)
-    cell = getattr(args, "cell", None)
-    col = getattr(args, "col", None)
-    table_index = getattr(args, "table", None)
+@dataclass
+class _ReplacementPlan:
+    """Front half of a find/replace shared by `edit` and `suggest`."""
 
-    # Resolve text from args or files (fail fast before API calls)
+    doc_id: str
+    quiet: bool
+    change_info: object  # ChangeInfo | None
+    old_text: str | None
+    new_text: str
+    matches: list
+    revision_id: str
+    tab_id: str | None
+    search_body: dict
+
+
+def _resolve_replacement_text(args, cell) -> tuple[str | None, str | None]:
+    """Resolve old/new text from positionals, `-` (stdin), or --old/--new-file.
+
+    Fails fast (exit 3) before any API call when the combination is invalid.
+    """
     old_text = args.old_text
     new_text = args.new_text
     old_file = getattr(args, "old_file", None)
@@ -1099,6 +1108,27 @@ def cmd_edit(args) -> int:
                 "(or use --old-file/--new-file)",
                 exit_code=3,
             )
+    return old_text, new_text
+
+
+def _prepare_text_replacement(
+    args, doc_id: str, old_text: str | None, new_text: str,
+    *, suggest: bool = False,
+) -> _ReplacementPlan:
+    """Pre-flight, read the document, and locate the ranges to replace.
+
+    `edit` reads the default view (legacy `body`, or the named tab).
+    `suggest` always reads every tab with SUGGESTIONS_INLINE — the only
+    view whose indexes match what a suggest-mode batchUpdate addresses —
+    and targets an explicit tab (the first when --tab is absent).
+    """
+    quiet = getattr(args, "quiet", False)
+    replace_all = getattr(args, "all", False)
+    case_sensitive = getattr(args, "case_sensitive", False)
+    normalize = getattr(args, "normalize", False)
+    cell = getattr(args, "cell", None)
+    col = getattr(args, "col", None)
+    table_index = getattr(args, "table", None)
 
     # Pre-flight awareness check
     from gdoc.notify import pre_flight
@@ -1111,12 +1141,40 @@ def cmd_edit(args) -> int:
         print("WARN: doc changed since last read", file=sys.stderr)
 
     # Get document structure + revision ID
-    from gdoc.api.docs import find_text_in_document, get_document, replace_formatted
+    from gdoc.api.docs import find_text_in_document, get_document
 
     tab_name = getattr(args, "tab", None)
     tab_id = None
 
-    if tab_name:
+    if suggest:
+        from gdoc.api.docs import (
+            SUGGESTIONS_INLINE,
+            flatten_tabs,
+            get_document_structure,
+            resolve_tab,
+        )
+        try:
+            doc = get_document_structure(
+                doc_id, suggestions_view_mode=SUGGESTIONS_INLINE,
+            )
+        except GdocError as e:
+            # Live: a reader gets 403 "You do not have permission to access
+            # the document suggestions." on this view; commenters and
+            # editors read it fine.
+            if str(e).startswith("Permission denied"):
+                raise GdocError(
+                    f"{e} (reading suggestions inline needs comment or "
+                    "edit access on the document)", exit_code=e.exit_code,
+                )
+            raise
+        revision_id = doc.get("revisionId", "")
+        tabs = flatten_tabs(doc.get("tabs", []))
+        if not tabs:
+            raise GdocError(f"document has no tabs: {doc_id}")
+        tab_match = resolve_tab(tabs, tab_name) if tab_name else tabs[0]
+        tab_id = tab_match["id"]
+        search_body = tab_match["body"]
+    elif tab_name:
         from gdoc.api.docs import flatten_tabs, get_document_with_tabs, resolve_tab
         doc = get_document_with_tabs(doc_id)
         revision_id = doc.get("revisionId", "")
@@ -1157,6 +1215,24 @@ def cmd_edit(args) -> int:
                 exit_code=3,
             )
 
+    return _ReplacementPlan(
+        doc_id=doc_id, quiet=quiet, change_info=change_info,
+        old_text=old_text, new_text=new_text, matches=matches,
+        revision_id=revision_id, tab_id=tab_id, search_body=search_body,
+    )
+
+
+def cmd_edit(args) -> int:
+    """Handler for `gdoc edit`."""
+    doc_id = _resolve_doc_id(args.doc)
+    cell = getattr(args, "cell", None)
+
+    # Resolve text from args or files (fail fast before API calls)
+    old_text, new_text = _resolve_replacement_text(args, cell)
+
+    plan = _prepare_text_replacement(args, doc_id, old_text, new_text)
+    matches = plan.matches
+
     # Check if replacement contains tables — not supported with --all
     from gdoc.mdparse import parse_markdown as _parse_md
     _parsed = _parse_md(new_text)
@@ -1167,8 +1243,10 @@ def cmd_edit(args) -> int:
         )
 
     # Perform formatted replacement via Docs API batchUpdate
+    from gdoc.api.docs import replace_formatted
+
     occurrences = replace_formatted(
-        doc_id, matches, new_text, revision_id, tab_id=tab_id,
+        doc_id, matches, new_text, plan.revision_id, tab_id=plan.tab_id,
     )
 
     # Get post-edit version for state tracking (Decision #12)
@@ -1178,7 +1256,7 @@ def cmd_edit(args) -> int:
     command_version = version_data.get("version")
 
     # Output
-    from gdoc.format import get_output_mode, format_json
+    from gdoc.format import format_json, get_output_mode
 
     mode = get_output_mode(args)
     label = "occurrence" if occurrences == 1 else "occurrences"
@@ -1186,7 +1264,7 @@ def cmd_edit(args) -> int:
         print(format_json(replaced=occurrences))
     elif mode == "plain":
         print(f"id\t{doc_id}")
-        print(f"status\tupdated")
+        print("status\tupdated")
     else:
         print(f"OK replaced {occurrences} {label}")
 
@@ -1194,10 +1272,96 @@ def cmd_edit(args) -> int:
     from gdoc.state import update_state_after_command
 
     update_state_after_command(
-        doc_id, change_info, command="edit",
-        quiet=quiet, command_version=command_version,
+        doc_id, plan.change_info, command="edit",
+        quiet=plan.quiet, command_version=command_version,
     )
 
+    return 0
+
+
+def cmd_suggest(args) -> int:
+    """Handler for `gdoc suggest`: a find/replace made as a suggested edit.
+
+    Same matching as `edit`, but the batchUpdate runs with
+    writeControl.writeMode=SUGGEST (Docs API Developer Preview) so the
+    change lands as a reviewable suggestion — the original text stays in
+    place until someone accepts it. There is no fallback: if suggest mode
+    is unavailable or unverifiable the command fails and nothing is
+    edited directly.
+    """
+    doc_id = _resolve_doc_id(args.doc)
+
+    old_text, new_text = _resolve_replacement_text(args, None)
+
+    # Structural Markdown needs the multi-batch cleanup/table phases that
+    # suggest mode does not run — reject it before any API call.
+    from gdoc.api.docs import check_inline_only_markdown
+    from gdoc.mdparse import parse_markdown
+
+    check_inline_only_markdown(parse_markdown(new_text))
+
+    plan = _prepare_text_replacement(
+        args, doc_id, old_text, new_text, suggest=True,
+    )
+
+    # Never touch an existing review thread by accident: Google may merge a
+    # change into an overlapping open suggestion, so refuse any match that
+    # intersects one (v1; an explicit opt-in can come later).
+    from gdoc.api.docs import find_suggestions_in_range
+
+    for m in plan.matches:
+        overlapping = find_suggestions_in_range(
+            plan.search_body, m["startIndex"], m["endIndex"],
+        )
+        if overlapping:
+            ids = ", ".join(sorted(overlapping))
+            raise GdocError(
+                f"match at index {m['startIndex']} overlaps existing "
+                f"suggestion(s) {ids}; accept or reject them first, or "
+                "choose an anchor outside the suggested text",
+                exit_code=3,
+            )
+
+    from gdoc.api.docs import suggest_replacement
+
+    result = suggest_replacement(
+        doc_id, plan.matches, new_text, plan.revision_id, tab_id=plan.tab_id,
+    )
+
+    from gdoc.api.drive import get_file_version
+
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+
+    mode = get_output_mode(args)
+    ids = result.suggestion_ids
+    if mode == "json":
+        print(format_json(
+            suggested=result.occurrences,
+            suggestionIds=ids,
+            createdSuggestionIds=result.created_suggestion_ids,
+            updatedSuggestionIds=result.updated_suggestion_ids,
+        ))
+    elif mode == "plain":
+        print(f"id\t{doc_id}")
+        print("status\tsuggested")
+        print(f"suggested\t{result.occurrences}")
+        print("suggestion_ids\t" + ",".join(ids))
+    else:
+        label = "occurrence" if result.occurrences == 1 else "occurrences"
+        tags = ", ".join(f"#{i}" for i in ids)
+        print(f"OK suggested {result.occurrences} {label} ({tags})")
+
+    # A suggestion is a partial write like `edit`: record the new version
+    # but do not advance the read baseline (update_state_after_command
+    # only does that for full-document writes).
+    from gdoc.state import update_state_after_command
+
+    update_state_after_command(
+        doc_id, plan.change_info, command="suggest",
+        quiet=plan.quiet, command_version=command_version,
+    )
     return 0
 
 
@@ -3815,6 +3979,45 @@ def build_parser() -> GdocArgumentParser:
         "--tab", help="Target a specific tab by title or ID"
     )
     edit_p.set_defaults(func=cmd_edit)
+
+    # suggest
+    suggest_p = sub.add_parser(
+        "suggest", parents=[output_parent],
+        help="Find and replace text as a suggested edit (review, not commit)",
+        epilog="Like `edit`, but the change is made in suggest mode (Docs API "
+               "Developer Preview): the original text stays until a reviewer "
+               "accepts it. Replacement text supports inline markdown only "
+               "(bold, italic, strikethrough, code, links); headings, lists, "
+               "and tables are rejected. Needs edit access on the doc and an "
+               "OAuth client from a preview-enrolled Cloud project; never "
+               "falls back to a direct edit.",
+    )
+    suggest_p.add_argument("doc", help="Document ID or URL")
+    suggest_p.add_argument(
+        "old_text", nargs="?", default=None, help="Text to find",
+    )
+    suggest_p.add_argument(
+        "new_text", nargs="?", default=None, help="Replacement text",
+    )
+    suggest_p.add_argument("--old-file", help="Read old text from file")
+    suggest_p.add_argument("--new-file", help="Read new text from file")
+    suggest_p.add_argument(
+        "--all", action="store_true", help="Suggest for all occurrences"
+    )
+    suggest_p.add_argument(
+        "--case-sensitive", action="store_true", help="Case-sensitive matching"
+    )
+    suggest_p.add_argument(
+        "--normalize", action="store_true",
+        help="Match through smart-quote/dash differences (\u2019 matches ')",
+    )
+    suggest_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    suggest_p.add_argument(
+        "--tab", help="Target a specific tab by title or ID"
+    )
+    suggest_p.set_defaults(func=cmd_suggest)
 
     # diff
     diff_p = sub.add_parser(

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1338,7 +1338,9 @@ def cmd_suggest(args) -> int:
     command_version = None
     try:
         command_version = get_file_version(doc_id).get("version")
-    except GdocError as e:
+    except Exception as e:  # noqa: BLE001 — post-mutation; any failure here
+        # (HttpError already translated to GdocError, but also transport
+        # ConnectionError/timeout) must not hide the saved suggestion IDs.
         version_error = e
 
     from gdoc.format import format_json, get_output_mode

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1296,6 +1296,14 @@ def cmd_suggest(args) -> int:
 
     check_inline_only_markdown(parse_markdown(new_text))
 
+    # Capture the token identity before the document read: the write
+    # verifies against this baseline, so the grant that read the ranges is
+    # the grant that authors the suggestion (see suggest_replacement).
+    from gdoc.api import account_cache_key
+    from gdoc.api.docs import _token_identity
+
+    read_identity = _token_identity(account_cache_key()[0])
+
     plan = _prepare_text_replacement(
         args, doc_id, old_text, suggest=True,
     )
@@ -1322,6 +1330,7 @@ def cmd_suggest(args) -> int:
 
     result = suggest_replacement(
         doc_id, plan.matches, new_text, plan.revision_id, tab_id=plan.tab_id,
+        expected_token_identity=read_identity,
     )
 
     # The suggestion is saved and verified at this point. A failure of the

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -1375,10 +1375,21 @@ def cmd_suggest(args) -> int:
     # only does that for full-document writes).
     from gdoc.state import update_state_after_command
 
-    update_state_after_command(
-        doc_id, plan.change_info, command="suggest",
-        quiet=plan.quiet, command_version=command_version,
-    )
+    try:
+        update_state_after_command(
+            doc_id, plan.change_info, command="suggest",
+            quiet=plan.quiet, command_version=command_version,
+        )
+    except Exception as e:  # noqa: BLE001 — post-mutation; the local state
+        # file failing to write (read-only dir, full disk) must not turn
+        # the saved suggestion into a reported failure that an automated
+        # caller would blindly retry.
+        print(
+            "WARN: suggestion saved ("
+            + ", ".join(f"#{i}" for i in ids)
+            + f") but awareness state was not persisted: {e}",
+            file=sys.stderr,
+        )
     return 0
 
 
@@ -4581,7 +4592,17 @@ def run_argv(argv: list[str] | None = None, *, check_updates: bool = True) -> in
             from gdoc.update import check_for_update
             check_for_update()
 
-        return args.func(args)
+        # Pin one account for the whole invocation: unpinned, every service
+        # access re-resolves the configured default, so a `gdoc auth
+        # --set-default` from another process could hand one command's read
+        # and write to different accounts. The MCP server is exempt — it
+        # pins per tool call instead, so a default changed mid-serve is
+        # still picked up on the next call.
+        if args.command == "mcp":
+            return args.func(args)
+        from gdoc.util import account_context, resolve_account
+        with account_context(resolve_account()):
+            return args.func(args)
     except AuthError as e:
         print(f"ERR: {e}", file=sys.stderr)
         return 2

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -116,6 +116,15 @@ _LOCAL_PATH_CHOICES: dict[str, dict[str, frozenset[str]]] = {
     "diff": {"format": frozenset({"html"})},
 }
 
+# Parameters where the CLI treats a literal `-` as "read from stdin".
+# Over MCP stdin is the JSON-RPC stream, shielded to an empty string for
+# the call's duration, so `-` would silently resolve to "" — turning a
+# replacement into a deletion — instead of reading anything.
+_STDIN_SENTINEL_PARAMS: dict[str, frozenset[str]] = {
+    "edit": frozenset({"old_text", "new_text"}),
+    "suggest": frozenset({"old_text", "new_text"}),
+}
+
 # Commands that use diff-style exit codes: 1 means "differences found",
 # not failure. Real errors still print an ERR: line to stderr.
 _DIFF_EXIT_COMMANDS = frozenset({"diff"})
@@ -440,6 +449,7 @@ def call_command(
         raise ValueError(f"unknown command: {command}")
 
     _reject_local_paths(command, arguments)
+    _reject_stdin_sentinels(command, arguments)
 
     # Schema `required` cannot force a boolean to be true, so guard here:
     # with stdin detached, confirm_destructive() can never prompt.
@@ -465,14 +475,16 @@ def call_command(
     ):
         raise ValueError("`text` is required: the markdown content, inline")
 
-    from gdoc.util import account_context
+    from gdoc.util import account_context, resolve_account
 
     # Scope the account like a fresh CLI invocation: an explicit account
-    # pins this call only, and an unpinned call re-resolves the configured
-    # default at call time (service caches key on the resolved account, so
-    # a default changed mid-serve is picked up automatically).
+    # pins this call only, and an unpinned call resolves the configured
+    # default once at call entry (service caches key on the resolved
+    # account, so a default changed mid-serve is picked up on the next
+    # call). Resolving once, not per service access, keeps a single call
+    # from straddling a `gdoc auth --set-default` made while it runs.
     with (
-        account_context(arguments.get("account")),
+        account_context(arguments.get("account") or resolve_account()),
         _materialised_text(command, arguments) as prepared,
     ):
         argv = _argv_for(command, prepared, subparser)
@@ -512,6 +524,16 @@ def _reject_local_paths(command: str, arguments: dict[str, Any]) -> None:
             raise ValueError(
                 f"{dest}={value} writes a local file and is not available "
                 "over MCP"
+            )
+
+
+def _reject_stdin_sentinels(command: str, arguments: dict[str, Any]) -> None:
+    """Refuse the CLI's `-` (stdin) convention, which MCP cannot honour."""
+    for param in _STDIN_SENTINEL_PARAMS.get(command, frozenset()):
+        if arguments.get(param) == "-":
+            raise ValueError(
+                f'`{param}: "-"` (read from stdin) is not available over '
+                "MCP; pass the text itself"
             )
 
 

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -137,6 +137,9 @@ _EXTRA_REQUIRED: dict[str, tuple[str, ...]] = {
     "cells": ("value",),
     # confirm_destructive() cannot prompt over MCP (stdin is detached)
     "delete-comment": ("force",),
+    # --old-file/--new-file are hidden over MCP and suggest has no cell
+    # mode, so the text pair is the only way to supply the replacement
+    "suggest": ("old_text", "new_text"),
 }
 
 # Cross-parameter requirements JSON Schema could only express with a

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -63,6 +63,7 @@ EXPOSED_COMMANDS: dict[str, bool] = {
     "drives": True,
     # writes
     "edit": False,
+    "suggest": False,
     "insert": False,
     "write": False,
     "cells": False,
@@ -100,6 +101,7 @@ _TEXT_DESCRIPTION = "Markdown content, supplied inline."
 # time.
 _LOCAL_PATH_PARAMS: dict[str, frozenset[str]] = {
     "edit": frozenset({"old_file", "new_file"}),
+    "suggest": frozenset({"old_file", "new_file"}),
     "write": frozenset({"file"}),
     "insert": frozenset({"file"}),
     "new": frozenset({"file_path"}),
@@ -138,6 +140,11 @@ _DESCRIPTION_NOTES: dict[str, str] = {
     "edit": (
         "Text replacement needs `old_text` and `new_text`; `cell` mode "
         "addresses a table cell instead."
+    ),
+    "suggest": (
+        "Needs `old_text` and `new_text`. The replacement lands as a "
+        "suggested edit for review, not a direct change; inline markdown "
+        "only."
     ),
 }
 

--- a/gdoc/mdparse.py
+++ b/gdoc/mdparse.py
@@ -565,6 +565,11 @@ def to_docs_requests(
     return requests
 
 
+def utf16_len(text: str) -> int:
+    """Length of *text* in UTF-16 code units (the Docs API index space)."""
+    return sum(2 if ord(ch) > 0xFFFF else 1 for ch in text)
+
+
 def _utf16_prefix(text: str) -> list[int]:
     """offsets[i] = UTF-16 length of text[:i] (len(text) + 1 entries)."""
     offsets = [0]

--- a/gdoc/mdparse.py
+++ b/gdoc/mdparse.py
@@ -479,6 +479,11 @@ def to_docs_requests(
 
     requests: list[dict] = []
 
+    # Style ranges are Python code-point offsets into plain_text; Docs API
+    # indexes are UTF-16 code units, so an emoji (non-BMP) earlier in the
+    # replacement shifts every later range by one extra unit.
+    utf16 = _utf16_prefix(parsed.plain_text)
+
     def _location(index: int) -> dict:
         loc = {"index": index}
         if tab_id:
@@ -507,7 +512,8 @@ def to_docs_requests(
             requests.append({
                 "updateParagraphStyle": {
                     "range": _range(
-                        sr.start + insert_index, sr.end + insert_index,
+                        utf16[sr.start] + insert_index,
+                        utf16[sr.end] + insert_index,
                     ),
                     "paragraphStyle": sr.style,
                     "fields": _paragraph_style_fields(sr.style),
@@ -522,7 +528,8 @@ def to_docs_requests(
             requests.append({
                 "updateTextStyle": {
                     "range": _range(
-                        sr.start + insert_index, sr.end + insert_index,
+                        utf16[sr.start] + insert_index,
+                        utf16[sr.end] + insert_index,
                     ),
                     "textStyle": sr.style,
                     "fields": _text_style_fields(sr.style),
@@ -547,8 +554,8 @@ def to_docs_requests(
         requests.append({
             "createParagraphBullets": {
                 "range": _range(
-                    sr.start + insert_index - removed,
-                    sr.end + insert_index - removed,
+                    utf16[sr.start] + insert_index - removed,
+                    utf16[sr.end] + insert_index - removed,
                 ),
                 "bulletPreset": sr.style["bulletPreset"],
             }
@@ -556,6 +563,16 @@ def to_docs_requests(
         removed += leading
 
     return requests
+
+
+def _utf16_prefix(text: str) -> list[int]:
+    """offsets[i] = UTF-16 length of text[:i] (len(text) + 1 entries)."""
+    offsets = [0]
+    total = 0
+    for ch in text:
+        total += 2 if ord(ch) > 0xFFFF else 1
+        offsets.append(total)
+    return offsets
 
 
 def text_style_fields(style: dict) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.20.1"
+version = "0.21.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_account_context.py
+++ b/tests/test_account_context.py
@@ -158,3 +158,50 @@ def test_token_path_for_resolved_accounts():
         util.token_path_for("work")
         == util.CONFIG_DIR / "accounts" / "work" / "token.json"
     )
+
+
+def test_run_argv_pins_one_account_across_the_command(mocker):
+    """A `gdoc auth --set-default` from another process landing mid-command
+    must not hand the command's later service accesses (the write) a
+    different account than its earlier ones (the read)."""
+    from gdoc import cli
+
+    default = ["acct-a"]
+    mocker.patch(
+        "gdoc.util.get_default_account", side_effect=lambda: default[0],
+    )
+    seen = []
+
+    def fake_cmd(args):
+        seen.append(util.resolve_account())
+        default[0] = "acct-b"  # the flip lands mid-command
+        seen.append(util.resolve_account())
+        return 0
+
+    mocker.patch("gdoc.cli.cmd_tabs", side_effect=fake_cmd)
+    assert cli.run_argv(["tabs", "doc123"], check_updates=False) == 0
+    assert seen == ["acct-a", "acct-a"]
+    assert util.get_active_account() is None  # the pin is scoped, not leaked
+
+
+def test_run_argv_leaves_the_mcp_server_unpinned(mocker):
+    """The MCP server pins per tool call (call_command), so the server
+    process itself must keep floating resolution — a default changed
+    mid-serve is picked up on the next call, not frozen at startup."""
+    from gdoc import cli
+
+    default = ["acct-a"]
+    mocker.patch(
+        "gdoc.util.get_default_account", side_effect=lambda: default[0],
+    )
+    seen = []
+
+    def fake_mcp(args):
+        seen.append(util.resolve_account())
+        default[0] = "acct-b"
+        seen.append(util.resolve_account())
+        return 0
+
+    mocker.patch("gdoc.cli.cmd_mcp", side_effect=fake_mcp)
+    assert cli.run_argv(["mcp"], check_updates=False) == 0
+    assert seen == ["acct-a", "acct-b"]

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -377,6 +377,44 @@ class TestReplaceFormattedCleanupPositions:
 
     @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])
     @patch("gdoc.api.docs.get_docs_service")
+    def test_cleanup_position_counts_emoji_as_two_units(self, mock_svc, mock_cleanup):
+        """Docs indexes are UTF-16: a non-BMP emoji in the replacement
+        grows the document by 2, so the cleanup position must reflect it."""
+        from gdoc.api.docs import replace_formatted
+
+        mock_svc.return_value.documents.return_value \
+            .batchUpdate.return_value.execute.return_value = {}
+        mock_svc.return_value.documents.return_value \
+            .get.return_value.execute.return_value = {"body": {"content": []}}
+
+        matches = [{"startIndex": 10, "endIndex": 13}]
+        replace_formatted("doc1", matches, "\U0001F600ab", "rev1")  # 3 chars, 4 units
+
+        pos = mock_cleanup.call_args[0][1]
+        assert pos == 14
+
+    @patch("gdoc.api.docs._insert_table")
+    @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_table_index_after_emoji_is_utf16(
+        self, mock_svc, _cleanup, mock_table,
+    ):
+        from gdoc.api.docs import replace_formatted
+
+        mock_svc.return_value.documents.return_value \
+            .batchUpdate.return_value.execute.return_value = {}
+        mock_svc.return_value.documents.return_value \
+            .get.return_value.execute.return_value = {"body": {"content": []}}
+
+        md = "\U0001F600 x\n| a | b |\n|---|---|\n| 1 | 2 |"
+        replace_formatted("doc1", [{"startIndex": 5, "endIndex": 6}], md, "rev1")
+
+        # plain text before the table placeholder is "😀 x\n" = 4 code
+        # points but 5 UTF-16 units.
+        assert mock_table.call_args[0][1] == 5 + 5
+
+    @patch("gdoc.api.docs._build_cleanup_requests", return_value=[])
+    @patch("gdoc.api.docs.get_docs_service")
     def test_same_length_replacement_no_drift(self, mock_svc, mock_cleanup):
         """When replacement is same length as original, delta=0."""
         from gdoc.api.docs import replace_formatted

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -161,12 +161,12 @@ class TestReplaceAllText:
             replace_all_text("abc123", "old", "new")
 
 
-@patch("gdoc.api.docs.get_docs_service")
 class TestGetDocsServiceCaches:
-    def test_caches_service(self, mock_get_service):
-        """Verify the @lru_cache is applied (tested indirectly via import)."""
-        from gdoc.api.docs import get_docs_service
-        assert hasattr(get_docs_service, "cache_info")
+    def test_caches_service(self):
+        """The per-account @lru_cache lives on _docs_service; the public
+        get_docs_service is a thin wrapper that resolves the account."""
+        from gdoc.api.docs import _docs_service
+        assert hasattr(_docs_service, "cache_info")
 
 
 class TestGetDocumentWithTabs:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -419,6 +419,32 @@ class TestGetCredentials:
             with pytest.raises(AuthError, match="Not authenticated"):
                 get_credentials()
 
+    def test_network_failure_during_refresh_is_not_an_auth_error(self):
+        """A TransportError from the refresh (Wi-Fi blip, DNS failure) must
+        not become "Not authenticated. Run `gdoc auth`" — the stored
+        credentials are fine and re-authenticating is the wrong advice."""
+        from google.auth.exceptions import TransportError
+
+        from gdoc.util import GdocError
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = "refresh-xxx"
+        mock_creds.refresh.side_effect = TransportError("dns failure")
+
+        with (
+            patch("gdoc.auth._load_token", return_value=mock_creds),
+            patch("gdoc.auth.Request"),
+        ):
+            with pytest.raises(GdocError) as exc:
+                get_credentials()
+
+        assert "network error" in str(exc.value)
+        assert "dns failure" in str(exc.value)
+        assert not isinstance(exc.value, AuthError)
+        assert exc.value.exit_code == 1
+
 
 class TestDefaultAccount:
     def test_configured_default_resolves_to_named_token(self, tmp_path):

--- a/tests/test_docs_batch.py
+++ b/tests/test_docs_batch.py
@@ -177,6 +177,20 @@ class TestReplaceFormatted:
         assert first_del["deleteContentRange"]["range"]["startIndex"] == 20
 
     @patch("gdoc.api.docs.get_docs_service")
+    def test_overlapping_matches_are_rejected(self, mock_svc):
+        """`aa` in `aaa` matches [1,3) and [2,4): the last-to-first plan
+        would land on shifted text, so refuse — same guard as suggest."""
+        chain = _docs_chain(mock_svc)
+        matches = [
+            {"startIndex": 1, "endIndex": 3},
+            {"startIndex": 2, "endIndex": 4},
+        ]
+        with pytest.raises(GdocError, match="overlap each other") as exc:
+            replace_formatted("d1", matches, "b", "r1")
+        assert exc.value.exit_code == 3
+        chain.batchUpdate.assert_not_called()
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_formatted_replacement(self, mock_svc):
         """Markdown generates style requests."""
         chain = _docs_chain(mock_svc)

--- a/tests/test_edit_cell.py
+++ b/tests/test_edit_cell.py
@@ -65,6 +65,13 @@ class TestCellTextRange:
         ]}
         assert _cell_text_range(cell) == {"startIndex": 5, "endIndex": 8}
 
+    def test_cell_ending_with_emoji_counts_utf16_units(self):
+        """Doc indexes are UTF-16: 'hi😀\\n' spans 5 units, so the editable
+        end (excluding the final paragraph mark) is start+4 — a code-point
+        count would split the emoji's surrogate pair on delete."""
+        r = _cell_text_range(_cell("hi\U0001F600\n", 5))
+        assert r == {"startIndex": 5, "endIndex": 9}
+
 
 class TestResolveCellRange:
     def test_label_targets_cell_to_the_right(self):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -130,6 +130,14 @@ def test_cells_requires_a_value():
     assert schema["properties"]["value"]["minItems"] == 1
 
 
+def test_suggest_requires_the_text_pair():
+    schema = mcp.build_tools(allow={"suggest"})["gdoc_suggest"]["inputSchema"]
+    # With --old-file/--new-file hidden and no cell mode, the text pair is
+    # the only data source; a call without it would always fail at runtime.
+    assert "old_text" in schema["required"]
+    assert "new_text" in schema["required"]
+
+
 def test_delete_comment_requires_force():
     schema = mcp.build_tools(allow={"delete-comment"})[
         "gdoc_delete_comment"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -406,6 +406,19 @@ def test_default_account_change_reaches_next_unpinned_call(mocker, _service_prob
     assert built[services[2]] == "creds:b"
 
 
+@pytest.mark.parametrize("command", ["edit", "suggest"])
+@pytest.mark.parametrize("param", ["old_text", "new_text"])
+def test_stdin_sentinel_dash_is_rejected(mocker, command, param):
+    """The CLI's `-` (stdin) convention cannot work over MCP: stdin is
+    shielded to an empty string, so `-` would silently resolve to "" and
+    turn a replacement into a deletion of the anchor."""
+    run = mocker.patch("gdoc.cli.run_argv", return_value=0)
+    arguments = {"doc": "D", "old_text": "x", "new_text": "y", param: "-"}
+    with pytest.raises(ValueError, match="stdin.*not available over MCP"):
+        mcp.call_command(command, arguments)
+    run.assert_not_called()
+
+
 def test_stdin_is_shielded_from_tool_calls(mocker):
     """A command that reads stdin must not consume the protocol stream."""
     import sys

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -342,6 +342,20 @@ class TestSuggestRequestShape:
         service.documents.return_value.batchUpdate.assert_not_called()
 
     @patch("gdoc.api.docs.get_docs_service")
+    def test_credential_change_between_gate_and_write_aborts(self, mock_svc):
+        """A token rewrite between the enrollment gate and the write could
+        swap the OAuth client project — proving enrollment for one project
+        and writing through another. The write must abort pre-send."""
+        mock_svc.return_value = _service(_ok_response())
+        with patch(
+            "gdoc.api.docs.account_cache_key",
+            side_effect=[("acct", (1, 1, 1)), ("acct", (2, 2, 2))],
+        ):
+            with pytest.raises(GdocError, match="No change was made"):
+                suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        mock_svc.return_value.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_no_requests_returns_zero_without_calling_api(self, mock_svc):
         service = _service(_ok_response())
         mock_svc.return_value = service

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -762,6 +762,47 @@ class TestPreviewGate:
         with pytest.raises(GdocError, match=r"API error \(503\)"):
             self._run(_gate_response(503, text="backend", reason="Service Unavailable"))
 
+    def test_refresh_failure_is_auth_error(self):
+        from google.auth.exceptions import RefreshError
+
+        with patch("gdoc.api.docs.account_cache_key", return_value=("acct", None)), \
+             patch("gdoc.auth.get_credentials", return_value="creds"), \
+             patch(
+                 "google.auth.transport.requests.AuthorizedSession",
+                 side_effect=RefreshError("invalid_grant: Token has been revoked"),
+             ):
+            with pytest.raises(AuthError, match="Run `gdoc auth`"):
+                check_suggest_preview_access("doc1")
+
+    def test_network_failure_fails_closed_as_gdoc_error(self):
+        from requests.exceptions import ConnectionError as ReqConnectionError
+
+        session = MagicMock()
+        session.get.side_effect = ReqConnectionError("dns failure")
+        with patch("gdoc.api.docs.account_cache_key", return_value=("acct", None)), \
+             patch("gdoc.auth.get_credentials", return_value="creds"), \
+             patch(
+                 "google.auth.transport.requests.AuthorizedSession",
+                 return_value=session,
+             ):
+            with pytest.raises(GdocError, match="network error") as exc:
+                check_suggest_preview_access("doc1")
+        assert "No change was made" in str(exc.value)
+        assert not isinstance(exc.value, AuthError)
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_gate_network_failure_blocks_the_write(
+        self, mock_svc, _preview_gate_passes,
+    ):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        _preview_gate_passes.side_effect = GdocError(
+            "suggest mode check failed before any write (network error: x)",
+        )
+        with pytest.raises(GdocError, match="network error"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        service.documents.return_value.batchUpdate.assert_not_called()
+
     def test_other_400_is_api_error_not_enrollment(self):
         with pytest.raises(GdocError, match=r"API error \(400\)"):
             self._run(_gate_response(400, text="something else", reason="Bad Request"))
@@ -1080,6 +1121,24 @@ class TestCmdSuggest:
         assert "WARN: suggestion saved (#suggest.abc)" in err
         assert "API error (503)" in err
         assert "state not updated" in err
+        mock_state.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version")
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_version_lookup_transport_error_after_write_still_reports_ids(
+        self, _pf, _doc, _sug, mock_ver, mock_state, capsys,
+    ):
+        """drive.get_file_version only translates HttpError; a raw
+        ConnectionError must not escape and hide the saved IDs either."""
+        mock_ver.side_effect = ConnectionError("connection reset")
+        assert cmd_suggest(_args()) == 0
+        out, err = capsys.readouterr()
+        assert out == "OK suggested 1 occurrence (#suggest.abc)\n"
+        assert "WARN: suggestion saved (#suggest.abc)" in err
+        assert "connection reset" in err
         mock_state.assert_not_called()
 
     @patch("gdoc.api.docs.suggest_replacement")

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -532,6 +532,36 @@ class TestSuggestErrors:
             suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
 
     @patch("gdoc.api.docs.get_docs_service")
+    def test_batch_refresh_network_failure_is_pre_send(self, mock_svc):
+        """TransportError is raised while refreshing the token, before the
+        request is sent — the error must say nothing was written, not that
+        the outcome is unknown."""
+        from google.auth.exceptions import TransportError
+
+        mock_svc.return_value = _service(
+            batch_error=TransportError("connection refused"),
+        )
+        with pytest.raises(GdocError) as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        msg = str(exc.value)
+        assert "No change was made" in msg
+        assert "outcome is unknown" not in msg
+        assert not isinstance(exc.value, AuthError)
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_batch_refresh_credential_failure_is_auth_error(self, mock_svc):
+        """A revoked/expired-beyond-refresh credential fails before the
+        request is sent and must keep its AuthError classification
+        (exit 2), not be reported as an indeterminate write."""
+        from google.auth.exceptions import RefreshError
+
+        mock_svc.return_value = _service(
+            batch_error=RefreshError("invalid_grant: Token has been revoked"),
+        )
+        with pytest.raises(AuthError, match="Run `gdoc auth`"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_400_unknown_name_means_no_preview(self, mock_svc):
         mock_svc.return_value = _service(batch_error=_http_error(
             400, b'{"error": {"message": "Invalid JSON payload received. '
@@ -744,6 +774,42 @@ class TestFindSuggestionsInRange:
     def test_zero_width_insert_inside_suggested_run(self):
         assert find_suggestions_in_range(self._body_with_insertion(), 9, 9) == {"s.ins"}
 
+    def test_suggested_section_break_inside_match_blocks(self):
+        """A match can span a section break (segments concatenate across
+        it); a suggested break inside the range is a review thread too."""
+        body = _body(
+            _para(_run("Hello wor", 1, 10)),
+            {
+                "startIndex": 10, "endIndex": 11,
+                "sectionBreak": {"suggestedInsertionIds": ["s.sec"]},
+            },
+            _para(_run("ld!\n", 11, 15)),
+        )
+        assert find_suggestions_in_range(body, 7, 13) == {"s.sec"}
+
+    def test_plain_section_break_does_not_block(self):
+        body = _body(
+            _para(_run("Hello wor", 1, 10)),
+            {"startIndex": 10, "endIndex": 11, "sectionBreak": {}},
+            _para(_run("ld!\n", 11, 15)),
+        )
+        assert find_suggestions_in_range(body, 7, 13) == set()
+
+    def test_suggestion_inside_overlapping_toc_blocks(self):
+        body = _body({
+            "startIndex": 8, "endIndex": 20,
+            "tableOfContents": {"content": [_para({
+                "startIndex": 9, "endIndex": 19,
+                "textRun": {
+                    "content": "toc entry\n",
+                    "suggestedInsertionIds": ["s.toc"],
+                },
+            })]},
+        })
+        assert find_suggestions_in_range(body, 5, 12) == {"s.toc"}
+        # A range that never reaches the TOC stays clear.
+        assert find_suggestions_in_range(body, 1, 5) == set()
+
 
 class TestPreviewGate:
     """check_suggest_preview_access: the raw preview-only read."""
@@ -821,6 +887,26 @@ class TestPreviewGate:
 
         session = MagicMock()
         session.get.side_effect = ReqConnectionError("dns failure")
+        with patch("gdoc.api.docs.account_cache_key", return_value=("acct", None)), \
+             patch("gdoc.auth.get_credentials", return_value="creds"), \
+             patch(
+                 "google.auth.transport.requests.AuthorizedSession",
+                 return_value=session,
+             ):
+            with pytest.raises(GdocError, match="network error") as exc:
+                check_suggest_preview_access("doc1")
+        assert "No change was made" in str(exc.value)
+        assert not isinstance(exc.value, AuthError)
+
+    def test_refresh_network_failure_is_not_an_auth_error(self):
+        """google-auth wraps a network failure during token refresh in
+        TransportError, a GoogleAuthError subclass — it must take the
+        fail-closed network branch, not become "run `gdoc auth`" (exit 2)
+        over a Wi-Fi blip."""
+        from google.auth.exceptions import TransportError
+
+        session = MagicMock()
+        session.get.side_effect = TransportError("connection refused")
         with patch("gdoc.api.docs.account_cache_key", return_value=("acct", None)), \
              patch("gdoc.auth.get_credentials", return_value="creds"), \
              patch(

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -553,6 +553,22 @@ class TestSuggestResponseIds:
 
     @patch("gdoc.api.docs.get_document_structure")
     @patch("gdoc.api.docs.get_docs_service")
+    def test_partial_save_failure_names_the_reported_ids(
+        self, mock_svc, mock_rb,
+    ):
+        """A non-ALL_SAVED response that still carries suggestion IDs must
+        name them, not just count them: some review objects may exist, and
+        a caller deciding whether to retry has to be able to find them."""
+        resp = _ok_response(created=("s.maybe1", "s.maybe2"))
+        resp["commentUpdateState"] = "ALL_FAILED_UNKNOWN_REASON"
+        mock_svc.return_value = _service(resp)
+        with pytest.raises(GdocError) as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert "s.maybe1, s.maybe2" in str(exc.value)
+        mock_rb.assert_not_called()
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
     def test_readback_uses_suggestions_inline(self, mock_svc, mock_rb):
         mock_svc.return_value = _service(_ok_response())
         mock_rb.return_value = _readback("suggest.abc")

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1128,6 +1128,26 @@ class TestCmdSuggest:
         out = capsys.readouterr().out
         assert out == "OK suggested 1 occurrence (#suggest.abc)\n"
 
+    @patch(
+        "gdoc.state.update_state_after_command",
+        side_effect=OSError("disk full"),
+    )
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_state_persistence_failure_after_write_still_succeeds(
+        self, _pf, _doc, _sug, _ver, _state, capsys,
+    ):
+        """The local state file failing to write after the verified
+        suggestion must warn and exit 0 — reporting failure would invite an
+        automated caller to retry a mutation that already succeeded."""
+        assert cmd_suggest(_args()) == 0
+        captured = capsys.readouterr()
+        assert "OK suggested 1 occurrence (#suggest.abc)" in captured.out
+        assert "WARN: suggestion saved" in captured.err
+        assert "disk full" in captured.err
+
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
     @patch(

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -392,6 +392,42 @@ class TestSuggestRequestShape:
         assert result.suggestion_ids == ["suggest.abc"]
 
     @patch("gdoc.api.docs.get_docs_service")
+    def test_expected_identity_from_before_the_read_is_the_baseline(
+        self, mock_svc,
+    ):
+        """The CLI captures the token identity before the document read and
+        passes it in; a re-auth landing anywhere between that read and the
+        write must abort pre-send, not just one between gate and write."""
+        mock_svc.return_value = _service(_ok_response())
+        with patch(
+            "gdoc.api.docs._token_identity",
+            return_value=("client-a.apps", "rt2"),  # current, post-re-auth
+        ):
+            with pytest.raises(GdocError, match="No change was made"):
+                suggest_replacement(
+                    "doc1", MATCH, "x", "rev", tab_id="t.0",
+                    expected_token_identity=("client-a.apps", "rt1"),
+                )
+        mock_svc.return_value.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_matching_expected_identity_writes(self, mock_svc, _rb):
+        mock_svc.return_value = _service(_ok_response())
+        with patch(
+            "gdoc.api.docs._token_identity",
+            return_value=("client-a.apps", "rt1"),
+        ):
+            result = suggest_replacement(
+                "doc1", MATCH, "x", "rev", tab_id="t.0",
+                expected_token_identity=("client-a.apps", "rt1"),
+            )
+        assert result.suggestion_ids == ["suggest.abc"]
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_no_requests_returns_zero_without_calling_api(self, mock_svc):
         service = _service(_ok_response())
         mock_svc.return_value = service
@@ -1248,21 +1284,25 @@ class TestCmdSuggest:
             "suggestion_ids\ts.1,s.2",
         ]
 
+    @patch("gdoc.api.docs._token_identity", return_value=("cid.apps", "rt1"))
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
     @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
     @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
     @patch("gdoc.notify.pre_flight", return_value=None)
     def test_reads_inline_view_and_targets_first_tab(
-        self, _pf, mock_doc, mock_sug, _ver, _state,
+        self, _pf, mock_doc, mock_sug, _ver, _state, _tid,
     ):
         cmd_suggest(_args(doc="https://docs.google.com/document/d/abc123/edit"))
         mock_doc.assert_called_once_with(
             "abc123", suggestions_view_mode="SUGGESTIONS_INLINE",
         )
+        # The token identity captured before the read travels to the write,
+        # so a re-auth anywhere between them aborts pre-send.
         mock_sug.assert_called_once_with(
             "abc123", [{"startIndex": 1, "endIndex": 6}], "world", "rev123",
             tab_id="t.first",
+            expected_token_identity=("cid.apps", "rt1"),
         )
 
     @patch("gdoc.state.update_state_after_command")

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -348,8 +348,23 @@ class TestSuggestRequestShape:
         project and write through another. The write must abort pre-send."""
         mock_svc.return_value = _service(_ok_response())
         with patch(
-            "gdoc.api.docs._token_client_id",
-            side_effect=["client-a.apps", "client-b.apps"],
+            "gdoc.api.docs._token_identity",
+            side_effect=[("client-a.apps", "rt1"), ("client-b.apps", "rt1")],
+        ):
+            with pytest.raises(GdocError, match="No change was made"):
+                suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        mock_svc.return_value.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_user_swap_between_gate_and_write_aborts(self, mock_svc):
+        """Re-authenticating the same account name to a different Google
+        user through the same client keeps client_id equal but mints a new
+        refresh_token; the suggestion must not be authored by the
+        replacement user."""
+        mock_svc.return_value = _service(_ok_response())
+        with patch(
+            "gdoc.api.docs._token_identity",
+            side_effect=[("client-a.apps", "rt1"), ("client-a.apps", "rt2")],
         ):
             with pytest.raises(GdocError, match="No change was made"):
                 suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
@@ -365,13 +380,13 @@ class TestSuggestRequestShape:
     ):
         """The gate's own get_credentials persists a refreshed access token
         (a long-lived process may have refreshed only in memory), rewriting
-        the token file with the same client_id. That must not read as a
-        credential swap — a file-identity comparison aborted the first
-        suggest after token expiry."""
+        the token file with the same client_id and refresh_token. That must
+        not read as a credential swap — a file-identity comparison aborted
+        the first suggest after token expiry."""
         mock_svc.return_value = _service(_ok_response())
         with patch(
-            "gdoc.api.docs._token_client_id",
-            side_effect=["client-a.apps", "client-a.apps"],
+            "gdoc.api.docs._token_identity",
+            side_effect=[("client-a.apps", "rt1"), ("client-a.apps", "rt1")],
         ):
             result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
         assert result.suggestion_ids == ["suggest.abc"]
@@ -971,19 +986,23 @@ class TestPreviewGate:
             self._run(_gate_response(400, text="something else", reason="Bad Request"))
 
 
-class TestTokenClientId:
+class TestTokenIdentity:
     def test_reads_parses_and_fails_soft(self, tmp_path):
-        from gdoc.api.docs import _token_client_id
+        from gdoc.api.docs import _token_identity
 
         token = tmp_path / "token.json"
         with patch("gdoc.util.token_path_for", return_value=token):
-            assert _token_client_id("acct") is None  # missing file
+            assert _token_identity("acct") == (None, None)  # missing file
+            token.write_text(
+                '{"client_id": "abc.apps", "refresh_token": "rt1"}'
+            )
+            assert _token_identity("acct") == ("abc.apps", "rt1")
             token.write_text('{"client_id": "abc.apps"}')
-            assert _token_client_id("acct") == "abc.apps"
+            assert _token_identity("acct") == ("abc.apps", None)
             token.write_text("not json")
-            assert _token_client_id("acct") is None
+            assert _token_identity("acct") == (None, None)
             token.write_text('["a", "list"]')
-            assert _token_client_id("acct") is None
+            assert _token_identity("acct") == (None, None)
 
 
 class TestTableContainerSuggestions:

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -18,6 +18,7 @@ from gdoc.api.docs import (
     SUGGESTIONS_INLINE,
     SuggestionResult,
     check_inline_only_markdown,
+    check_suggest_preview_access,
     collect_suggestion_ids,
     find_suggestions_in_range,
     find_text_in_document,
@@ -107,6 +108,27 @@ def _body(*structural):
 
 
 MATCH = [{"startIndex": 1, "endIndex": 6}]
+
+
+@pytest.fixture(autouse=True)
+def _preview_gate_passes():
+    """The non-mutating enrollment gate is exercised by TestPreviewGate;
+    everywhere else it is assumed to pass so the write path is what's
+    under test."""
+    with patch("gdoc.api.docs.check_suggest_preview_access") as gate:
+        yield gate
+
+
+def _gate_response(status, body=None, text="", reason="Error"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.reason = reason
+    resp.text = text if text else json.dumps(body or {})
+    if body is not None:
+        resp.json.return_value = body
+    else:
+        resp.json.side_effect = ValueError("no json")
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +276,61 @@ class TestSuggestRequestShape:
         assert result.created_suggestion_ids == ["suggest.abc"]
         assert result.updated_suggestion_ids == []
         assert result.suggestion_ids == ["suggest.abc"]
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_style_ranges_in_replacement_are_utf16(self, mock_svc, _rb):
+        """An emoji inside the replacement shifts later style ranges by 2."""
+        mock_svc.return_value = _service(_ok_response())
+        suggest_replacement(
+            "doc1", [{"startIndex": 10, "endIndex": 15}], "\U0001F600 **bold**",
+            "rev", tab_id="t.0",
+        )
+        reqs = _batch_call(mock_svc.return_value).kwargs["body"]["requests"]
+        style = next(r["updateTextStyle"] for r in reqs if "updateTextStyle" in r)
+        # plain text is "😀 bold": emoji = 2 units, space = 1 → bold at +3..+7
+        assert style["range"] == {"startIndex": 13, "endIndex": 17, "tabId": "t.0"}
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_overlapping_matches_are_rejected(self, mock_svc):
+        """`aa` in `aaa` matches [1,3) and [2,4); replacing both is undefined."""
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        body = _body(_para(_run("aaa\n", 1, 5)))
+        matches = find_text_in_document(None, "aa", body=body)
+        assert matches == [
+            {"startIndex": 1, "endIndex": 3}, {"startIndex": 2, "endIndex": 4},
+        ]
+        with pytest.raises(GdocError, match="overlap each other") as exc:
+            suggest_replacement("doc1", matches, "b", "rev", tab_id="t.0")
+        assert exc.value.exit_code == 3
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_preview_gate_runs_before_the_write(self, mock_svc, _preview_gate_passes):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        _preview_gate_passes.side_effect = GdocError(
+            "suggest mode not available: not enrolled",
+        )
+        with pytest.raises(GdocError, match="not enrolled"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        _preview_gate_passes.assert_called_once_with("doc1")
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_preview_gate_not_needed_when_nothing_to_send(
+        self, mock_svc, _rb, _preview_gate_passes,
+    ):
+        suggest_replacement("doc1", [{"startIndex": 3, "endIndex": 3}], "", "rev")
+        _preview_gate_passes.assert_not_called()
 
     @patch("gdoc.api.docs.get_docs_service")
     def test_empty_revision_never_sent(self, mock_svc):
@@ -626,6 +703,108 @@ class TestFindSuggestionsInRange:
         assert find_suggestions_in_range(self._body_with_insertion(), 9, 9) == {"s.ins"}
 
 
+class TestPreviewGate:
+    """check_suggest_preview_access: the raw preview-only read."""
+
+    def _run(self, resp):
+        session = MagicMock()
+        session.get.return_value = resp
+        with patch("gdoc.api.docs.account_cache_key", return_value=("acct", None)), \
+             patch("gdoc.auth.get_credentials", return_value="creds"), \
+             patch(
+                 "google.auth.transport.requests.AuthorizedSession",
+                 return_value=session,
+             ):
+            check_suggest_preview_access("doc1")
+        return session
+
+    def test_registered_project_echoes_the_field(self):
+        session = self._run(_gate_response(200, {
+            "documentId": "doc1", "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+        }))
+        call = session.get.call_args
+        assert call.args[0] == "https://docs.googleapis.com/v1/documents/doc1"
+        assert call.kwargs["params"] == {
+            "includeTabsContent": "true",
+            "suggestionsViewMode": "SUGGESTIONS_INLINE",
+            "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+            "fields": "documentId,commentsViewMode",
+        }
+
+    def test_unregistered_project_400_unknown_name(self):
+        with pytest.raises(GdocError, match="not enrolled") as exc:
+            self._run(_gate_response(
+                400,
+                text='{"error": {"message": "Invalid JSON payload received. '
+                     'Unknown name \\"comments_view_mode\\": Cannot find field."}}',
+            ))
+        assert "No change was made" in str(exc.value)
+
+    def test_200_without_echo_is_refused(self):
+        """A backend that silently drops the preview field can't be trusted
+        to honour writeMode either."""
+        with pytest.raises(GdocError, match="did not apply"):
+            self._run(_gate_response(200, {"documentId": "doc1"}))
+
+    def test_403_is_permission(self):
+        with pytest.raises(GdocError, match="Permission denied: doc1"):
+            self._run(_gate_response(403, text="forbidden"))
+
+    def test_401_is_auth_error(self):
+        with pytest.raises(AuthError):
+            self._run(_gate_response(401, text="unauthorized"))
+
+    def test_404_is_not_found(self):
+        with pytest.raises(GdocError, match="Document not found: doc1"):
+            self._run(_gate_response(404, text="nope"))
+
+    def test_other_status_is_api_error(self):
+        with pytest.raises(GdocError, match=r"API error \(503\)"):
+            self._run(_gate_response(503, text="backend", reason="Service Unavailable"))
+
+    def test_other_400_is_api_error_not_enrollment(self):
+        with pytest.raises(GdocError, match=r"API error \(400\)"):
+            self._run(_gate_response(400, text="something else", reason="Bad Request"))
+
+
+class TestTableContainerSuggestions:
+    def _table(self, table_extra=None, row_extra=None, cell_extra=None):
+        para = _para(_run("cell\n", 10, 15))
+        cell = {"startIndex": 9, "endIndex": 15, "content": [para]}
+        cell.update(cell_extra or {})
+        row = {"startIndex": 8, "endIndex": 15, "tableCells": [cell]}
+        row.update(row_extra or {})
+        table = {"tableRows": [row]}
+        table.update(table_extra or {})
+        return _body({"startIndex": 7, "endIndex": 17, "table": table})
+
+    def test_suggested_table_insertion_blocks_cell_edit(self):
+        body = self._table(table_extra={"suggestedInsertionIds": ["s.table"]})
+        assert find_suggestions_in_range(body, 11, 13) == {"s.table"}
+
+    def test_suggested_row_deletion_blocks_cell_edit(self):
+        body = self._table(row_extra={"suggestedDeletionIds": ["s.row"]})
+        assert find_suggestions_in_range(body, 11, 13) == {"s.row"}
+
+    def test_suggested_cell_style_blocks_cell_edit(self):
+        body = self._table(cell_extra={
+            "suggestedTableCellStyleChanges": {"s.cell": {}},
+        })
+        assert find_suggestions_in_range(body, 11, 13) == {"s.cell"}
+
+    def test_row_outside_range_is_ignored(self):
+        body = self._table(row_extra={"suggestedDeletionIds": ["s.row"]})
+        # Second, clean row at a later index holds the match.
+        body["content"][0]["table"]["tableRows"].append({
+            "startIndex": 15, "endIndex": 22,
+            "tableCells": [{"startIndex": 16, "endIndex": 22, "content": [
+                _para(_run("other\n", 17, 22)),
+            ]}],
+        })
+        body["content"][0]["endIndex"] = 23
+        assert find_suggestions_in_range(body, 18, 20) == set()
+
+
 class TestCollectSuggestionIds:
     def test_walks_ids_lists_and_changes_maps(self):
         doc = {"tabs": [{"documentTab": {"body": {"content": [
@@ -865,6 +1044,43 @@ class TestCmdSuggest:
             cmd_suggest(_args())
         assert exc.value.exit_code == 3
         mock_sug.assert_not_called()
+
+    @patch("gdoc.api.drive.get_file_version")
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_self_overlapping_all_matches_exit_3(
+        self, _pf, mock_doc, mock_svc, mock_ver,
+    ):
+        mock_doc.return_value = _structure(tabs=[
+            ("t.0", "Tab 1", _body(_para(_run("aaa\n", 1, 5)))),
+        ])
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        with pytest.raises(GdocError, match="overlap each other") as exc:
+            cmd_suggest(_args(old_text="aa", new_text="b", all=True))
+        assert exc.value.exit_code == 3
+        service.documents.return_value.batchUpdate.assert_not_called()
+        mock_ver.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version")
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_version_lookup_failure_after_write_still_reports_ids(
+        self, _pf, _doc, _sug, mock_ver, mock_state, capsys,
+    ):
+        """The suggestion is saved and verified; a Drive hiccup afterwards
+        must not hide its ID behind an ordinary error."""
+        mock_ver.side_effect = GdocError("API error (503): Backend Error")
+        assert cmd_suggest(_args(json=True)) == 0
+        out, err = capsys.readouterr()
+        assert json.loads(out)["suggestionIds"] == ["suggest.abc"]
+        assert "WARN: suggestion saved (#suggest.abc)" in err
+        assert "API error (503)" in err
+        assert "state not updated" in err
+        mock_state.assert_not_called()
 
     @patch("gdoc.api.docs.suggest_replacement")
     @patch("gdoc.api.docs.get_document_structure")

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -342,18 +342,39 @@ class TestSuggestRequestShape:
         service.documents.return_value.batchUpdate.assert_not_called()
 
     @patch("gdoc.api.docs.get_docs_service")
-    def test_credential_change_between_gate_and_write_aborts(self, mock_svc):
-        """A token rewrite between the enrollment gate and the write could
-        swap the OAuth client project — proving enrollment for one project
-        and writing through another. The write must abort pre-send."""
+    def test_client_swap_between_gate_and_write_aborts(self, mock_svc):
+        """A re-auth with a different OAuth client landing between the
+        enrollment gate and the write would prove enrollment for one
+        project and write through another. The write must abort pre-send."""
         mock_svc.return_value = _service(_ok_response())
         with patch(
-            "gdoc.api.docs.account_cache_key",
-            side_effect=[("acct", (1, 1, 1)), ("acct", (2, 2, 2))],
+            "gdoc.api.docs._token_client_id",
+            side_effect=["client-a.apps", "client-b.apps"],
         ):
             with pytest.raises(GdocError, match="No change was made"):
                 suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
         mock_svc.return_value.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_routine_token_refresh_between_gate_and_write_is_allowed(
+        self, mock_svc, _rb,
+    ):
+        """The gate's own get_credentials persists a refreshed access token
+        (a long-lived process may have refreshed only in memory), rewriting
+        the token file with the same client_id. That must not read as a
+        credential swap — a file-identity comparison aborted the first
+        suggest after token expiry."""
+        mock_svc.return_value = _service(_ok_response())
+        with patch(
+            "gdoc.api.docs._token_client_id",
+            side_effect=["client-a.apps", "client-a.apps"],
+        ):
+            result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert result.suggestion_ids == ["suggest.abc"]
 
     @patch("gdoc.api.docs.get_docs_service")
     def test_no_requests_returns_zero_without_calling_api(self, mock_svc):
@@ -948,6 +969,21 @@ class TestPreviewGate:
     def test_other_400_is_api_error_not_enrollment(self):
         with pytest.raises(GdocError, match=r"API error \(400\)"):
             self._run(_gate_response(400, text="something else", reason="Bad Request"))
+
+
+class TestTokenClientId:
+    def test_reads_parses_and_fails_soft(self, tmp_path):
+        from gdoc.api.docs import _token_client_id
+
+        token = tmp_path / "token.json"
+        with patch("gdoc.util.token_path_for", return_value=token):
+            assert _token_client_id("acct") is None  # missing file
+            token.write_text('{"client_id": "abc.apps"}')
+            assert _token_client_id("acct") == "abc.apps"
+            token.write_text("not json")
+            assert _token_client_id("acct") is None
+            token.write_text('["a", "list"]')
+            assert _token_client_id("acct") is None
 
 
 class TestTableContainerSuggestions:

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -364,6 +364,20 @@ class TestSuggestResponseIds:
 
     @patch("gdoc.api.docs.get_document_structure")
     @patch("gdoc.api.docs.get_docs_service")
+    def test_readback_api_failure_names_the_saved_ids(self, mock_svc, mock_rb):
+        """A 5xx on the verification read must not hide that the write
+        already succeeded."""
+        service = _service(_ok_response(created=("s.saved",)))
+        mock_svc.return_value = service
+        mock_rb.side_effect = GdocError("API error (503): Backend Error")
+        with pytest.raises(GdocError, match="s.saved") as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert "could not be verified" in str(exc.value)
+        assert "API error (503)" in str(exc.value)
+        assert service.documents.return_value.batchUpdate.call_count == 1
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
     def test_readback_missing_id_is_an_error(self, mock_svc, mock_rb):
         mock_svc.return_value = _service(_ok_response(created=("s.1", "s.2")))
         mock_rb.return_value = _readback("s.1")
@@ -435,6 +449,17 @@ class TestSuggestErrors:
             suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
 
     @patch("gdoc.api.docs.get_docs_service")
+    def test_400_malformed_revision_is_not_reported_as_a_race(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(
+            400, b'{"error": {"message": "Invalid value at '
+                 b'\'write_control.required_revision_id\'"}}',
+            reason="Bad Request",
+        ))
+        with pytest.raises(GdocError) as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert "re-run it" not in str(exc.value)
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_403_reports_both_possibilities(self, mock_svc):
         mock_svc.return_value = _service(batch_error=_http_error(403))
         with pytest.raises(GdocError, match="Permission denied: doc1") as exc:
@@ -492,12 +517,30 @@ class TestCheckInlineOnly:
     @pytest.mark.parametrize("markdown", [
         "plain",
         "two\nparagraphs",
+        "a\n\nb",
+        "```\ncode\n```",
         "**bold** and *italic* and ~~strike~~",
         "`code` and [a link](https://example.com)",
         "",
     ])
     def test_inline_markdown_accepted(self, markdown):
         check_inline_only_markdown(parse_markdown(markdown))
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_multi_paragraph_replacement_sends_no_paragraph_style(
+        self, mock_svc, _rb,
+    ):
+        """Newlines become suggested paragraph breaks; the new paragraphs
+        inherit the anchor's style rather than being reset to NORMAL_TEXT."""
+        mock_svc.return_value = _service(_ok_response())
+        suggest_replacement("doc1", MATCH, "a\n\nb", "rev", tab_id="t.0")
+        reqs = _batch_call(mock_svc.return_value).kwargs["body"]["requests"]
+        assert [next(iter(r)) for r in reqs] == ["deleteContentRange", "insertText"]
+        assert reqs[1]["insertText"]["text"] == "a\n\nb"
 
     @pytest.mark.parametrize("markdown", [
         "## Heading", "* bullet", "2. numbered", "***", "> quoted",
@@ -601,6 +644,15 @@ class TestCollectSuggestionIds:
 
     def test_empty_document(self):
         assert collect_suggestion_ids({"tabs": []}) == set()
+
+    def test_positioned_object_ids_map_is_keyed_by_suggestion_id(self):
+        """suggestedPositionedObjectIds is a map despite the *Ids name."""
+        para = _para(
+            _run("hello\n", 1, 7),
+            suggestedPositionedObjectIds={"s.pos": {"objectIds": ["kix.1"]}},
+        )
+        assert collect_suggestion_ids({"body": _body(para)}) == {"s.pos"}
+        assert find_suggestions_in_range(_body(para), 2, 4) == {"s.pos"}
 
 
 class TestSuggestionResult:

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1,0 +1,1058 @@
+"""Tests for `gdoc suggest` — find/replace as a suggested edit (SUGGEST mode).
+
+Covers the API wrapper (`suggest_replacement` and its helpers) with mocked
+Docs services asserting the exact JSON sent to Google, and the CLI handler
+(`cmd_suggest`) with the API layer mocked. No fallback path exists: every
+failure must surface as an error, never as a direct edit.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc.api.docs import (
+    SUGGESTIONS_INLINE,
+    SuggestionResult,
+    check_inline_only_markdown,
+    collect_suggestion_ids,
+    find_suggestions_in_range,
+    find_text_in_document,
+    suggest_replacement,
+)
+from gdoc.cli import build_parser, cmd_suggest
+from gdoc.mdparse import parse_markdown
+from gdoc.notify import ChangeInfo
+from gdoc.util import AuthError, GdocError
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _http_error(status, content=b"", reason="Error"):
+    resp = httplib2.Response({"status": str(status)})
+    resp.reason = reason
+    return HttpError(resp, content, uri="")
+
+
+def _service(batch_response=None, batch_error=None):
+    """Docs service mock whose batchUpdate().execute() returns or raises."""
+    service = MagicMock()
+    execute = service.documents.return_value.batchUpdate.return_value.execute
+    if batch_error is not None:
+        execute.side_effect = batch_error
+    else:
+        execute.return_value = batch_response if batch_response is not None else {}
+    return service
+
+
+def _batch_call(service):
+    return service.documents.return_value.batchUpdate.call_args
+
+
+def _ok_response(created=("suggest.abc",), updated=()):
+    return {
+        "commentUpdateState": "ALL_SAVED",
+        "replies": [{}, {}],
+        "suggestionResponses": [
+            {
+                "createdSuggestionIds": list(created),
+                "updatedSummarySuggestionIds": list(updated),
+            }
+        ],
+    }
+
+
+def _readback(*ids, tab_id="t.0"):
+    """A SUGGESTIONS_INLINE documents.get carrying *ids* as insertions."""
+    return {
+        "revisionId": "rev-after",
+        "tabs": [{
+            "tabProperties": {"tabId": tab_id, "title": "Tab 1", "index": 0},
+            "documentTab": {"body": {"content": [{
+                "startIndex": 1, "endIndex": 20,
+                "paragraph": {"elements": [{
+                    "startIndex": 1, "endIndex": 20,
+                    "textRun": {
+                        "content": "hello brave new world\n",
+                        "suggestedInsertionIds": list(ids),
+                    },
+                }]},
+            }]}},
+        }],
+    }
+
+
+def _run(text="hello", start=1, end=6):
+    return {
+        "startIndex": start, "endIndex": end,
+        "textRun": {"content": text, "textStyle": {}},
+    }
+
+
+def _para(*elements, **extra):
+    start = elements[0]["startIndex"]
+    end = elements[-1]["endIndex"]
+    para = {"elements": list(elements)}
+    para.update(extra)
+    return {"startIndex": start, "endIndex": end, "paragraph": para}
+
+
+def _body(*structural):
+    return {"content": list(structural)}
+
+
+MATCH = [{"startIndex": 1, "endIndex": 6}]
+
+
+# ---------------------------------------------------------------------------
+# suggest_replacement: request shape
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestRequestShape:
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_write_control_has_revision_and_suggest_mode(self, mock_svc, _rb):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+
+        result = suggest_replacement("doc1", MATCH, "world", "rev123", tab_id="t.0")
+
+        call = _batch_call(service)
+        assert call.kwargs["documentId"] == "doc1"
+        body = call.kwargs["body"]
+        assert body["writeControl"] == {
+            "requiredRevisionId": "rev123",
+            "writeMode": "SUGGEST",
+        }
+        assert body["requests"] == [
+            {"deleteContentRange": {"range": {
+                "startIndex": 1, "endIndex": 6, "tabId": "t.0",
+            }}},
+            {"insertText": {
+                "location": {"index": 1, "tabId": "t.0"}, "text": "world",
+            }},
+        ]
+        assert result.occurrences == 1
+        assert result.suggestion_ids == ["suggest.abc"]
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_paragraph_style_requests_in_suggest_batch(self, mock_svc, _rb):
+        """Plain paragraphs must not become suggested NORMAL_TEXT style changes."""
+        mock_svc.return_value = _service(_ok_response())
+        suggest_replacement("doc1", MATCH, "plain text", "rev", tab_id="t.0")
+        reqs = _batch_call(mock_svc.return_value).kwargs["body"]["requests"]
+        kinds = [next(iter(r)) for r in reqs]
+        assert "updateParagraphStyle" not in kinds
+        assert kinds == ["deleteContentRange", "insertText"]
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_inline_styles_stay_in_the_same_batch(self, mock_svc, _rb):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+
+        suggest_replacement(
+            "doc1", MATCH, "**bold** ~~gone~~ [link](https://x.test)", "rev",
+            tab_id="t.0",
+        )
+
+        assert service.documents.return_value.batchUpdate.call_count == 1
+        reqs = _batch_call(service).kwargs["body"]["requests"]
+        styles = [r["updateTextStyle"] for r in reqs if "updateTextStyle" in r]
+        assert len(styles) == 3
+        assert all(s["range"]["tabId"] == "t.0" for s in styles)
+        assert styles[0]["textStyle"] == {"bold": True}
+        assert styles[1]["textStyle"] == {"strikethrough": True}
+        assert styles[2]["textStyle"] == {"link": {"url": "https://x.test"}}
+        assert "updateParagraphStyle" not in {next(iter(r)) for r in reqs}
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_multiple_matches_last_to_first_with_tab_id(self, mock_svc, _rb):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        matches = [
+            {"startIndex": 1, "endIndex": 6}, {"startIndex": 40, "endIndex": 45},
+        ]
+
+        result = suggest_replacement("doc1", matches, "x", "rev", tab_id="t.9")
+
+        reqs = _batch_call(service).kwargs["body"]["requests"]
+        deletes = [
+            r["deleteContentRange"]["range"] for r in reqs if "deleteContentRange" in r
+        ]
+        assert [d["startIndex"] for d in deletes] == [40, 1]
+        assert all(d["tabId"] == "t.9" for d in deletes)
+        inserts = [r["insertText"]["location"] for r in reqs if "insertText" in r]
+        assert inserts == [
+            {"index": 40, "tabId": "t.9"}, {"index": 1, "tabId": "t.9"},
+        ]
+        assert result.occurrences == 2
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_utf16_range_from_find_text(self, mock_svc, _rb):
+        """An emoji before the anchor shifts Docs indexes by 2, not 1."""
+        mock_svc.return_value = _service(_ok_response())
+        body = _body(_para(_run("\U0001F600 hello\n", 1, 10)))
+        matches = find_text_in_document(None, "hello", body=body)
+        assert matches == [{"startIndex": 4, "endIndex": 9}]
+
+        suggest_replacement("doc1", matches, "x", "rev", tab_id="t.0")
+
+        reqs = _batch_call(mock_svc.return_value).kwargs["body"]["requests"]
+        assert reqs[0]["deleteContentRange"]["range"]["startIndex"] == 4
+        assert reqs[0]["deleteContentRange"]["range"]["endIndex"] == 9
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_zero_width_match_is_pure_insert(self, mock_svc, _rb):
+        mock_svc.return_value = _service(_ok_response())
+        suggest_replacement(
+            "doc1", [{"startIndex": 5, "endIndex": 5}], "new", "rev", tab_id="t.0",
+        )
+        reqs = _batch_call(mock_svc.return_value).kwargs["body"]["requests"]
+        assert [next(iter(r)) for r in reqs] == ["insertText"]
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_created_id_echoed_as_updated_is_reported_once(self, mock_svc, _rb):
+        """Live shape: Google lists a new ID under both created and
+        updatedSummarySuggestionIds."""
+        mock_svc.return_value = _service(
+            _ok_response(created=("suggest.abc",), updated=("suggest.abc",)),
+        )
+        result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert result.created_suggestion_ids == ["suggest.abc"]
+        assert result.updated_suggestion_ids == []
+        assert result.suggestion_ids == ["suggest.abc"]
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_empty_revision_never_sent(self, mock_svc):
+        """A missing revisionId must not become `requiredRevisionId: ""`."""
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        with pytest.raises(GdocError, match="commenter permission"):
+            suggest_replacement("doc1", MATCH, "x", "", tab_id="t.0")
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_requests_returns_zero_without_calling_api(self, mock_svc):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        result = suggest_replacement(
+            "doc1", [{"startIndex": 3, "endIndex": 3}], "", "rev",
+        )
+        assert result.occurrences == 0
+        assert result.suggestion_ids == []
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# suggest_replacement: response handling
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestResponseIds:
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_ids_flattened_and_deduped_across_responses(self, mock_svc, mock_rb):
+        mock_svc.return_value = _service({
+            "commentUpdateState": "ALL_SAVED",
+            "suggestionResponses": [
+                {"createdSuggestionIds": ["s.1", "s.2"]},
+                {
+                    "createdSuggestionIds": ["s.2"],
+                    "updatedSummarySuggestionIds": ["s.3"],
+                },
+                {},
+                {"updatedSummarySuggestionIds": ["s.3", "s.1"]},
+            ],
+        })
+        mock_rb.return_value = _readback("s.1", "s.2", "s.3")
+
+        result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+        assert result.created_suggestion_ids == ["s.1", "s.2"]
+        # s.1 was created in this batch, so it is not also "updated".
+        assert result.updated_suggestion_ids == ["s.3"]
+        assert result.suggestion_ids == ["s.1", "s.2", "s.3"]
+        assert result.comment_update_state == "ALL_SAVED"
+
+    @patch("gdoc.api.docs.get_document_structure", return_value=_readback("s.open"))
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_merge_into_existing_suggestion_is_success(self, mock_svc, _rb):
+        """Google can fold the edit into the author's open suggestion: no
+        created ID, one updated ID. That is still a durable review object."""
+        mock_svc.return_value = _service(
+            _ok_response(created=(), updated=("s.open",)),
+        )
+        result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert result.created_suggestion_ids == []
+        assert result.updated_suggestion_ids == ["s.open"]
+        assert result.suggestion_ids == ["s.open"]
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_200_without_ids_is_an_error(self, mock_svc, mock_rb):
+        """HTTP 200 + no suggestion IDs = the server may have edited directly."""
+        mock_svc.return_value = _service(
+            {"commentUpdateState": "ALL_SAVED", "replies": [{}]},
+        )
+        with pytest.raises(GdocError, match="edited directly"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        mock_rb.assert_not_called()
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_missing_comment_update_state_is_an_error(self, mock_svc, mock_rb):
+        """An ordinary (non-suggest) batch returns no commentUpdateState —
+        the shape an unenrolled backend produces when it ignores writeMode."""
+        mock_svc.return_value = _service({"replies": [{}, {}]})
+        with pytest.raises(GdocError, match="commentUpdateState=none"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        mock_rb.assert_not_called()
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_partial_save_failure_is_an_error(self, mock_svc, mock_rb):
+        resp = _ok_response()
+        resp["commentUpdateState"] = "ALL_FAILED_UNKNOWN_REASON"
+        mock_svc.return_value = _service(resp)
+        with pytest.raises(GdocError, match="ALL_FAILED_UNKNOWN_REASON"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        mock_rb.assert_not_called()
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_readback_uses_suggestions_inline(self, mock_svc, mock_rb):
+        mock_svc.return_value = _service(_ok_response())
+        mock_rb.return_value = _readback("suggest.abc")
+        suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        mock_rb.assert_called_once_with(
+            "doc1", suggestions_view_mode=SUGGESTIONS_INLINE,
+        )
+        assert SUGGESTIONS_INLINE == "SUGGESTIONS_INLINE"
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_readback_missing_id_is_an_error(self, mock_svc, mock_rb):
+        mock_svc.return_value = _service(_ok_response(created=("s.1", "s.2")))
+        mock_rb.return_value = _readback("s.1")
+        with pytest.raises(GdocError, match=r"read-back: s\.2"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_readback_finds_ids_in_style_maps_and_other_tabs(
+        self, mock_svc, mock_rb,
+    ):
+        mock_svc.return_value = _service(_ok_response(created=("s.style",)))
+        mock_rb.return_value = {"tabs": [
+            {
+                "tabProperties": {"tabId": "t.0"},
+                "documentTab": {"body": {"content": []}},
+            },
+            {"tabProperties": {"tabId": "t.1"}, "documentTab": {"body": {"content": [
+                _para({
+                    "startIndex": 1, "endIndex": 5,
+                    "textRun": {
+                        "content": "abcd",
+                        "suggestedTextStyleChanges": {
+                            "s.style": {"textStyle": {"bold": True}},
+                        },
+                    },
+                }),
+            ]}}},
+        ]}
+        result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert result.suggestion_ids == ["s.style"]
+
+
+class TestSuggestErrors:
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_400_unknown_name_means_no_preview(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(
+            400, b'{"error": {"message": "Invalid JSON payload received. '
+                 b'Unknown name \\"write_mode\\" at \'write_control\'"}}',
+            reason="Bad Request",
+        ))
+        with pytest.raises(GdocError, match="not enrolled") as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert "No change was made" in str(exc.value)
+        assert exc.value.exit_code == 1
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_400_no_request_set_means_no_preview(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(
+            400, b'{"error": {"message": "Invalid requests[0]: No request set."}}',
+        ))
+        with pytest.raises(GdocError, match="suggest mode not available"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_400_cannot_find_field_means_no_preview(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(
+            400, b'{"error": {"message": "Cannot find field."}}',
+        ))
+        with pytest.raises(GdocError, match="suggest mode not available"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_400_revision_mismatch_asks_for_rerun(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(
+            400, b'{"error": {"message": "The revision ID is stale"}}',
+        ))
+        with pytest.raises(GdocError, match="re-run it"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_403_reports_both_possibilities(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(403))
+        with pytest.raises(GdocError, match="Permission denied: doc1") as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        msg = str(exc.value)
+        assert "comment or edit access" in msg
+        assert "Developer Preview" in msg
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_401_is_auth_error(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(401))
+        with pytest.raises(AuthError):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_is_not_found(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(404))
+        with pytest.raises(GdocError, match="Document not found: doc1"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_other_400_is_generic_api_error(self, mock_svc):
+        mock_svc.return_value = _service(batch_error=_http_error(
+            400, b'{"error": {"message": "Index 99 must be less than end"}}',
+            reason="Bad Request",
+        ))
+        with pytest.raises(GdocError, match=r"API error \(400\)"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
+    @pytest.mark.parametrize("markdown", [
+        "# Heading",
+        "- item",
+        "1. item",
+        "---",
+        "> quote",
+        "| a | b |\n|---|---|\n| 1 | 2 |",
+        "text\n\n## Sub\nmore",
+    ])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_structural_markdown_fails_before_write(self, mock_svc, markdown):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        with pytest.raises(GdocError, match="not supported yet") as exc:
+            suggest_replacement("doc1", MATCH, markdown, "rev", tab_id="t.0")
+        assert exc.value.exit_code == 3
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# helpers: inline-only check, overlap detection, id collection
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInlineOnly:
+    @pytest.mark.parametrize("markdown", [
+        "plain",
+        "two\nparagraphs",
+        "**bold** and *italic* and ~~strike~~",
+        "`code` and [a link](https://example.com)",
+        "",
+    ])
+    def test_inline_markdown_accepted(self, markdown):
+        check_inline_only_markdown(parse_markdown(markdown))
+
+    @pytest.mark.parametrize("markdown", [
+        "## Heading", "* bullet", "2. numbered", "***", "> quoted",
+        "| h |\n|---|\n| c |",
+    ])
+    def test_structural_markdown_rejected(self, markdown):
+        with pytest.raises(GdocError) as exc:
+            check_inline_only_markdown(parse_markdown(markdown))
+        assert exc.value.exit_code == 3
+
+
+class TestFindSuggestionsInRange:
+    def _body_with_insertion(self):
+        return _body(_para(
+            _run("hello ", 1, 7),
+            {
+                "startIndex": 7, "endIndex": 12,
+                "textRun": {"content": "brave", "suggestedInsertionIds": ["s.ins"]},
+            },
+            _run(" world\n", 12, 19),
+        ))
+
+    def test_range_inside_clean_run_is_clear(self):
+        assert find_suggestions_in_range(self._body_with_insertion(), 1, 6) == set()
+
+    def test_range_touching_suggested_insertion(self):
+        assert find_suggestions_in_range(self._body_with_insertion(), 5, 9) == {"s.ins"}
+
+    def test_range_adjacent_but_not_overlapping_is_clear(self):
+        # [1, 7) ends exactly where the suggested run starts.
+        assert find_suggestions_in_range(self._body_with_insertion(), 1, 7) == set()
+
+    def test_suggested_deletion_and_style_change(self):
+        body = _body(_para(
+            {
+                "startIndex": 1, "endIndex": 5,
+                "textRun": {"content": "gone", "suggestedDeletionIds": ["s.del"]},
+            },
+            {
+                "startIndex": 5, "endIndex": 10,
+                "textRun": {
+                    "content": "bold\n",
+                    "suggestedTextStyleChanges": {
+                        "s.sty": {"textStyle": {"bold": True}},
+                    },
+                },
+            },
+        ))
+        assert find_suggestions_in_range(body, 2, 3) == {"s.del"}
+        assert find_suggestions_in_range(body, 6, 8) == {"s.sty"}
+        assert find_suggestions_in_range(body, 1, 10) == {"s.del", "s.sty"}
+
+    def test_paragraph_level_suggestion_counts(self):
+        body = _body(_para(
+            _run("hello\n", 1, 7),
+            suggestedParagraphStyleChanges={"s.para": {}},
+        ))
+        assert find_suggestions_in_range(body, 2, 4) == {"s.para"}
+
+    def test_other_paragraph_suggestion_ignored(self):
+        body = _body(
+            _para(_run("hello\n", 1, 7)),
+            _para({
+                "startIndex": 7, "endIndex": 12,
+                "textRun": {"content": "more\n", "suggestedInsertionIds": ["s.far"]},
+            }),
+        )
+        assert find_suggestions_in_range(body, 1, 6) == set()
+
+    def test_table_cell_is_searched(self):
+        cell = {"content": [_para({
+            "startIndex": 10, "endIndex": 15,
+            "textRun": {"content": "cell\n", "suggestedInsertionIds": ["s.cell"]},
+        })]}
+        body = _body({
+            "startIndex": 8, "endIndex": 20,
+            "table": {"tableRows": [{"tableCells": [cell]}]},
+        })
+        assert find_suggestions_in_range(body, 11, 13) == {"s.cell"}
+        assert find_suggestions_in_range(body, 1, 5) == set()
+
+    def test_zero_width_insert_inside_suggested_run(self):
+        assert find_suggestions_in_range(self._body_with_insertion(), 9, 9) == {"s.ins"}
+
+
+class TestCollectSuggestionIds:
+    def test_walks_ids_lists_and_changes_maps(self):
+        doc = {"tabs": [{"documentTab": {"body": {"content": [
+            _para(
+                {"startIndex": 1, "endIndex": 3, "textRun": {
+                    "content": "ab", "suggestedInsertionIds": ["a"],
+                }},
+                {"startIndex": 3, "endIndex": 5, "textRun": {
+                    "content": "cd", "suggestedDeletionIds": ["b"],
+                    "suggestedTextStyleChanges": {"c": {}},
+                }},
+                suggestedBulletChanges={"d": {}},
+            ),
+        ]}}}]}
+        assert collect_suggestion_ids(doc) == {"a", "b", "c", "d"}
+
+    def test_empty_document(self):
+        assert collect_suggestion_ids({"tabs": []}) == set()
+
+
+class TestSuggestionResult:
+    def test_suggestion_ids_property_dedupes_in_order(self):
+        r = SuggestionResult(1, ["b", "a"], ["a", "c"], "ALL_SAVED")
+        assert r.suggestion_ids == ["b", "a", "c"]
+
+
+# ---------------------------------------------------------------------------
+# CLI: parser
+# ---------------------------------------------------------------------------
+
+
+def _option_strings(parser, command):
+    sub = next(a for a in parser._actions if a.dest == "command")
+    p = sub.choices[command]
+    return {o for a in p._actions for o in a.option_strings}, [
+        a.dest for a in p._actions if not a.option_strings
+    ]
+
+
+class TestSuggestParser:
+    def test_parity_with_edit_minus_cell_mode(self):
+        parser = build_parser()
+        edit_opts, edit_pos = _option_strings(parser, "edit")
+        sug_opts, sug_pos = _option_strings(parser, "suggest")
+        assert edit_opts - sug_opts == {"--cell", "--col", "--table"}
+        assert sug_opts - edit_opts == set()
+        assert sug_pos == edit_pos == ["doc", "old_text", "new_text"]
+
+    def test_parses_flags(self):
+        args = build_parser().parse_args([
+            "suggest", "abc", "old", "new", "--all", "--case-sensitive",
+            "--normalize", "--quiet", "--tab", "Draft", "--json",
+        ])
+        assert args.func is cmd_suggest
+        assert (args.all, args.case_sensitive, args.normalize, args.quiet) == (
+            True, True, True, True,
+        )
+        assert args.tab == "Draft"
+        assert args.json is True
+        assert not hasattr(args, "cell")
+
+    def test_cell_is_rejected(self):
+        with pytest.raises(SystemExit) as exc:
+            build_parser().parse_args(["suggest", "abc", "--cell", "Label", "x"])
+        assert exc.value.code == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_suggest
+# ---------------------------------------------------------------------------
+
+
+def _args(**overrides):
+    defaults = {
+        "command": "suggest",
+        "doc": "abc123",
+        "old_text": "hello",
+        "new_text": "world",
+        "old_file": None,
+        "new_file": None,
+        "all": False,
+        "case_sensitive": False,
+        "normalize": False,
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": False,
+        "tab": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _structure(revision_id="rev123", tabs=None):
+    """A documents.get(includeTabsContent, SUGGESTIONS_INLINE) response."""
+    if tabs is None:
+        tabs = [("t.first", "Tab 1", _body(_para(_run("hello world\n", 1, 13))))]
+    return {
+        "revisionId": revision_id,
+        "tabs": [
+            {
+                "tabProperties": {"tabId": tid, "title": title, "index": i},
+                "documentTab": {"body": body},
+            }
+            for i, (tid, title, body) in enumerate(tabs)
+        ],
+    }
+
+
+def _result(occurrences=1, created=("suggest.abc",), updated=()):
+    return SuggestionResult(
+        occurrences, list(created), list(updated), "ALL_SAVED",
+    )
+
+
+_VERSION = {"version": 42, "modifiedTime": "2026-08-26T00:00:00Z"}
+
+
+class TestCmdSuggest:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_terse_output_names_suggestion(
+        self, _pf, _doc, _sug, _ver, _state, capsys,
+    ):
+        assert cmd_suggest(_args()) == 0
+        out = capsys.readouterr().out
+        assert out == "OK suggested 1 occurrence (#suggest.abc)\n"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch(
+        "gdoc.api.docs.suggest_replacement", return_value=_result(3, ("s.1", "s.2")),
+    )
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_terse_output_plural(self, _pf, _doc, _sug, _ver, _state, capsys):
+        cmd_suggest(_args(all=True))
+        assert capsys.readouterr().out == "OK suggested 3 occurrences (#s.1, #s.2)\n"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch(
+        "gdoc.api.docs.suggest_replacement",
+        return_value=_result(1, ("s.new",), ("s.merged",)),
+    )
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_json_output(self, _pf, _doc, _sug, _ver, _state, capsys):
+        cmd_suggest(_args(json=True))
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True,
+            "suggested": 1,
+            "suggestionIds": ["s.new", "s.merged"],
+            "createdSuggestionIds": ["s.new"],
+            "updatedSuggestionIds": ["s.merged"],
+        }
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch(
+        "gdoc.api.docs.suggest_replacement", return_value=_result(2, ("s.1", "s.2")),
+    )
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_plain_output(self, _pf, _doc, _sug, _ver, _state, capsys):
+        cmd_suggest(_args(plain=True, all=True))
+        assert capsys.readouterr().out.splitlines() == [
+            "id\tabc123",
+            "status\tsuggested",
+            "suggested\t2",
+            "suggestion_ids\ts.1,s.2",
+        ]
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_reads_inline_view_and_targets_first_tab(
+        self, _pf, mock_doc, mock_sug, _ver, _state,
+    ):
+        cmd_suggest(_args(doc="https://docs.google.com/document/d/abc123/edit"))
+        mock_doc.assert_called_once_with(
+            "abc123", suggestions_view_mode="SUGGESTIONS_INLINE",
+        )
+        mock_sug.assert_called_once_with(
+            "abc123", [{"startIndex": 1, "endIndex": 6}], "world", "rev123",
+            tab_id="t.first",
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_tab_option_resolves_by_title_and_propagates_tab_id(
+        self, _pf, mock_doc, mock_sug, _ver, _state,
+    ):
+        mock_doc.return_value = _structure(tabs=[
+            ("t.first", "Tab 1", _body(_para(_run("nothing here\n", 1, 14)))),
+            ("t.draft", "Draft", _body(_para(_run("say hello\n", 1, 11)))),
+        ])
+        cmd_suggest(_args(tab="draft"))
+        call = mock_sug.call_args
+        assert call.args[1] == [{"startIndex": 5, "endIndex": 10}]
+        assert call.kwargs["tab_id"] == "t.draft"
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_no_match_exit_3(self, _pf, _doc, mock_sug):
+        with pytest.raises(GdocError, match="no match found") as exc:
+            cmd_suggest(_args(old_text="absent"))
+        assert exc.value.exit_code == 3
+        mock_sug.assert_not_called()
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_multiple_matches_need_all(self, _pf, mock_doc, mock_sug):
+        mock_doc.return_value = _structure(tabs=[
+            ("t.0", "Tab 1", _body(_para(_run("hello hello\n", 1, 13)))),
+        ])
+        with pytest.raises(GdocError, match="multiple matches") as exc:
+            cmd_suggest(_args())
+        assert exc.value.exit_code == 3
+        mock_sug.assert_not_called()
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_overlap_with_existing_suggestion_exit_3(self, _pf, mock_doc, mock_sug):
+        mock_doc.return_value = _structure(tabs=[("t.0", "Tab 1", _body(_para(
+            _run("say ", 1, 5),
+            {
+                "startIndex": 5, "endIndex": 10,
+                "textRun": {"content": "hello", "suggestedInsertionIds": ["suggest.x"]},
+            },
+            _run("\n", 10, 11),
+        )))])
+        with pytest.raises(
+            GdocError, match=r"overlaps existing suggestion\(s\) suggest\.x",
+        ) as exc:
+            cmd_suggest(_args())
+        assert exc.value.exit_code == 3
+        mock_sug.assert_not_called()
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_overlap_with_suggested_deletion_exit_3(self, _pf, mock_doc, mock_sug):
+        mock_doc.return_value = _structure(tabs=[("t.0", "Tab 1", _body(_para(
+            {
+                "startIndex": 1, "endIndex": 6,
+                "textRun": {"content": "hello", "suggestedDeletionIds": ["suggest.d"]},
+            },
+            _run(" world\n", 6, 13),
+        )))])
+        with pytest.raises(GdocError, match="suggest.d"):
+            cmd_suggest(_args())
+        mock_sug.assert_not_called()
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_structural_markdown_rejected_before_any_api_call(
+        self, mock_pf, mock_doc, mock_sug,
+    ):
+        with pytest.raises(GdocError, match="not supported yet") as exc:
+            cmd_suggest(_args(new_text="# Heading"))
+        assert exc.value.exit_code == 3
+        mock_pf.assert_not_called()
+        mock_doc.assert_not_called()
+        mock_sug.assert_not_called()
+
+    @pytest.mark.parametrize("new_text", [
+        "- bullet", "1. item", "---", "> quote", "| a |\n|---|\n| b |",
+    ])
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_each_structural_form_rejected(self, mock_pf, mock_sug, new_text):
+        with pytest.raises(GdocError) as exc:
+            cmd_suggest(_args(new_text=new_text))
+        assert exc.value.exit_code == 3
+        mock_pf.assert_not_called()
+        mock_sug.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_inline_markdown_passes_through_verbatim(
+        self, _pf, _doc, mock_sug, _ver, _state,
+    ):
+        cmd_suggest(_args(new_text="**bold** [x](https://x.test)"))
+        assert mock_sug.call_args.args[2] == "**bold** [x](https://x.test)"
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_structure(revision_id=""),
+    )
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_missing_revision_id_is_passed_for_api_to_refuse(
+        self, _pf, _doc, mock_sug,
+    ):
+        """A read without revisionId: the CLI hands the empty value to the
+        API layer, which refuses rather than sending ""."""
+        mock_sug.side_effect = GdocError("cannot suggest: ... commenter permission")
+        with pytest.raises(GdocError, match="commenter permission"):
+            cmd_suggest(_args())
+        assert mock_sug.call_args.args[3] == ""
+
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_structure(revision_id=""),
+    )
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_missing_revision_id_end_to_end_never_calls_batch_update(
+        self, mock_svc, _pf, _doc,
+    ):
+        service = _service(_ok_response())
+        mock_svc.return_value = service
+        with pytest.raises(GdocError, match="commenter permission"):
+            cmd_suggest(_args())
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_reader_403_on_inline_read_gets_permission_hint(
+        self, _pf, mock_doc, mock_sug,
+    ):
+        """Live: a reader's SUGGESTIONS_INLINE read is refused with 403."""
+        mock_doc.side_effect = GdocError("Permission denied: abc123")
+        with pytest.raises(GdocError, match="comment or edit access") as exc:
+            cmd_suggest(_args())
+        assert str(exc.value).startswith("Permission denied: abc123")
+        assert exc.value.exit_code == 1
+        mock_sug.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_state_updated_as_partial_write(
+        self, _pf, _doc, _sug, _ver, mock_state,
+    ):
+        change_info = ChangeInfo(current_version=41)
+        _pf.return_value = change_info
+        cmd_suggest(_args())
+        mock_state.assert_called_once_with(
+            "abc123", change_info, command="suggest", quiet=False,
+            command_version=42,
+        )
+
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight")
+    def test_state_does_not_advance_read_baseline(
+        self, mock_pf, _doc, _sug, _ver, tmp_path,
+    ):
+        from gdoc.state import DocState, load_state, save_state
+
+        mock_pf.return_value = ChangeInfo(current_version=41)
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("abc123", DocState(last_version=40, last_read_version=40))
+            cmd_suggest(_args())
+            state = load_state("abc123")
+        assert state.last_version == 42
+        assert state.last_read_version == 40
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_quiet_skips_preflight(self, mock_pf, _doc, _sug, _ver, mock_state):
+        cmd_suggest(_args(quiet=True))
+        mock_pf.assert_called_once_with("abc123", quiet=True)
+        assert mock_state.call_args.kwargs["quiet"] is True
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_conflict_warning_does_not_block(
+        self, mock_pf, _doc, _sug, _ver, _state, capsys,
+    ):
+        mock_pf.return_value = ChangeInfo(current_version=41, last_read_version=40)
+        assert cmd_suggest(_args()) == 0
+        assert "WARN: doc changed since last read" in capsys.readouterr().err
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_old_and_new_file(self, _pf, _doc, mock_sug, _ver, _state, tmp_path):
+        old = tmp_path / "old.txt"
+        new = tmp_path / "new.txt"
+        old.write_text("hello\n")
+        new.write_text("**world**\n")
+        cmd_suggest(_args(
+            old_text=None, new_text=None, old_file=str(old), new_file=str(new),
+        ))
+        assert mock_sug.call_args.args[1] == [{"startIndex": 1, "endIndex": 6}]
+        assert mock_sug.call_args.args[2] == "**world**"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_stdin_dash_for_new_text(
+        self, _pf, _doc, mock_sug, _ver, _state, monkeypatch,
+    ):
+        import io
+
+        monkeypatch.setattr("sys.stdin", io.StringIO("from stdin"))
+        cmd_suggest(_args(new_text="-"))
+        assert mock_sug.call_args.args[2] == "from stdin"
+
+    def test_missing_text_exit_3(self):
+        with pytest.raises(
+            GdocError, match="old_text and new_text required",
+        ) as exc:
+            cmd_suggest(_args(old_text=None, new_text=None))
+        assert exc.value.exit_code == 3
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_api_failure_propagates_without_state_update(
+        self, _pf, _doc, mock_sug, mock_ver, mock_state,
+    ):
+        mock_sug.side_effect = GdocError("suggest mode not available: ...")
+        with pytest.raises(GdocError, match="suggest mode not available"):
+            cmd_suggest(_args())
+        mock_ver.assert_not_called()
+        mock_state.assert_not_called()
+
+    @patch("gdoc.api.docs.suggest_replacement")
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value={"revisionId": "r", "tabs": []},
+    )
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_document_without_tabs_is_an_error(self, _pf, _doc, mock_sug):
+        with pytest.raises(GdocError, match="no tabs"):
+            cmd_suggest(_args())
+        mock_sug.assert_not_called()
+
+
+class TestMcpExposure:
+    def test_suggest_is_a_write_tool_with_file_params_hidden(self):
+        from gdoc import mcp
+
+        assert mcp.EXPOSED_COMMANDS["suggest"] is False
+        assert mcp._LOCAL_PATH_PARAMS["suggest"] == frozenset(
+            {"old_file", "new_file"},
+        )
+        assert "suggest" in mcp._DESCRIPTION_NOTES

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -645,6 +645,21 @@ class TestSuggestResponseIds:
 
 class TestSuggestErrors:
     @patch("gdoc.api.docs.get_docs_service")
+    def test_5xx_on_the_batch_is_indeterminate(self, mock_svc):
+        """A 503 can arrive after Google applied the mutation: like a
+        transport failure it must say the outcome is unknown, not read as
+        a generic API error inviting a blind retry."""
+        mock_svc.return_value = _service(
+            batch_error=_http_error(503, reason="Backend Error"),
+        )
+        with pytest.raises(GdocError) as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        msg = str(exc.value)
+        assert "outcome is unknown" in msg
+        assert "503" in msg
+        assert "Inspect the document" in msg
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_batch_transport_failure_reports_unknown_outcome(self, mock_svc):
         """A timeout/reset on batchUpdate itself can land after Google has
         accepted the write: the error must say the outcome is unknown and

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -455,6 +455,22 @@ class TestSuggestResponseIds:
 
     @patch("gdoc.api.docs.get_document_structure")
     @patch("gdoc.api.docs.get_docs_service")
+    def test_readback_transport_failure_names_the_saved_ids(
+        self, mock_svc, mock_rb,
+    ):
+        """Only HttpError is translated inside the verification read; an
+        untranslated ConnectionError must still report the IDs the batch
+        already saved instead of escaping as a generic error."""
+        mock_svc.return_value = _service(_ok_response(created=("s.saved",)))
+        mock_rb.side_effect = ConnectionError("connection reset")
+        with pytest.raises(GdocError, match=r"s\.saved") as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert "could not be verified" in str(exc.value)
+        assert "connection reset" in str(exc.value)
+        assert exc.value.exit_code == 1
+
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.api.docs.get_docs_service")
     def test_readback_missing_id_is_an_error(self, mock_svc, mock_rb):
         mock_svc.return_value = _service(_ok_response(created=("s.1", "s.2")))
         mock_rb.return_value = _readback("s.1")
@@ -489,6 +505,32 @@ class TestSuggestResponseIds:
 
 
 class TestSuggestErrors:
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_batch_transport_failure_reports_unknown_outcome(self, mock_svc):
+        """A timeout/reset on batchUpdate itself can land after Google has
+        accepted the write: the error must say the outcome is unknown and
+        point at the document, not surface as a generic unexpected error."""
+        mock_svc.return_value = _service(
+            batch_error=ConnectionError("connection reset"),
+        )
+        with pytest.raises(GdocError) as exc:
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        msg = str(exc.value)
+        assert "outcome is unknown" in msg
+        assert "connection reset" in msg
+        assert "Inspect the document" in msg
+        assert exc.value.exit_code == 1
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_batch_transport_failure_with_no_message_names_the_type(
+        self, mock_svc,
+    ):
+        """str(TimeoutError()) is empty; the error must fall back to the
+        exception type instead of an empty pair of parentheses."""
+        mock_svc.return_value = _service(batch_error=TimeoutError())
+        with pytest.raises(GdocError, match="TimeoutError"):
+            suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+
     @patch("gdoc.api.docs.get_docs_service")
     def test_400_unknown_name_means_no_preview(self, mock_svc):
         mock_svc.return_value = _service(batch_error=_http_error(

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -391,6 +391,43 @@ class TestSuggestRequestShape:
             result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
         assert result.suggestion_ids == ["suggest.abc"]
 
+    @patch(
+        "gdoc.api.docs.get_document_structure",
+        return_value=_readback("suggest.abc"),
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_direct_call_pins_the_resolved_account(
+        self, mock_svc, _rb, _preview_gate_passes, monkeypatch,
+    ):
+        """Called directly (no CLI/MCP pinning), a default-account flip
+        between the gate and the service lookup must not split them across
+        two accounts — the gate could prove enrollment for one account
+        while the write goes through another, possibly unenrolled, one."""
+        from gdoc import util
+
+        util.set_active_account(None)
+        default = ["acct-a"]
+        monkeypatch.setattr(
+            "gdoc.util.get_default_account", lambda: default[0],
+        )
+        seen = []
+
+        def gate_spy(doc_id):
+            seen.append(util.resolve_account())
+            default[0] = "acct-b"  # the flip lands right after the gate
+
+        _preview_gate_passes.side_effect = gate_spy
+
+        def service_spy():
+            seen.append(util.resolve_account())
+            return _service(_ok_response())
+
+        mock_svc.side_effect = service_spy
+
+        result = suggest_replacement("doc1", MATCH, "x", "rev", tab_id="t.0")
+        assert result.suggestion_ids == ["suggest.abc"]
+        assert seen == ["acct-a", "acct-a"]
+
     @patch("gdoc.api.docs.get_docs_service")
     def test_expected_identity_from_before_the_read_is_the_baseline(
         self, mock_svc,

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.19.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Adds **`gdoc suggest DOC OLD NEW`** — the first of the Docs API Developer Preview write features after `comment --quote` (#40): a find-and-replace made as a **suggested edit** instead of a committed one.

`suggest` is `edit`'s sibling, not a flag on it: `gdoc edit` = committed mutation, `gdoc suggest` = reviewable mutation, which is unambiguous in agent traces. It accepts the text-oriented `edit` flags (`--all`, `--case-sensitive`, `--normalize`, `--old-file`/`--new-file`, `-` for stdin, `--tab`, `--quiet`) and runs the same matching pipeline, but the single `batchUpdate` carries `writeControl: {requiredRevisionId, writeMode: "SUGGEST"}`. The original text stays in place with an accept/reject control in the Docs UI.

### Contract

- **Success is verified, never assumed.** All of: HTTP 200, `commentUpdateState == ALL_SAVED`, ≥1 ID in `suggestionResponses[].createdSuggestionIds` / `updatedSummarySuggestionIds`, and a follow-up `documents.get(suggestionsViewMode=SUGGESTIONS_INLINE)` that shows every reported ID. Anything else is an error that tells the caller to inspect the document.
- **No fallback, ever — and no write before enrollment is proven.** An unenrolled backend has previously been observed *ignoring* `writeMode: SUGGEST` and applying the batch as a direct edit, so `suggest_replacement` first runs `check_suggest_preview_access()`: a raw, non-mutating `documents.get` with the preview-only `commentsViewMode` field (+ `includeTabsContent`, `suggestionsViewMode=SUGGESTIONS_INLINE`, which Google requires with it). A registered project echoes the field (200); an unregistered one rejects it (400 `Unknown name "comments_view_mode"`) → `suggest mode not available … No change was made.` and the batchUpdate is never sent. Unlike `comment --quote`, nothing degrades to a direct edit. The response is still checked afterwards: a 200 with no suggestion IDs or without `commentUpdateState: ALL_SAVED` fails with an explicit "the text may have been edited directly" warning.
- **Never touches an existing review thread.** The doc is read with `SUGGESTIONS_INLINE` (the only view whose indexes a suggest-mode write addresses) and a match that intersects an existing suggested insertion/deletion/style change is refused (exit 3) with the offending IDs. Google may otherwise merge the change into that thread.
- **Never sends an empty `requiredRevisionId`.** A read without `revisionId` is refused before any write.
- **Inline Markdown only** (bold, italic, strike, code, links — suggested in the same batch; style ranges are UTF-16-converted in `to_docs_requests`, which also fixes `edit`/`insert` with emoji in formatted replacement text). Newlines become suggested paragraph breaks inheriting the anchor paragraph's style. Self-overlapping `--all` matches (`aa` in `aaa`) are refused before any write. Headings, lists, blockquotes, HRs, tables, and `--cell` fail before any API call with a specific usage error. Suggest mode runs one batch; `replace_formatted`'s read-back cleanup and table phases would each need to stay in SUGGEST mode and their suggested-structure shapes are unverified.
- **Output:** `OK suggested 1 occurrence (#suggest.abc)`; `--json` → `{"ok": true, "suggested": 1, "suggestionIds": [...], "createdSuggestionIds": [...], "updatedSuggestionIds": [...]}`; `--plain` → `id`, `status suggested`, `suggested N`, `suggestion_ids`. `updatedSuggestionIds` lists only pre-existing threads the edit was merged into (Google also echoes new IDs under `updatedSummarySuggestionIds`; those are reported once, as created).
- **State:** records the post-command version like `edit`; does **not** advance `last_read_version` (partial write).
- **MCP:** exposed as `gdoc_suggest` (write tool, `old_file`/`new_file` hidden like `edit`).

### Files

- `gdoc/api/docs.py` — `suggest_replacement()`, `SuggestionResult`, `check_inline_only_markdown()`, `find_suggestions_in_range()`, `collect_suggestion_ids()`, `_classify_suggest_error()`; `_build_replacement_requests()` extracted from `replace_formatted()` (which now calls it — behaviour unchanged).
- `gdoc/cli.py` — `cmd_suggest` + parser; `cmd_edit` refactored onto the shared `_resolve_replacement_text()` / `_prepare_text_replacement()` front half. `edit`'s behaviour and its 60 existing tests are unchanged.
- `gdoc/mcp.py`, `README.md` ("Suggesting edits" section), `gdoc.md`, `CHANGELOG.md`, version 0.21.0 (separate commit; also syncs `uv.lock`, which was still at 0.19.0 on main).
- `tests/test_suggest.py` — 114 tests; `tests/test_api_docs.py` +2 (UTF-16 cleanup/table offsets for `edit`).
- `gdoc/mdparse.py` — `to_docs_requests` emits UTF-16 ranges (`_utf16_prefix`, `utf16_len`); `replace_formatted`/`insert_markdown_into_tab`/`_insert_table` use UTF-16 for cleanup and table offsets too.

Design reference: this is "PR 1" of a three-PR sequence (suggest → list/accept/reject/delete suggestions → native comment posts). PR 2 will reuse `collect_suggestion_ids` and the `SUGGESTIONS_INLINE` read.

## Test plan

```
uv run pytest tests/test_suggest.py tests/test_edit.py tests/test_api_docs.py -v   # 226 passed
uv run pytest tests/ -v                                                             # 1534 passed
uv run ruff check gdoc/ tests/     # no new findings (42 pre-existing in gdoc/cli.py etc., 44 on main — two fixed in moved edit code)
bash scripts/check-no-stubs.sh     # OK
```

Focused coverage: exact `writeControl`; delete+insert+`updateTextStyle` in one batch with `tabId`; no `updateParagraphStyle` in suggest batches; last-to-first multi-match; UTF-16 offsets (emoji before anchor); zero-width insert; created/updated/duplicate ID flattening; merge-into-existing-suggestion (updated-only) success; created ID echoed as updated reported once; `ALL_FAILED_UNKNOWN_REASON`, missing `commentUpdateState`, 200-without-IDs; read-back missing an ID; read-back finding IDs in style maps / other tabs; 400 unknown-name / no-request-set / cannot-find-field / revision-stale / other; 403 / 401 / 404; empty `revisionId` never sent; every structural Markdown form rejected before any API call (also before pre-flight in the CLI); overlap with suggested insertion / deletion / style / paragraph-level / table-cell / zero-width; parser parity with `edit` minus `--cell/--col/--table`; terse/plain/json output; `--tab` resolution and `tabId` propagation; `--quiet`; conflict warning non-blocking; files/stdin; reader 403 hint; state update as partial write with a real `STATE_DIR` round-trip proving `last_read_version` is untouched; MCP exposure.

## Live evidence (2026-08-26, scratch doc, no credentials recorded)

All `gdoc` calls used gdoc's own OAuth client, Cloud project **`1009200210134`** (registered in the Developer Preview; confirmed today with a preview-only `commentsViewMode` read returning HTTP 200). Scratch doc: two tabs, an emoji before an anchor, inline formatting, then existing suggestions from earlier steps.

**Registered project, editor** (`alejandro.acelas-contractor@80000hours.org`, owner):
- `suggest "ship in Q3" "ship in Q4"` → `OK suggested 1 occurrence (#suggest.6c5wmpj58op0)`
- `suggest "plain wording to restyle" '**bold** ~~struck~~ [linked](…) `code` wording' --json` → one ID; `PREVIEW_SUGGESTIONS_ACCEPTED` read shows the bold/strike/link/code applied, `PREVIEW_WITHOUT_SUGGESTIONS` shows the original — i.e. the styles are **suggested**, not applied directly.
- `suggest colour color --all --plain` (emoji earlier on the line) → 2 IDs, both landed on the right words.
- `suggest "draft text" "revised text" --tab Draft` → 1 ID in the second tab (verified per-tab on read-back).
- Base text of every tab unchanged in `PREVIEW_WITHOUT_SUGGESTIONS`; every ID present in `SUGGESTIONS_INLINE`; native thread read (`commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`, raw HTTP — the discovery doc doesn't know the field) lists all 6 threads `OPEN` with summaries like `Replace: “ship in Q3” with “ship in Q4”` and the correct author (`me: true` for the editor's).
- Overlap: `suggest Q4 Q5` (inside the suggested insertion) and `suggest "ship in" "sail in" --all` (touching the suggested deletion) → exit 3 naming `suggest.6c5wmpj58op0`, nothing written.
- Structural: `# Heading`, `- bullet` → exit 3 before any API call. `nonexistent` → `no match found`, exit 3.
- Regression: `gdoc edit … --tab Draft` and `gdoc comment --quote` (`anchored: true`) still work on the same doc.
- `acceptSuggestion` / `rejectSuggestion` (raw preview probes, PR 2 territory) on two of the IDs → 200 with `acceptedSuggestionIds` / `rejectedSuggestionIds`; the accepted text became base text. The objects are real, decidable suggestions.

**Registered project, editor, after the review-fix commits:** the preview gate passes (200, field echoed) for both the editor and the commenter account; `suggest "Intro paragraph" '😀 **Intro** paragraph' --json` → one ID and `PREVIEW_SUGGESTIONS_ACCEPTED` shows `😀 **Intro** paragraph` — the bold range is correct despite the non-BMP emoji before it.

**Registered project, commenter** (`alejoacelas@gmail.com`, shared as commenter): `SUGGESTIONS_INLINE` read **did include `revisionId`**, and `suggest "and more" "plus more"` → `OK suggested 1 occurrence (#suggest.k4pny8lqxjaj)`, authored by that account in the native thread. So, contrary to Google's "editors only" note on `revisionId`, commenters can suggest through the API with revision pinning; docs and errors say "comment or edit access". The empty-`revisionId` refusal stays as a guard.

**Registered project, reader** (`alejo@habere.org`, shared as reader): the inline read fails with 403 `You do not have permission to access the document suggestions.` → `Permission denied: … (reading suggestions inline needs comment or edit access on the document)`, exit 1, nothing written.

**Unregistered project `856825977485`** (`80k-control` client, same work account, same doc): a harmless `insertComment` batchUpdate → **400 `Invalid requests[0]: No request set.`** (preview request stripped; no mutation). The gate's exact probe (`commentsViewMode` read) against this project was recorded on 2026-08-25 with the same client: **400 `Unknown name "comments_view_mode"`** — the shape `check_suggest_preview_access` maps to `suggest mode not available`. It could not be re-sent today through `gog` (its discovery-validated client rejects the unknown query parameter locally) and no refresh token was exported to do it by hand. **No `writeMode: SUGGEST` write was attempted on the unregistered project** — an unenrolled backend has previously been observed applying it as a direct edit; `_classify_suggest_error` maps this exact rejection shape to `suggest mode not available`.

Not live-tested: an actual merge-into-existing-suggestion (`updatedSummarySuggestionIds` without a created ID — covered by unit test only), and a live `ALL_FAILED_UNKNOWN_REASON`.

## Review status

- **CodeRabbit:** first pass 2 findings (epilog wording — fixed in `987188e`; CHANGELOG MD022 — rejected per repo convention, thread resolved by CodeRabbit). Re-review requested after each push; CodeRabbit may be rate-limited — a stale review state is not treated as an open finding.
- **Codex:** GitHub-native `@codex review` could not run (the alejoacelas account is not connected to Codex; no native Codex approval is claimed). An independent Codex worker reviewed `987188e` read-only and returned 5 findings, all accepted and fixed in `61e7ea3` (pre-write preview gate; UTF-16 style ranges; table/row/cell container suggestions; overlapping `--all` matches; post-write version-lookup failure) with regression tests. It found no separate issue in tab selection, revision pinning, response-ID flattening, or the shared `edit` refactor. A second Codex pass on `a884c3d` returned 3 findings (post-write transport errors; remaining code-point table/cleanup offsets in `edit`/`insert`; unclassified gate transport/refresh exceptions), all accepted and fixed in `89cad29` with regression tests.
- **Local independent review** (Claude, read-only, full diff): 6 findings — 5 fixed in `987188e`, 1 rejected (refusing matches *adjacent* to a suggestion: an adjacency merge is surfaced as `updatedSuggestionIds`).

## Known limits (v1)

- Inline Markdown only; no `--cell`. Structural forms need a live fixture per shape before being added.
- Overlap with any existing suggestion is refused; an explicit opt-in to merge could come later.
- Listing/accepting/rejecting suggestions is PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYNUuYcwoq1Jc2dEnKsGp6
