### PR TITLE
feat: list and decide native suggestion threads (developer preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ All notable changes to `gdoc` are documented here. This project follows
   `_prepare_text_replacement`) and one request builder
   (`_build_replacement_requests`); `edit` behaviour is unchanged.
 
+- **Suggestion threads: `suggestions`, `suggestion-info`,
+  `accept-suggestion`, `reject-suggestion`, `delete-suggestion`.** Reads
+  Google's native suggestion threads through the Docs API developer
+  preview (`documents.get?commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`,
+  sent over the authorized transport because the public Discovery document
+  doesn't list the parameter) and decides one suggestion per command with
+  `acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion`, pinned to
+  `requiredRevisionId`. Each decision checks `commentUpdateState`, then
+  reads the document back and only reports `OK` when the thread is in the
+  requested state. Threads carry no range, so each command derives the
+  tab and UTF-16 range(s) a suggestion touches from the
+  `SUGGESTIONS_INLINE` structure (`suggestedInsertionIds`,
+  `suggestedDeletionIds`, `suggested*Changes`, header/footer/footnote
+  segment IDs) and reports them separately from the raw thread. No Drive fallback: a project without preview access
+  gets an explicit error and no mutation. Permission failures name the
+  rule Google applies (accept: edit access; reject: edit access or author;
+  delete: author). `delete-suggestion` uses the standard destructive
+  confirmation / `--force`. All five are exposed over MCP.
+
 ### Fixed
 - **`edit --all` with a self-overlapping anchor** (`aa` matching twice in
   `aaa`) is refused before any write (exit 3) instead of corrupting the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,13 @@ All notable changes to `gdoc` are documented here. This project follows
   preview (`documents.get?commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`,
   sent over the authorized transport because the public Discovery document
   doesn't list the parameter) and decides one suggestion per command with
-  `acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion`, pinned to
-  `requiredRevisionId`. Each decision checks `commentUpdateState`, then
-  reads the document back and only reports `OK` when the thread is in the
-  requested state. Threads carry no range, so each command derives the
+  `acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion`. Accept is
+  always pinned to `requiredRevisionId`; reject/delete are pinned when the
+  read returned a revision and go unpinned only when it did not (a
+  suggestion's commenter-author may not receive one). Each decision
+  requires `commentUpdateState: ALL_SAVED` and its ID in
+  `suggestionResponses`, then reads the document back and only reports
+  `OK` when the thread is in the requested state. Threads carry no range, so each command derives the
   tab and UTF-16 range(s) a suggestion touches from the
   `SUGGESTIONS_INLINE` structure (`suggestedInsertionIds`,
   `suggestedDeletionIds`, `suggested*Changes`, header/footer/footnote

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ uv sync --extra dev
 
 2. **API layer** (`gdoc/api/`): Thin wrappers around Google APIs. Each module translates `HttpError` into `GdocError`/`AuthError` at the API boundary — the CLI layer does not catch `HttpError`. Service objects are `lru_cache`d per account: keyed by `account_cache_key()` (resolved account + token-file identity), so a long-lived multi-account process never serves one account another account's service, and a token re-auth/removal or default-account change is picked up on the next call. The active account is a `ContextVar`; long-lived servers scope it per call with `account_context()`.
    - `api/drive.py` — Drive v3: export, list, search, file info, update content, create, copy, share
-   - `api/docs.py` — Docs v1: `replace_all_text` (for the `edit` command)
+   - `api/docs.py` — Docs v1: `replace_all_text` (for the `edit` command); developer-preview requests (`insert_comment`, `get_document_threads`, `decide_suggestion`) keep all preview JSON shapes behind this boundary
    - `api/comments.py` — Drive v3 comments: list (paginated), create comment, create reply
 
 3. **Awareness system** (`gdoc/state.py` + `gdoc/notify.py`): Tracks per-document state in `~/.config/gdoc/state/{doc_id}.json`. Before most commands, `pre_flight()` detects changes (edits, new comments, resolved/reopened) since last interaction and prints a banner to stderr. The `write` command uses version tracking to prevent conflicts (blocks unless `--force`).

--- a/README.md
+++ b/README.md
@@ -245,9 +245,12 @@ gdoc cat 1aBcDeFg...
 
 These read Google's native suggestion threads (`documents.get` with
 `commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`) and send one
-`acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion` request per command,
-pinned to the revision that was just read. Unlike comments there is **no Drive
-fallback**: the OAuth client's Cloud project must be enrolled in the
+`acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion` request per command.
+`accept-suggestion` is always pinned to the revision that was just read (it
+needs edit access, which is also what Google requires for a `revisionId`);
+`reject-suggestion`/`delete-suggestion` are pinned whenever the read returned a
+revision and are sent unpinned only when it did not (a suggestion's author may
+be a commenter). Unlike comments there is **no Drive fallback**: the OAuth client's Cloud project must be enrolled in the
 [Workspace Developer Preview Program](https://developers.google.com/workspace/preview),
 otherwise the commands fail with an explicit "not enrolled" error (exit 1) and
 nothing is changed. A decision is only reported as `OK` after a read-back shows

--- a/README.md
+++ b/README.md
@@ -233,6 +233,32 @@ gdoc cat 1aBcDeFg...
 | `reopen DOC COMMENT_ID` | Reopen a resolved comment |
 | `delete-comment DOC ID` | Delete a comment (`--force` to skip confirmation) |
 
+### Suggestions (Docs API developer preview)
+
+| Command | Description |
+|---------|-------------|
+| `suggestions DOC` | List open suggestion threads with author, summary, and the tab/UTF-16 range(s) each touches (`--all` to include accepted/rejected) |
+| `suggestion-info DOC ID` | One suggestion thread in full (`--json` returns the raw thread plus derived `locations`) |
+| `accept-suggestion DOC ID` | Accept a suggested edit (requires edit access) |
+| `reject-suggestion DOC ID` | Reject a suggested edit (edit access, or the suggestion's author) |
+| `delete-suggestion DOC ID` | Delete a suggestion thread you authored (`--force` to skip confirmation) |
+
+These read Google's native suggestion threads (`documents.get` with
+`commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`) and send one
+`acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion` request per command,
+pinned to the revision that was just read. Unlike comments there is **no Drive
+fallback**: the OAuth client's Cloud project must be enrolled in the
+[Workspace Developer Preview Program](https://developers.google.com/workspace/preview),
+otherwise the commands fail with an explicit "not enrolled" error (exit 1) and
+nothing is changed. A decision is only reported as `OK` after a read-back shows
+the thread in the requested state; accepted and rejected threads stay listed
+under `--all` with that status, deleted ones disappear. Suggestion threads carry
+no range of their own, so the `@Tab start-end kind` lines (and `locations` in
+`--json`) are derived from the `SUGGESTIONS_INLINE` document structure keyed by
+suggestion ID — they are kept separate from the raw thread. Header, footer,
+and footnote ranges are labelled with their segment ID (their indexes restart
+at 0); marks with no range at all (document/named styles) print `(no range)`.
+
 `comment --quote "some doc text"` anchors the comment to the first occurrence
 of that text (all tabs are searched). When the OAuth client's Cloud project is
 enrolled in the

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2421,9 +2421,16 @@ def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
         })
 
     def marked_ids(node: dict, key: str) -> list[str]:
+        """Suggestion IDs under *key* in any of the three API shapes:
+        a list (suggestedInsertionIds/suggestedDeletionIds), a single
+        string (suggestedInsertionId on objects/lists), or a map keyed by
+        suggestion ID (Paragraph.suggestedPositionedObjectIds →
+        ObjectReferences)."""
         value = node.get(key)
         if isinstance(value, str):
             return [value]
+        if isinstance(value, dict):
+            return list(value)
         return list(value) if isinstance(value, list) else []
 
     def walk(node, ctx: dict, enclosing: dict) -> None:
@@ -2448,8 +2455,9 @@ def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
             add(sid, ctx, "insert", enclosing, text)
         for sid in marked_ids(node, "suggestedDeletionIds"):
             add(sid, ctx, "delete", enclosing, text)
-        # Paragraph.suggestedPositionedObjectIds: objects suggested to be
-        # anchored to this paragraph; the paragraph's range is the location.
+        # Paragraph.suggestedPositionedObjectIds (map suggestion ID →
+        # ObjectReferences): objects suggested to be anchored to this
+        # paragraph; the paragraph's range is the location.
         for sid in marked_ids(node, "suggestedPositionedObjectIds"):
             add(sid, ctx, "positioned-object", enclosing, text)
         for key, kind in _SUGGESTION_STYLE_KEYS.items():

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2568,8 +2568,8 @@ def decide_suggestion(
     # commenter and may not receive a revisionId. Neither request depends
     # on document coordinates, so they are sent unpinned in that case —
     # never with an empty requiredRevisionId.
+    service = get_docs_service()
     try:
-        service = get_docs_service()
         result = (
             service.documents()
             .batchUpdate(documentId=doc_id, body=body)
@@ -2600,6 +2600,16 @@ def decide_suggestion(
                 f"{message or e.reason}"
             )
         _translate_http_error(e, doc_id)
+    except Exception as e:  # noqa: BLE001 — .execute() is the network call
+        # A timeout/reset can arrive after Google applied the decision. Do
+        # not let an automated caller mistake this for a safe-to-retry
+        # pre-write failure, especially for destructive delete requests.
+        raise GdocError(
+            f"the {decision} request for suggestion {suggestion_id} failed "
+            f"in transit ({str(e) or type(e).__name__}). The outcome is "
+            "unknown — the decision may or may not have been applied. "
+            "Inspect `gdoc suggestions --all` before retrying."
+        )
 
     # A batch that must save a suggestion thread requires ALL_SAVED, and
     # the 1:1 suggestionResponses entry must name this ID (observed live:

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2375,6 +2375,7 @@ _SUGGESTION_STYLE_KEYS = {
     "suggestedDocumentStyleChanges": "document-style",
     "suggestedNamedStylesChanges": "named-styles",
     "suggestedListPropertiesChanges": "list-properties",
+    "suggestedDateElementPropertiesChanges": "date-properties",
 }
 
 # Non-body segments of a tab whose indexes restart at 0 (Docs API
@@ -2399,7 +2400,9 @@ def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
     meaningful together with it. Marks on objects that have no indexes at
     all (document style, named styles, the inlineObjects/lists maps) are
     reported with ``startIndex``/``endIndex`` of None rather than a fake
-    0-0 range. A textRun's insertion carries the same ID in its
+    0-0 range — unless the same insertion/deletion also appears on a
+    ranged element, in which case only the ranged entry is kept. A
+    textRun's insertion carries the same ID in its
     ``suggestedTextStyleChanges``; that mirror entry is dropped so plain
     insertions are not reported twice.
     """
@@ -2445,6 +2448,10 @@ def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
             add(sid, ctx, "insert", enclosing, text)
         for sid in marked_ids(node, "suggestedDeletionIds"):
             add(sid, ctx, "delete", enclosing, text)
+        # Paragraph.suggestedPositionedObjectIds: objects suggested to be
+        # anchored to this paragraph; the paragraph's range is the location.
+        for sid in marked_ids(node, "suggestedPositionedObjectIds"):
+            add(sid, ctx, "positioned-object", enclosing, text)
         for key, kind in _SUGGESTION_STYLE_KEYS.items():
             changes = node.get(key)
             if isinstance(changes, dict):
@@ -2455,7 +2462,7 @@ def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
         for key, value in node.items():
             if key in _SUGGESTION_STYLE_KEYS or key in (
                 "suggestedInsertionIds", "suggestedInsertionId",
-                "suggestedDeletionIds",
+                "suggestedDeletionIds", "suggestedPositionedObjectIds",
             ):
                 continue
             if key in _SEGMENT_MAPS and isinstance(value, dict):
@@ -2479,6 +2486,17 @@ def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
             walk_tabs(tab.get("childTabs", []))
 
     walk_tabs(doc.get("tabs", []))
+    # An inserted/deleted object is marked twice: on its ranged element in
+    # the paragraph and, without a range, in the inlineObjects/
+    # positionedObjects map. Keep the ranged one; unrelated no-range
+    # entries (e.g. an object-properties change) are preserved.
+    for sid, entries in locations.items():
+        if any(e["startIndex"] is not None for e in entries):
+            locations[sid] = [
+                e for e in entries
+                if e["startIndex"] is not None
+                or e["kind"] not in ("insert", "delete")
+            ]
     return locations
 
 
@@ -2507,10 +2525,12 @@ def decide_suggestion(
     """Send one acceptSuggestion/rejectSuggestion/deleteSuggestion request.
 
     One ID per call keeps a failure atomic and auditable. The write is
-    pinned to *revision_id* (must be non-empty: the caller has just read
-    the document, and an unpinned decision could land after a collaborator
-    changed it). The raw batchUpdate response is returned so the caller
-    can inspect ``suggestionResponses``/``commentUpdateState``; a
+    pinned to *revision_id* when the read returned one (editors always
+    get it; live, a commenter did too). Accept refuses to run unpinned;
+    reject/delete — which a commenter-author may perform — go unpinned
+    only when no revisionId was available. The raw batchUpdate response
+    is returned so the caller can inspect ``suggestionResponses`` /
+    ``commentUpdateState``; a
     ``commentUpdateState`` other than ALL_SAVED is raised here because it
     means the thread update was not durably saved.
 
@@ -2523,15 +2543,23 @@ def decide_suggestion(
     if decision not in SUGGESTION_DECISIONS:
         raise ValueError(f"unknown suggestion decision: {decision}")
     request_key, rule = SUGGESTION_DECISIONS[decision]
-    if not revision_id:
-        raise GdocError(
-            f"cannot {decision} suggestion: the document read returned no "
-            "revisionId (suggestion decisions need edit-level read access)"
-        )
-    body = {
+    body: dict = {
         "requests": [{request_key: {"suggestionId": suggestion_id}}],
-        "writeControl": {"requiredRevisionId": revision_id},
     }
+    if revision_id:
+        body["writeControl"] = {"requiredRevisionId": revision_id}
+    elif decision == "accept":
+        # Google documents revisionId as available to users with edit
+        # access, which accept requires anyway; without it we cannot pin
+        # the content change to what was just read, so refuse.
+        raise GdocError(
+            "cannot accept suggestion: the document read returned no "
+            "revisionId (accepting needs edit access)"
+        )
+    # reject/delete are also open to the suggestion's author, who may be a
+    # commenter and may not receive a revisionId. Neither request depends
+    # on document coordinates, so they are sent unpinned in that case —
+    # never with an empty requiredRevisionId.
     try:
         service = get_docs_service()
         result = (

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -2232,3 +2232,366 @@ def suggest_replacement(
                 "it as a pending suggestion; inspect the document."
             )
         return outcome
+# --- Suggestion threads (Workspace Developer Preview) ---------------------
+#
+# documents.get?commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED returns native
+# `suggestions[]` (and `comments[]`) threads. The parameter, the thread
+# schema, and the accept/reject/deleteSuggestion requests are preview-only:
+# the public Discovery document doesn't list them, so the discovery-built
+# client rejects the query parameter client-side ("unexpected keyword
+# argument"). The read therefore goes over the service's authorized HTTP
+# transport directly; the write requests travel in the opaque batchUpdate
+# body like insertComment does. Every preview shape is confined to the
+# helpers below.
+
+SUGGESTIONS_VIEW_MODE_INLINE = "SUGGESTIONS_INLINE"
+COMMENTS_VIEW_MODE_INCLUDED = "COMMENTS_VIEW_MODE_INCLUDED"
+_DOCS_BASE_URL = "https://docs.googleapis.com/v1/documents/"
+
+# batchUpdate request union member per decision, and the permission rule
+# Google documents for each (accept: edit access; reject: edit access or
+# suggestion author; delete: suggestion author).
+SUGGESTION_DECISION_STATUS = {
+    "accept": "accepted",
+    "reject": "rejected",
+    "delete": "deleted",
+}
+SUGGESTION_DECISIONS: dict[str, tuple[str, str]] = {
+    "accept": ("acceptSuggestion", "edit access"),
+    "reject": ("rejectSuggestion", "edit access or suggestion authorship"),
+    "delete": ("deleteSuggestion", "suggestion authorship"),
+}
+
+
+def _preview_parse_error(e: HttpError) -> bool:
+    """True when a 400 says the server didn't understand a preview field.
+
+    A project not enrolled in the Developer Preview sees preview fields as
+    unknown — rejected by name ("Unknown name", "Cannot find field") or
+    silently dropped so the request union is empty ("No request set").
+    """
+    if int(e.resp.status) != 400:
+        return False
+    detail = str(e)
+    return (
+        "Unknown name" in detail
+        or "Cannot find field" in detail
+        or "No request set" in detail
+    )
+
+
+def _documents_get_raw(service, doc_id: str, params: dict) -> dict:
+    """documents.get through the service's authorized transport.
+
+    Bypasses the discovery-generated method so preview query parameters
+    the public Discovery document doesn't list can be sent. Raises
+    HttpError on non-2xx exactly like a discovery-built call.
+    """
+    from urllib.parse import quote, urlencode
+
+    from googleapiclient.http import HttpRequest
+    from googleapiclient.model import JsonModel
+
+    uri = f"{_DOCS_BASE_URL}{quote(doc_id, safe='')}?{urlencode(params)}"
+    request = HttpRequest(
+        service._http, JsonModel().response, uri, method="GET",
+    )
+    return request.execute()
+
+
+def get_document_threads(doc_id: str) -> dict:
+    """Fetch the document with native comment and suggestion threads.
+
+    Reads with includeTabsContent=True, suggestionsViewMode=
+    SUGGESTIONS_INLINE (the only view whose indexes are valid for a later
+    write) and commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED, so the
+    response carries ``suggestions[]``/``comments[]`` plus ``revisionId``
+    and every tab's inline suggestion IDs.
+
+    Raises PreviewUnavailableError when the project lacks preview access
+    (Google rejects ``commentsViewMode`` as an unknown field). Other
+    HttpErrors are translated as usual.
+    """
+    params = {
+        "includeTabsContent": "true",
+        "suggestionsViewMode": SUGGESTIONS_VIEW_MODE_INLINE,
+        "commentsViewMode": COMMENTS_VIEW_MODE_INCLUDED,
+    }
+    try:
+        service = get_docs_service()
+        doc = _documents_get_raw(service, doc_id, params)
+    except HttpError as e:
+        if _preview_parse_error(e):
+            raise PreviewUnavailableError(
+                "suggestion threads are not available: the OAuth client's "
+                "Cloud project is not enrolled in the Workspace Developer "
+                "Preview (commentsViewMode rejected)"
+            )
+        _translate_http_error(e, doc_id)
+    if "suggestions" not in doc:
+        doc = {**doc, "suggestions": []}
+    return doc
+
+
+def _thread_author(thread: dict) -> str:
+    author = thread.get("headPost", {}).get("author", {})
+    return (
+        author.get("emailAddress")
+        or author.get("displayName")
+        or author.get("user")
+        or "unknown"
+    )
+
+
+def summarize_suggestion_thread(thread: dict) -> dict:
+    """Flatten a SuggestionThread into the fields the CLI prints.
+
+    Only fields observed live are read (suggestionId, status, headPost
+    author/createTime/updateTime, summaryText); everything else stays in
+    the raw thread, which callers pass through in --json.
+    """
+    head = thread.get("headPost", {})
+    replies = thread.get("replies") or thread.get("posts") or []
+    return {
+        "id": thread.get("suggestionId", ""),
+        "status": (thread.get("status") or "UNKNOWN").lower(),
+        "author": _thread_author(thread),
+        "author_is_me": bool(head.get("author", {}).get("me")),
+        "created": head.get("createTime", ""),
+        "updated": head.get("updateTime", ""),
+        "summary": thread.get("summaryText", ""),
+        "replies": len(replies),
+    }
+
+
+_SUGGESTION_STYLE_KEYS = {
+    "suggestedTextStyleChanges": "style",
+    "suggestedParagraphStyleChanges": "paragraph-style",
+    "suggestedBulletChanges": "bullet",
+    "suggestedTableRowStyleChanges": "table-row-style",
+    "suggestedTableCellStyleChanges": "table-cell-style",
+    "suggestedInlineObjectPropertiesChanges": "object-properties",
+    "suggestedPositionedObjectPropertiesChanges": "object-properties",
+    "suggestedDocumentStyleChanges": "document-style",
+    "suggestedNamedStylesChanges": "named-styles",
+    "suggestedListPropertiesChanges": "list-properties",
+}
+
+# Non-body segments of a tab whose indexes restart at 0 (Docs API
+# "segmentId" for range requests). Body content has no segment ID.
+_SEGMENT_MAPS = {"headers": "header", "footers": "footer", "footnotes": "footnote"}
+
+
+def collect_suggestion_locations(doc: dict) -> dict[str, list[dict]]:
+    """Derive where each suggestion touches the document.
+
+    SuggestionThread carries no range. In a SUGGESTIONS_INLINE read the
+    structure marks suggested content instead: ``suggestedInsertionIds`` /
+    ``suggestedDeletionIds`` (or the singular ``suggestedInsertionId`` on
+    inline/positioned objects and lists) on structural elements, and
+    ``suggested*Changes`` maps keyed by suggestion ID. This walks every
+    tab (including child tabs) and returns, per suggestion ID, a list of
+    ``{tab, tabId, segmentId, kind, startIndex, endIndex, text}`` entries
+    using the nearest enclosing element's UTF-16 indexes.
+
+    ``segmentId`` is "" for body content and the header/footer/footnote ID
+    otherwise — those segments' indexes restart at 0, so a range is only
+    meaningful together with it. Marks on objects that have no indexes at
+    all (document style, named styles, the inlineObjects/lists maps) are
+    reported with ``startIndex``/``endIndex`` of None rather than a fake
+    0-0 range. A textRun's insertion carries the same ID in its
+    ``suggestedTextStyleChanges``; that mirror entry is dropped so plain
+    insertions are not reported twice.
+    """
+    locations: dict[str, list[dict]] = {}
+
+    def add(sid: str, ctx: dict, kind: str, node: dict, text: str) -> None:
+        has_range = "startIndex" in node or "endIndex" in node
+        locations.setdefault(sid, []).append({
+            "tab": ctx["tab"],
+            "tabId": ctx["tabId"],
+            "segmentId": ctx["segmentId"],
+            "kind": kind,
+            "startIndex": node.get("startIndex", 0) if has_range else None,
+            "endIndex": node.get("endIndex", 0) if has_range else None,
+            "text": text,
+        })
+
+    def marked_ids(node: dict, key: str) -> list[str]:
+        value = node.get(key)
+        if isinstance(value, str):
+            return [value]
+        return list(value) if isinstance(value, list) else []
+
+    def walk(node, ctx: dict, enclosing: dict) -> None:
+        if isinstance(node, list):
+            for item in node:
+                walk(item, ctx, enclosing)
+            return
+        if not isinstance(node, dict):
+            return
+        # An element with its own indexes becomes the range for anything
+        # marked inside it that lacks indexes (e.g. paragraphStyle).
+        if "startIndex" in node or "endIndex" in node:
+            enclosing = node
+        text = node.get("content", "") if "textRun" in enclosing else ""
+        if isinstance(node.get("textRun"), dict):
+            text = node["textRun"].get("content", "")
+        inserted = (
+            marked_ids(node, "suggestedInsertionIds")
+            + marked_ids(node, "suggestedInsertionId")
+        )
+        for sid in inserted:
+            add(sid, ctx, "insert", enclosing, text)
+        for sid in marked_ids(node, "suggestedDeletionIds"):
+            add(sid, ctx, "delete", enclosing, text)
+        for key, kind in _SUGGESTION_STYLE_KEYS.items():
+            changes = node.get(key)
+            if isinstance(changes, dict):
+                for sid in changes:
+                    if key == "suggestedTextStyleChanges" and sid in inserted:
+                        continue  # style of the inserted text itself
+                    add(sid, ctx, kind, enclosing, text)
+        for key, value in node.items():
+            if key in _SUGGESTION_STYLE_KEYS or key in (
+                "suggestedInsertionIds", "suggestedInsertionId",
+                "suggestedDeletionIds",
+            ):
+                continue
+            if key in _SEGMENT_MAPS and isinstance(value, dict):
+                for segment_id, segment in value.items():
+                    walk(segment, {**ctx, "segmentId": segment_id}, {})
+                continue
+            if isinstance(value, (dict, list)):
+                walk(value, ctx, enclosing)
+
+    def walk_tabs(tabs: list[dict]) -> None:
+        for tab in tabs:
+            props = tab.get("tabProperties", {})
+            ctx = {
+                "tab": props.get("title", ""),
+                "tabId": props.get("tabId", ""),
+                "segmentId": "",
+            }
+            doc_tab = tab.get("documentTab")
+            if isinstance(doc_tab, dict):
+                walk(doc_tab, ctx, {})
+            walk_tabs(tab.get("childTabs", []))
+
+    walk_tabs(doc.get("tabs", []))
+    return locations
+
+
+def sorted_suggestion_threads(doc: dict) -> list[dict]:
+    """Threads ordered by head-post createTime (the API order is arbitrary)."""
+    return sorted(
+        doc.get("suggestions", []),
+        key=lambda t: t.get("headPost", {}).get("createTime", ""),
+    )
+
+
+def find_suggestion_thread(doc: dict, suggestion_id: str) -> dict | None:
+    """Return the SuggestionThread with *suggestion_id*, or None."""
+    for thread in doc.get("suggestions", []):
+        if thread.get("suggestionId") == suggestion_id:
+            return thread
+    return None
+
+
+def decide_suggestion(
+    doc_id: str,
+    suggestion_id: str,
+    decision: str,
+    revision_id: str,
+) -> dict:
+    """Send one acceptSuggestion/rejectSuggestion/deleteSuggestion request.
+
+    One ID per call keeps a failure atomic and auditable. The write is
+    pinned to *revision_id* (must be non-empty: the caller has just read
+    the document, and an unpinned decision could land after a collaborator
+    changed it). The raw batchUpdate response is returned so the caller
+    can inspect ``suggestionResponses``/``commentUpdateState``; a
+    ``commentUpdateState`` other than ALL_SAVED is raised here because it
+    means the thread update was not durably saved.
+
+    Raises:
+        GdocError: revision mismatch (exit 1, "re-run"), permission denied
+            with the rule for this decision, missing revision ID, or other
+            API errors.
+        PreviewUnavailableError: the project lacks preview access.
+    """
+    if decision not in SUGGESTION_DECISIONS:
+        raise ValueError(f"unknown suggestion decision: {decision}")
+    request_key, rule = SUGGESTION_DECISIONS[decision]
+    if not revision_id:
+        raise GdocError(
+            f"cannot {decision} suggestion: the document read returned no "
+            "revisionId (suggestion decisions need edit-level read access)"
+        )
+    body = {
+        "requests": [{request_key: {"suggestionId": suggestion_id}}],
+        "writeControl": {"requiredRevisionId": revision_id},
+    }
+    try:
+        service = get_docs_service()
+        result = (
+            service.documents()
+            .batchUpdate(documentId=doc_id, body=body)
+            .execute()
+        )
+    except HttpError as e:
+        status = int(e.resp.status)
+        if _preview_parse_error(e):
+            raise PreviewUnavailableError(
+                f"{request_key} is not available: the OAuth client's Cloud "
+                "project is not enrolled in the Workspace Developer Preview"
+            )
+        _raise_if_stale_revision(e)
+        if status == 403:
+            raise GdocError(
+                f"Permission denied: cannot {decision} suggestion "
+                f"{suggestion_id} ({decision} requires {rule})"
+            )
+        message = _error_message(e)
+        if status == 404 and "uggestion" in message:
+            # Observed live: "Suggestion with ID suggest.x does not exist."
+            raise GdocError(
+                f"suggestion not found: {suggestion_id}", exit_code=3,
+            )
+        if status == 400:
+            raise GdocError(
+                f"cannot {decision} suggestion {suggestion_id}: "
+                f"{message or e.reason}"
+            )
+        _translate_http_error(e, doc_id)
+
+    # A batch that must save a suggestion thread requires ALL_SAVED, and
+    # the 1:1 suggestionResponses entry must name this ID (observed live:
+    # {"acceptedSuggestionIds": [...]} etc.). Anything else is a failure,
+    # never a silent success — the caller's read-back then reports the
+    # thread's real state.
+    state = result.get("commentUpdateState", "")
+    if state != "ALL_SAVED":
+        raise GdocError(
+            f"suggestion {decision} not saved "
+            f"(commentUpdateState={state or 'missing'}); re-read the "
+            "document before retrying"
+        )
+    responses = result.get("suggestionResponses") or [{}]
+    key = f"{SUGGESTION_DECISION_STATUS[decision]}SuggestionIds"
+    if suggestion_id not in (responses[0] or {}).get(key, []):
+        raise GdocError(
+            f"suggestion {decision} response did not report {suggestion_id} "
+            f"under {key}; re-run `gdoc suggestions --all` to see its state"
+        )
+    return result
+
+
+def _error_message(e: HttpError) -> str:
+    """Google's error message from the response body, or ""."""
+    try:
+        import json
+
+        return str(json.loads(e.content.decode("utf-8"))["error"]["message"])
+    except Exception:  # noqa: BLE001 - best effort decoration only
+        return ""

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3171,7 +3171,8 @@ def cmd_suggestion_info(args) -> int:
         print(f"status\t{summary['status']}")
         print(f"author\t{summary['author']}")
         print(f"created\t{summary['created']}")
-        print(f"summary\t{summary['summary']}")
+        summary_text = summary["summary"].replace("\t", " ").replace("\n", " ")
+        print(f"summary\t{summary_text}")
         for loc in locations:
             print(f"location\t{_plain_suggestion_location(loc)}")
         print(f"replies\t{summary['replies']}")

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3027,6 +3027,274 @@ def cmd_replace_image(args) -> int:
     return 0
 
 
+# --- Suggestion threads (Docs API developer preview) ----------------------
+
+
+def _suggestion_range(loc: dict) -> str:
+    if loc.get("startIndex") is None:
+        return "(no range)"
+    return f"{loc['startIndex']}-{loc['endIndex']}"
+
+
+def _format_suggestion_location(loc: dict) -> str:
+    tab = loc.get("tab") or loc.get("tabId") or "?"
+    seg = f" {loc['segmentId']}" if loc.get("segmentId") else ""
+    return f"@{tab}{seg} {_suggestion_range(loc)} {loc['kind']}"
+
+
+def _plain_suggestion_location(loc: dict) -> str:
+    """Machine-readable location: tabId[/segmentId]:start-end:kind."""
+    where = loc.get("tabId", "")
+    if loc.get("segmentId"):
+        where += f"/{loc['segmentId']}"
+    return f"{where}:{_suggestion_range(loc)}:{loc['kind']}"
+
+
+def _print_suggestion_thread(summary: dict, locations: list[dict], mode: str,
+                             replies_label: bool = True) -> None:
+    """Terse/verbose block for one suggestion thread."""
+    created = summary["created"]
+    date_str = created if mode == "verbose" else created[:10]
+    author = summary["author"] + (" (me)" if summary["author_is_me"] else "")
+    print(f"#{summary['id']} [{summary['status']}] {author} {date_str}")
+    if summary["summary"]:
+        print(f"  {summary['summary']}")
+    for loc in locations:
+        line = f"  {_format_suggestion_location(loc)}"
+        if mode == "verbose" and loc.get("text"):
+            snippet = loc["text"].replace("\n", "\\n")
+            line += f' "{snippet}"'
+        print(line)
+    if not locations:
+        print("  (no inline location found)")
+    if mode == "verbose":
+        print(f"  Modified: {summary['updated']}")
+    if replies_label and summary["replies"]:
+        label = "reply" if summary["replies"] == 1 else "replies"
+        print(f"  {summary['replies']} {label}")
+
+
+def cmd_suggestions(args) -> int:
+    """Handler for `gdoc suggestions`: list native suggestion threads."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    include_all = getattr(args, "all", False)
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+
+    from gdoc.api.docs import (
+        collect_suggestion_locations,
+        get_document_threads,
+        sorted_suggestion_threads,
+        summarize_suggestion_thread,
+    )
+    doc = get_document_threads(doc_id)
+    threads = sorted_suggestion_threads(doc)
+    if not include_all:
+        threads = [t for t in threads if t.get("status") == "OPEN"]
+    locations = collect_suggestion_locations(doc)
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(
+            suggestions=threads,
+            locations={
+                t.get("suggestionId", ""): locations.get(
+                    t.get("suggestionId", ""), [],
+                )
+                for t in threads
+            },
+            revisionId=doc.get("revisionId", ""),
+        ))
+    elif mode == "plain":
+        for t in threads:
+            s = summarize_suggestion_thread(t)
+            locs = ";".join(
+                _plain_suggestion_location(loc)
+                for loc in locations.get(s["id"], [])
+            )
+            summary = s["summary"].replace("\t", " ").replace("\n", " ")
+            print(f"{s['id']}\t{s['status']}\t{s['author']}\t{summary}\t{locs}")
+    elif not threads:
+        print("No suggestions." if include_all else "No open suggestions.")
+    else:
+        for t in threads:
+            s = summarize_suggestion_thread(t)
+            _print_suggestion_thread(s, locations.get(s["id"], []), mode)
+
+    from gdoc.state import update_state_after_command
+    update_state_after_command(
+        doc_id, change_info, command="suggestions", quiet=quiet,
+    )
+    return 0
+
+
+def cmd_suggestion_info(args) -> int:
+    """Handler for `gdoc suggestion-info`."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    suggestion_id = args.suggestion_id
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+
+    from gdoc.api.docs import (
+        collect_suggestion_locations,
+        find_suggestion_thread,
+        get_document_threads,
+        summarize_suggestion_thread,
+    )
+    doc = get_document_threads(doc_id)
+    thread = find_suggestion_thread(doc, suggestion_id)
+    if thread is None:
+        raise GdocError(
+            f"suggestion not found: {suggestion_id} "
+            "(`gdoc suggestions DOC --all` lists thread IDs)",
+            exit_code=3,
+        )
+    locations = collect_suggestion_locations(doc).get(suggestion_id, [])
+    summary = summarize_suggestion_thread(thread)
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    if mode == "json":
+        print(format_json(
+            suggestion=thread, locations=locations,
+            revisionId=doc.get("revisionId", ""),
+        ))
+    elif mode == "plain":
+        print(f"id\t{summary['id']}")
+        print(f"status\t{summary['status']}")
+        print(f"author\t{summary['author']}")
+        print(f"created\t{summary['created']}")
+        print(f"summary\t{summary['summary']}")
+        for loc in locations:
+            print(f"location\t{_plain_suggestion_location(loc)}")
+        print(f"replies\t{summary['replies']}")
+    else:
+        _print_suggestion_thread(summary, locations, mode)
+
+    from gdoc.state import update_state_after_command
+    update_state_after_command(
+        doc_id, change_info, command="suggestion-info", quiet=quiet,
+    )
+    return 0
+
+
+def _decide_suggestion(args, decision: str) -> int:
+    """Shared body of accept-/reject-/delete-suggestion.
+
+    Reads the thread (SUGGESTIONS_INLINE, so the revision is the one the
+    write is pinned to), refuses IDs that are unknown or already decided,
+    sends exactly one decision request, then reads back and requires the
+    thread to have left the OPEN state before reporting success.
+    """
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    suggestion_id = args.suggestion_id
+    command = f"{decision}-suggestion"
+    from gdoc.api.docs import SUGGESTION_DECISION_STATUS
+    final_status = SUGGESTION_DECISION_STATUS[decision]
+
+    if decision == "delete":
+        from gdoc.util import confirm_destructive
+        confirm_destructive(
+            f"delete suggestion #{suggestion_id}",
+            force=getattr(args, "force", False),
+        )
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+    _require_doc(doc_id, change_info)
+
+    from gdoc.api.docs import (
+        decide_suggestion,
+        find_suggestion_thread,
+        get_document_threads,
+        summarize_suggestion_thread,
+    )
+    doc = get_document_threads(doc_id)
+    thread = find_suggestion_thread(doc, suggestion_id)
+    if thread is None:
+        raise GdocError(
+            f"suggestion not found: {suggestion_id} "
+            "(`gdoc suggestions DOC --all` lists thread IDs)",
+            exit_code=3,
+        )
+    before = summarize_suggestion_thread(thread)
+    if before["status"] != "open":
+        raise GdocError(
+            f"suggestion {suggestion_id} is already {before['status']}",
+            exit_code=3,
+        )
+
+    result = decide_suggestion(
+        doc_id, suggestion_id, decision, doc.get("revisionId", ""),
+    )
+
+    # A 200 is not proof: read back and require the thread to be in the
+    # requested state. Observed live: accepted/rejected threads stay
+    # listed with that status; a deleted thread disappears.
+    after_doc = get_document_threads(doc_id)
+    after = find_suggestion_thread(after_doc, suggestion_id)
+    after_status = (
+        summarize_suggestion_thread(after)["status"] if after else "gone"
+    )
+    expected = "gone" if decision == "delete" else final_status
+    if after_status != expected:
+        raise GdocError(
+            f"{decision} request returned OK but suggestion "
+            f"{suggestion_id} reads back as {after_status} (expected "
+            f"{expected}); the decision may still have been applied — "
+            "check `gdoc suggestions --all`"
+        )
+
+    from gdoc.api.drive import get_file_version
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    if mode == "json":
+        extra = {}
+        if "suggestionResponses" in result:
+            extra["suggestionResponses"] = result["suggestionResponses"]
+        print(format_json(
+            id=suggestion_id, status=final_status, threadStatus=after_status,
+            **extra,
+        ))
+    elif mode == "plain":
+        print(f"id\t{suggestion_id}")
+        print(f"status\t{final_status}")
+    else:
+        print(f"OK {final_status} suggestion #{suggestion_id}")
+
+    from gdoc.state import update_state_after_command
+    update_state_after_command(
+        doc_id, change_info, command=command, quiet=quiet,
+        command_version=command_version,
+    )
+    return 0
+
+
+def cmd_accept_suggestion(args) -> int:
+    """Handler for `gdoc accept-suggestion`."""
+    return _decide_suggestion(args, "accept")
+
+
+def cmd_reject_suggestion(args) -> int:
+    """Handler for `gdoc reject-suggestion`."""
+    return _decide_suggestion(args, "reject")
+
+
+def cmd_delete_suggestion(args) -> int:
+    """Handler for `gdoc delete-suggestion`."""
+    return _decide_suggestion(args, "delete")
+
+
 def cmd_structure(args) -> int:
     """Handler for `gdoc structure`: raw document JSON for native edits."""
     import json
@@ -4298,6 +4566,79 @@ def build_parser() -> GdocArgumentParser:
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     ci_p.set_defaults(func=cmd_comment_info)
+
+    # suggestions (Docs API developer preview)
+    sugg_p = sub.add_parser(
+        "suggestions", parents=[output_parent],
+        help="List suggested edits (native suggestion threads)",
+        description=(
+            "List the document's native suggestion threads (Docs API "
+            "Workspace Developer Preview; requires an enrolled OAuth "
+            "client project). Each thread shows its ID, status, author, "
+            "summary, and the tab/UTF-16 range(s) it touches, derived "
+            "from the SUGGESTIONS_INLINE structure. Read-only."
+        ),
+    )
+    sugg_p.add_argument("doc", help="Document ID or URL")
+    sugg_p.add_argument(
+        "--all", action="store_true",
+        help="Include accepted/rejected threads (default: open only)",
+    )
+    sugg_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    sugg_p.set_defaults(func=cmd_suggestions)
+
+    # suggestion-info
+    si_p = sub.add_parser(
+        "suggestion-info", parents=[output_parent],
+        help="Get a single suggestion thread by ID",
+    )
+    si_p.add_argument("doc", help="Document ID or URL")
+    si_p.add_argument("suggestion_id", help="Suggestion ID (suggest.xxx)")
+    si_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    si_p.set_defaults(func=cmd_suggestion_info)
+
+    # accept-suggestion
+    acc_p = sub.add_parser(
+        "accept-suggestion", parents=[output_parent],
+        help="Accept a suggested edit (requires edit access)",
+    )
+    acc_p.add_argument("doc", help="Document ID or URL")
+    acc_p.add_argument("suggestion_id", help="Suggestion ID to accept")
+    acc_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    acc_p.set_defaults(func=cmd_accept_suggestion)
+
+    # reject-suggestion
+    rej_p = sub.add_parser(
+        "reject-suggestion", parents=[output_parent],
+        help="Reject a suggested edit (edit access or its author)",
+    )
+    rej_p.add_argument("doc", help="Document ID or URL")
+    rej_p.add_argument("suggestion_id", help="Suggestion ID to reject")
+    rej_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks"
+    )
+    rej_p.set_defaults(func=cmd_reject_suggestion)
+
+    # delete-suggestion
+    dels_p = sub.add_parser(
+        "delete-suggestion", parents=[output_parent],
+        help="Delete a suggestion thread you authored",
+    )
+    dels_p.add_argument("doc", help="Document ID or URL")
+    dels_p.add_argument("suggestion_id", help="Suggestion ID to delete")
+    dels_p.add_argument(
+        "--force", action="store_true", help="Skip confirmation prompt",
+    )
+    dels_p.add_argument(
+        "--quiet", action="store_true", help="Skip pre-flight checks",
+    )
+    dels_p.set_defaults(func=cmd_delete_suggestion)
 
     # images
     images_p = sub.add_parser(

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3239,7 +3239,16 @@ def _decide_suggestion(args, decision: str) -> int:
     # A 200 is not proof: read back and require the thread to be in the
     # requested state. Observed live: accepted/rejected threads stay
     # listed with that status; a deleted thread disappears.
-    after_doc = get_document_threads(doc_id)
+    try:
+        after_doc = get_document_threads(doc_id)
+    except Exception as e:  # noqa: BLE001 — the decision is already saved
+        raise GdocError(
+            f"suggestion {suggestion_id} was reported saved after "
+            f"{decision}, but verification failed "
+            f"({str(e) or type(e).__name__}). The decision may already "
+            "have been applied — inspect `gdoc suggestions --all` before "
+            "retrying."
+        )
     after = find_suggestion_thread(after_doc, suggestion_id)
     after_status = (
         summarize_suggestion_thread(after)["status"] if after else "gone"
@@ -3253,8 +3262,17 @@ def _decide_suggestion(args, decision: str) -> int:
             "check `gdoc suggestions --all`"
         )
 
+    # The decision is saved and verified at this point. Awareness
+    # bookkeeping must not turn that success into an ordinary failure that
+    # encourages an unsafe retry.
     from gdoc.api.drive import get_file_version
-    command_version = get_file_version(doc_id).get("version")
+
+    version_error = None
+    command_version = None
+    try:
+        command_version = get_file_version(doc_id).get("version")
+    except Exception as e:  # noqa: BLE001 — post-mutation bookkeeping
+        version_error = e
 
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)
@@ -3272,11 +3290,27 @@ def _decide_suggestion(args, decision: str) -> int:
     else:
         print(f"OK {final_status} suggestion #{suggestion_id}")
 
+    if version_error is not None:
+        print(
+            f"WARN: suggestion #{suggestion_id} is {final_status}, but the "
+            f"document version could not be refreshed: {version_error}; "
+            "awareness state not updated",
+            file=sys.stderr,
+        )
+        return 0
+
     from gdoc.state import update_state_after_command
-    update_state_after_command(
-        doc_id, change_info, command=command, quiet=quiet,
-        command_version=command_version,
-    )
+    try:
+        update_state_after_command(
+            doc_id, change_info, command=command, quiet=quiet,
+            command_version=command_version,
+        )
+    except Exception as e:  # noqa: BLE001 — post-mutation local state
+        print(
+            f"WARN: suggestion #{suggestion_id} is {final_status}, but "
+            f"awareness state was not persisted: {e}",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -57,6 +57,8 @@ EXPOSED_COMMANDS: dict[str, bool] = {
     "revisions": True,
     "comments": True,
     "comment-info": True,
+    "suggestions": True,
+    "suggestion-info": True,
     "diff": True,
     "images": True,
     "structure": True,
@@ -73,6 +75,9 @@ EXPOSED_COMMANDS: dict[str, bool] = {
     "resolve": False,
     "reopen": False,
     "delete-comment": False,
+    "accept-suggestion": False,
+    "reject-suggestion": False,
+    "delete-suggestion": False,
     "new": False,
     "cp": False,
     "mkdir": False,
@@ -140,6 +145,7 @@ _EXTRA_REQUIRED: dict[str, tuple[str, ...]] = {
     # --old-file/--new-file are hidden over MCP and suggest has no cell
     # mode, so the text pair is the only way to supply the replacement
     "suggest": ("old_text", "new_text"),
+    "delete-suggestion": ("force",),
 }
 
 # Cross-parameter requirements JSON Schema could only express with a
@@ -456,7 +462,9 @@ def call_command(
 
     # Schema `required` cannot force a boolean to be true, so guard here:
     # with stdin detached, confirm_destructive() can never prompt.
-    if command == "delete-comment" and not arguments.get("force"):
+    if command in ("delete-comment", "delete-suggestion") and not arguments.get(
+        "force"
+    ):
         raise ValueError(
             "`force: true` is required: deletion cannot prompt for "
             "confirmation over MCP"

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -28,8 +28,10 @@ class PreviewUnavailableError(GdocError):
     Raised when a preview-gated batchUpdate request (e.g. insertComment) is
     rejected because the Cloud project isn't enrolled in the Workspace
     Developer Preview Program, or the user's access level can't batchUpdate.
-    Callers catch this to fall back to a generally-available code path; it
-    should never surface to the user as a failure.
+    Callers with a generally-available equivalent (comment --quote → Drive
+    comment) catch it and fall back silently. Commands with no equivalent
+    (suggestion threads and decisions) let it surface as an ordinary
+    exit-1 error so nothing is mutated behind the user's back.
     """
 
 

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -246,6 +246,31 @@ class TestDocumentsGetRaw:
 # --- derived locations / summaries ----------------------------------------
 
 
+def _single_tab_doc(body, **document_tab_extras):
+    """One tab "Main"/t.0 with the given body content and extra
+    documentTab keys (headers, footers, footnotes, inlineObjects, ...)."""
+    return {
+        "tabs": [
+            {
+                "tabProperties": {"tabId": "t.0", "title": "Main"},
+                "documentTab": {"body": {"content": body}, **document_tab_extras},
+            }
+        ]
+    }
+
+
+def _loc(kind, start, end, segment="", text=""):
+    return {
+        "tab": "Main",
+        "tabId": "t.0",
+        "segmentId": segment,
+        "kind": kind,
+        "startIndex": start,
+        "endIndex": end,
+        "text": text,
+    }
+
+
 class TestCollectSuggestionLocations:
     def test_insert_delete_style_and_child_tab(self):
         locs = collect_suggestion_locations(_DOC)
@@ -408,8 +433,165 @@ class TestCollectSuggestionLocations:
             }
         ]
 
-    def test_legacy_body_shape_and_no_marks(self):
-        assert collect_suggestion_locations({"body": {"content": []}}) == {}
+    def test_pure_style_change_is_reported(self):
+        doc = _single_tab_doc(
+            body=[
+                {
+                    "startIndex": 1,
+                    "endIndex": 6,
+                    "paragraph": {
+                        "elements": [
+                            _text_run(
+                                1,
+                                6,
+                                "gamma",
+                                suggestedTextStyleChanges={"suggest.c": {}},
+                            )
+                        ]
+                    },
+                }
+            ]
+        )
+        assert collect_suggestion_locations(doc)["suggest.c"] == [
+            _loc("style", 1, 6, text="gamma")
+        ]
+
+    def test_header_footer_footnote_carry_segment_id(self):
+        # Segment indexes restart at 0: a header range 0-4 must not be
+        # confused with body 0-4.
+        def seg(start, end, text, **marks):
+            return {
+                "content": [
+                    {
+                        "startIndex": start,
+                        "endIndex": end,
+                        "paragraph": {
+                            "elements": [_text_run(start, end, text, **marks)]
+                        },
+                    }
+                ]
+            }
+
+        doc = _single_tab_doc(
+            body=[
+                {
+                    "startIndex": 0,
+                    "endIndex": 4,
+                    "paragraph": {"elements": [_text_run(0, 4, "body")]},
+                }
+            ],
+            headers={"h1": seg(0, 4, "head", suggestedInsertionIds=["suggest.hd"])},
+            footers={"f1": seg(0, 3, "foo", suggestedDeletionIds=["suggest.ft"])},
+            footnotes={
+                "kix.fn": seg(0, 5, "note\n", suggestedInsertionIds=["suggest.fn"])
+            },
+        )
+        locs = collect_suggestion_locations(doc)
+        assert locs["suggest.hd"] == [_loc("insert", 0, 4, segment="h1", text="head")]
+        assert locs["suggest.ft"] == [_loc("delete", 0, 3, segment="f1", text="foo")]
+        assert locs["suggest.fn"] == [
+            _loc("insert", 0, 5, segment="kix.fn", text="note\n")
+        ]
+
+    def test_object_and_list_maps_singular_id_and_no_fake_range(self):
+        doc = _single_tab_doc(
+            body=[],
+            inlineObjects={
+                "kix.img": {
+                    "objectId": "kix.img",
+                    "suggestedInsertionId": "suggest.img",
+                    "suggestedDeletionIds": ["suggest.rm"],
+                }
+            },
+            lists={"kix.l": {"suggestedListPropertiesChanges": {"suggest.lp": {}}}},
+            suggestedDocumentStyleChanges={"suggest.ds": {}},
+        )
+        locs = collect_suggestion_locations(doc)
+        assert locs["suggest.img"] == [_loc("insert", None, None)]
+        assert locs["suggest.rm"] == [_loc("delete", None, None)]
+        assert locs["suggest.lp"] == [_loc("list-properties", None, None)]
+        assert locs["suggest.ds"] == [_loc("document-style", None, None)]
+
+    def test_date_properties_and_positioned_object_ids(self):
+        doc = _single_tab_doc(
+            body=[
+                {
+                    "startIndex": 1,
+                    "endIndex": 12,
+                    "paragraph": {
+                        "elements": [
+                            _text_run(1, 6, "when "),
+                            {
+                                "startIndex": 6,
+                                "endIndex": 7,
+                                "dateElement": {
+                                    "dateElementProperties": {},
+                                    "suggestedDateElementPropertiesChanges": {
+                                        "suggest.date": {}
+                                    },
+                                },
+                            },
+                            _text_run(7, 12, " ok\n"),
+                        ],
+                        "positionedObjectIds": [],
+                        "suggestedPositionedObjectIds": ["suggest.pos"],
+                    },
+                }
+            ],
+            positionedObjects={
+                "kix.pos": {
+                    "objectId": "kix.pos",
+                    "suggestedInsertionId": "suggest.pos",
+                }
+            },
+        )
+        locs = collect_suggestion_locations(doc)
+        assert locs["suggest.date"] == [_loc("date-properties", 6, 7)]
+        # The paragraph anchor is ranged; the positionedObjects-map mirror
+        # (no range, kind insert) is dropped in its favour.
+        assert locs["suggest.pos"] == [_loc("positioned-object", 1, 12)]
+
+    def test_object_map_mirror_deduped_but_property_change_kept(self):
+        doc = _single_tab_doc(
+            body=[
+                {
+                    "startIndex": 1,
+                    "endIndex": 3,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 1,
+                                "endIndex": 2,
+                                "inlineObjectElement": {
+                                    "inlineObjectId": "kix.img",
+                                    "suggestedInsertionIds": ["suggest.img"],
+                                },
+                            },
+                            _text_run(2, 3, "\n"),
+                        ]
+                    },
+                }
+            ],
+            inlineObjects={
+                "kix.img": {
+                    "objectId": "kix.img",
+                    "suggestedInsertionId": "suggest.img",
+                    "suggestedInlineObjectPropertiesChanges": {
+                        "suggest.img": {},
+                        "suggest.props": {},
+                    },
+                }
+            },
+        )
+        locs = collect_suggestion_locations(doc)
+        assert locs["suggest.img"] == [
+            _loc("insert", 1, 2),
+            _loc("object-properties", None, None),
+        ]
+        assert locs["suggest.props"] == [_loc("object-properties", None, None)]
+
+    def test_no_tabs_or_marks(self):
+        assert collect_suggestion_locations({"tabs": []}) == {}
         assert collect_suggestion_locations({}) == {}
 
 
@@ -507,10 +689,37 @@ class TestDecideSuggestion:
         }
 
     @patch("gdoc.api.docs.get_docs_service")
-    def test_empty_revision_never_sent(self, mock_svc):
+    def test_accept_without_revision_is_refused_before_any_call(self, mock_svc):
         with pytest.raises(GdocError, match="no revisionId"):
             decide_suggestion("doc1", "suggest.a", "accept", "")
         mock_svc.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "decision,key,resp_key",
+        [
+            ("reject", "rejectSuggestion", "rejectedSuggestionIds"),
+            ("delete", "deleteSuggestion", "deletedSuggestionIds"),
+        ],
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_reject_delete_without_revision_go_unpinned(
+        self, mock_svc, decision, key, resp_key
+    ):
+        # A commenter-author may reject/delete their own suggestion and may
+        # not receive a revisionId; the request then carries no writeControl
+        # at all — never requiredRevisionId: "".
+        service = _mock_docs_service(
+            {
+                "replies": [{}],
+                "suggestionResponses": [{resp_key: ["suggest.a"]}],
+                "commentUpdateState": "ALL_SAVED",
+            }
+        )
+        mock_svc.return_value = service
+        decide_suggestion("doc1", "suggest.a", decision, "")
+        assert _batch_body(service) == {
+            "requests": [{key: {"suggestionId": "suggest.a"}}],
+        }
 
     def test_unknown_decision_is_programming_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -534,7 +534,10 @@ class TestCollectSuggestionLocations:
                             _text_run(7, 12, " ok\n"),
                         ],
                         "positionedObjectIds": [],
-                        "suggestedPositionedObjectIds": ["suggest.pos"],
+                        # API shape: map keyed by suggestion ID.
+                        "suggestedPositionedObjectIds": {
+                            "suggest.pos": {"objectIds": ["kix.pos"]}
+                        },
                     },
                 }
             ],

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -828,6 +828,20 @@ class TestDecideSuggestion:
             decide_suggestion("doc1", "suggest.a", "accept", "rev1")
 
     @patch("gdoc.api.docs.get_docs_service")
+    def test_transport_failure_is_indeterminate(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=TimeoutError("timed out")
+        )
+        with pytest.raises(
+            GdocError,
+            match=(
+                "accept request for suggestion suggest.a failed in transit.*"
+                "outcome is unknown.*Inspect `gdoc suggestions --all`"
+            ),
+        ):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
     def test_partial_save_failure_is_an_error(self, mock_svc):
         mock_svc.return_value = _mock_docs_service(
             {
@@ -1314,6 +1328,55 @@ class TestCmdDecisions:
                 )
         assert capsys.readouterr().out == ""
         mock_update.assert_not_called()
+
+    def test_failed_read_back_reports_saved_but_unverified(self, capsys):
+        p = _decision_patches("ACCEPTED")
+        with p[0] as mock_update, p[1], p[2], p[3], p[4] as mock_get:
+            mock_get.side_effect = [_DOC, TimeoutError("timed out")]
+            with pytest.raises(
+                GdocError,
+                match=(
+                    "suggestion suggest.a was reported saved after accept.*"
+                    "verification failed.*may already have been applied"
+                ),
+            ):
+                cmd_accept_suggestion(
+                    _args("accept-suggestion", suggestion_id="suggest.a")
+                )
+        assert capsys.readouterr().out == ""
+        mock_update.assert_not_called()
+
+    def test_version_failure_warns_after_verified_success(self, capsys):
+        p = _decision_patches("ACCEPTED")
+        with p[0] as mock_update, p[1], p[2] as mock_version, p[3], p[4]:
+            mock_version.side_effect = TimeoutError("timed out")
+            rc = cmd_accept_suggestion(
+                _args("accept-suggestion", suggestion_id="suggest.a")
+            )
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out == "OK accepted suggestion #suggest.a\n"
+        assert (
+            "WARN: suggestion #suggest.a is accepted, but the document "
+            "version could not be refreshed: timed out; awareness state "
+            "not updated"
+        ) in captured.err
+        mock_update.assert_not_called()
+
+    def test_state_failure_warns_after_verified_success(self, capsys):
+        p = _decision_patches("ACCEPTED")
+        with p[0] as mock_update, p[1], p[2], p[3], p[4]:
+            mock_update.side_effect = OSError("disk full")
+            rc = cmd_accept_suggestion(
+                _args("accept-suggestion", suggestion_id="suggest.a")
+            )
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out == "OK accepted suggestion #suggest.a\n"
+        assert (
+            "WARN: suggestion #suggest.a is accepted, but awareness state "
+            "was not persisted: disk full"
+        ) in captured.err
 
     def test_read_back_wrong_state_is_not_success(self):
         # A reject that reads back as accepted (or a delete that leaves the

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,1205 @@
+"""Tests for suggestion threads: list/info and accept/reject/delete.
+
+The Docs API developer preview exposes native suggestion threads through
+documents.get?commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED and decides them
+with acceptSuggestion/rejectSuggestion/deleteSuggestion. These tests pin the
+exact request shapes, the response shapes observed live (see PR notes),
+the derived location map, and the CLI's refusal to report success without
+a read-back in the requested state.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc import mcp
+from gdoc.api.docs import (
+    collect_suggestion_locations,
+    decide_suggestion,
+    find_suggestion_thread,
+    get_document_threads,
+    sorted_suggestion_threads,
+    summarize_suggestion_thread,
+)
+from gdoc.cli import (
+    cmd_accept_suggestion,
+    cmd_delete_suggestion,
+    cmd_reject_suggestion,
+    cmd_suggestion_info,
+    cmd_suggestions,
+)
+from gdoc.notify import ChangeInfo
+from gdoc.util import SPREADSHEET_MIME, AuthError, GdocError, PreviewUnavailableError
+
+
+def _http_error(status, content=b"", reason="Error"):
+    resp = httplib2.Response({"status": str(status)})
+    resp.reason = reason
+    return HttpError(resp, content, uri="")
+
+
+def _thread(
+    sid,
+    status="OPEN",
+    created="2026-08-26T17:23:54.236Z",
+    summary="Add: “(added A)”",
+    me=True,
+    name="Alejo Acelas",
+):
+    """SuggestionThread as observed live (no range fields)."""
+    return {
+        "suggestionId": sid,
+        "headPost": {
+            "postId": "AAACFyBdz8Y",
+            "author": {"displayName": name, "me": me, "user": "users/1"},
+            "createTime": created,
+            "updateTime": created,
+            "suggestionAction": "NO_SUGGESTION_ACTION_CHANGE",
+        },
+        "status": status,
+        "summaryText": summary,
+        "summaryHtml": "<div>...</div>",
+    }
+
+
+def _text_run(start, end, content, **marks):
+    run = {"content": content, "textStyle": {}}
+    run.update(marks)
+    return {"startIndex": start, "endIndex": end, "textRun": run}
+
+
+def _tab(tab_id, title, elements, children=None):
+    tab = {
+        "tabProperties": {"tabId": tab_id, "title": title, "index": 0},
+        "documentTab": {
+            "body": {
+                "content": [
+                    {
+                        "startIndex": elements[0]["startIndex"],
+                        "endIndex": elements[-1]["endIndex"],
+                        "paragraph": {"elements": elements},
+                    }
+                ]
+            }
+        },
+    }
+    if children:
+        tab["childTabs"] = children
+    return tab
+
+
+# Suggestion A: insertion (+ style map Google adds alongside), tab 1.
+# Suggestion B: deletion, tab 1. Suggestion H: insertion in a child tab.
+_DOC = {
+    "documentId": "doc1",
+    "title": "Scratch",
+    "revisionId": "rev1",
+    "suggestionsViewMode": "SUGGESTIONS_INLINE",
+    "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+    "tabs": [
+        _tab(
+            "t.0",
+            "Tab 1",
+            [
+                _text_run(1, 27, "Intro line \U0001f680 target alpha"),
+                _text_run(
+                    27,
+                    37,
+                    " (added A)",
+                    suggestedInsertionIds=["suggest.a"],
+                    suggestedTextStyleChanges={"suggest.a": {"textStyle": {}}},
+                ),
+                _text_run(37, 73, " stays here.\nSecond paragraph with "),
+                _text_run(
+                    73,
+                    92,
+                    "beta text to delete",
+                    suggestedDeletionIds=["suggest.b"],
+                ),
+            ],
+            children=[
+                _tab(
+                    "t.draft",
+                    "Draft",
+                    [
+                        _text_run(1, 18, "Draft tab epsilon"),
+                        _text_run(
+                            18,
+                            28,
+                            " (added H)",
+                            suggestedInsertionIds=["suggest.h"],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ],
+    "suggestions": [
+        _thread(
+            "suggest.h", created="2026-08-26T17:23:57.504Z", summary="Add: “(added H)”"
+        ),
+        _thread("suggest.a"),
+        _thread(
+            "suggest.b",
+            created="2026-08-26T17:23:55.448Z",
+            summary="Delete: “beta text to delete”",
+            me=False,
+            name="Alejandro Acelas",
+        ),
+        _thread(
+            "suggest.done",
+            status="ACCEPTED",
+            created="2026-08-26T17:20:00.000Z",
+            summary="Add: old",
+        ),
+    ],
+    "comments": [],
+}
+
+
+# --- get_document_threads ---------------------------------------------------
+
+
+class TestGetDocumentThreads:
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_sends_preview_view_modes(self, mock_svc, mock_raw):
+        mock_raw.return_value = dict(_DOC)
+        doc = get_document_threads("doc1")
+        assert doc["suggestions"][1]["suggestionId"] == "suggest.a"
+        service, doc_id, params = mock_raw.call_args.args
+        assert service is mock_svc.return_value
+        assert doc_id == "doc1"
+        assert params == {
+            "includeTabsContent": "true",
+            "suggestionsViewMode": "SUGGESTIONS_INLINE",
+            "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+        }
+
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_missing_suggestions_key_becomes_empty_list(self, _svc, mock_raw):
+        mock_raw.return_value = {"documentId": "doc1", "revisionId": "r"}
+        assert get_document_threads("doc1")["suggestions"] == []
+
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_unknown_field_400_is_preview_unavailable(self, _svc, mock_raw):
+        # Live shape from project 856825977485 (not enrolled).
+        mock_raw.side_effect = _http_error(
+            400,
+            b'{"error": {"code": 400, "message": "Invalid JSON payload '
+            b'received. Unknown name \\"comments_view_mode\\": Cannot bind '
+            b'query parameter.", "status": "INVALID_ARGUMENT"}}',
+        )
+        with pytest.raises(PreviewUnavailableError, match="not enrolled"):
+            get_document_threads("doc1")
+
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_other_400_is_generic_api_error(self, _svc, mock_raw):
+        mock_raw.side_effect = _http_error(400, b'{"error": {"message": "x"}}')
+        with pytest.raises(GdocError, match="API error \\(400\\)"):
+            get_document_threads("doc1")
+
+    @pytest.mark.parametrize(
+        "status,exc,msg",
+        [
+            (401, AuthError, "Authentication expired"),
+            (403, GdocError, "Permission denied: doc1"),
+            (404, GdocError, "Document not found: doc1"),
+        ],
+    )
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_standard_errors_translate(self, _svc, mock_raw, status, exc, msg):
+        mock_raw.side_effect = _http_error(status)
+        with pytest.raises(exc, match=msg):
+            get_document_threads("doc1")
+
+
+class TestDocumentsGetRaw:
+    def test_builds_authorized_get_with_query(self):
+        from gdoc.api.docs import _documents_get_raw
+
+        service = MagicMock()
+        with patch("googleapiclient.http.HttpRequest") as mock_req:
+            mock_req.return_value.execute.return_value = {"documentId": "d"}
+            out = _documents_get_raw(
+                service,
+                "doc/1",
+                {"commentsViewMode": "X", "a": "b"},
+            )
+        assert out == {"documentId": "d"}
+        args, kwargs = mock_req.call_args
+        assert args[0] is service._http
+        assert args[2] == (
+            "https://docs.googleapis.com/v1/documents/doc%2F1?commentsViewMode=X&a=b"
+        )
+        assert kwargs["method"] == "GET"
+
+
+# --- derived locations / summaries ----------------------------------------
+
+
+class TestCollectSuggestionLocations:
+    def test_insert_delete_style_and_child_tab(self):
+        locs = collect_suggestion_locations(_DOC)
+        assert locs["suggest.a"] == [
+            {
+                "tab": "Tab 1",
+                "tabId": "t.0",
+                "segmentId": "",
+                "kind": "insert",
+                "startIndex": 27,
+                "endIndex": 37,
+                "text": " (added A)",
+            },
+        ]  # the style map mirroring the insertion is not a second location
+        assert locs["suggest.b"] == [
+            {
+                "tab": "Tab 1",
+                "tabId": "t.0",
+                "segmentId": "",
+                "kind": "delete",
+                "startIndex": 73,
+                "endIndex": 92,
+                "text": "beta text to delete",
+            },
+        ]
+        assert locs["suggest.h"] == [
+            {
+                "tab": "Draft",
+                "tabId": "t.draft",
+                "segmentId": "",
+                "kind": "insert",
+                "startIndex": 18,
+                "endIndex": 28,
+                "text": " (added H)",
+            },
+        ]
+        # An accepted thread has no inline marks left.
+        assert "suggest.done" not in locs
+
+    def test_paragraph_style_change_uses_enclosing_paragraph_range(self):
+        doc = {
+            "tabs": [
+                {
+                    "tabProperties": {"tabId": "t.0", "title": "Main"},
+                    "documentTab": {
+                        "body": {
+                            "content": [
+                                {
+                                    "startIndex": 1,
+                                    "endIndex": 10,
+                                    "paragraph": {
+                                        "elements": [_text_run(1, 10, "Heading\n")],
+                                        "paragraphStyle": {
+                                            "namedStyleType": "NORMAL_TEXT"
+                                        },
+                                        "suggestedParagraphStyleChanges": {
+                                            "suggest.p": {"paragraphStyle": {}},
+                                        },
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        }
+        assert collect_suggestion_locations(doc) == {
+            "suggest.p": [
+                {
+                    "tab": "Main",
+                    "tabId": "t.0",
+                    "segmentId": "",
+                    "kind": "paragraph-style",
+                    "startIndex": 1,
+                    "endIndex": 10,
+                    "text": "",
+                }
+            ],
+        }
+
+    def test_table_cell_content_is_walked(self):
+        doc = {
+            "tabs": [
+                {
+                    "tabProperties": {"tabId": "t.0", "title": "Main"},
+                    "documentTab": {
+                        "body": {
+                            "content": [
+                                {
+                                    "startIndex": 1,
+                                    "endIndex": 20,
+                                    "table": {
+                                        "tableRows": [
+                                            {
+                                                "tableCells": [
+                                                    {
+                                                        "content": [
+                                                            {
+                                                                "startIndex": 2,
+                                                                "endIndex": 8,
+                                                                "paragraph": {
+                                                                    "elements": [
+                                                                        _text_run(
+                                                                            2,
+                                                                            8,
+                                                                            "cell\n",
+                                                                            suggestedInsertionIds=[
+                                                                                "suggest.t"
+                                                                            ],
+                                                                        )
+                                                                    ]
+                                                                },
+                                                            }
+                                                        ],
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        }
+        locs = collect_suggestion_locations(doc)
+        assert locs["suggest.t"][0]["startIndex"] == 2
+        assert locs["suggest.t"][0]["kind"] == "insert"
+
+    def test_structural_insertion_without_text_run(self):
+        doc = {
+            "tabs": [
+                {
+                    "tabProperties": {"tabId": "t.0", "title": "Main"},
+                    "documentTab": {
+                        "body": {
+                            "content": [
+                                {
+                                    "startIndex": 5,
+                                    "endIndex": 30,
+                                    "suggestedInsertionIds": ["suggest.tbl"],
+                                    "table": {"rows": 1, "columns": 1, "tableRows": []},
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        }
+        assert collect_suggestion_locations(doc)["suggest.tbl"] == [
+            {
+                "tab": "Main",
+                "tabId": "t.0",
+                "segmentId": "",
+                "kind": "insert",
+                "startIndex": 5,
+                "endIndex": 30,
+                "text": "",
+            }
+        ]
+
+    def test_legacy_body_shape_and_no_marks(self):
+        assert collect_suggestion_locations({"body": {"content": []}}) == {}
+        assert collect_suggestion_locations({}) == {}
+
+
+class TestThreadHelpers:
+    def test_summarize_reads_only_observed_fields(self):
+        s = summarize_suggestion_thread(_DOC["suggestions"][2])
+        assert s == {
+            "id": "suggest.b",
+            "status": "open",
+            "author": "Alejandro Acelas",
+            "author_is_me": False,
+            "created": "2026-08-26T17:23:55.448Z",
+            "updated": "2026-08-26T17:23:55.448Z",
+            "summary": "Delete: “beta text to delete”",
+            "replies": 0,
+        }
+
+    def test_summarize_tolerates_missing_fields(self):
+        s = summarize_suggestion_thread({"suggestionId": "suggest.x"})
+        assert s["status"] == "unknown"
+        assert s["author"] == "unknown"
+        assert s["summary"] == ""
+
+    def test_summarize_counts_replies_or_posts(self):
+        t = {**_thread("suggest.r"), "replies": [{"postId": "p1"}]}
+        assert summarize_suggestion_thread(t)["replies"] == 1
+        t = {**_thread("suggest.r"), "posts": [{}, {}]}
+        assert summarize_suggestion_thread(t)["replies"] == 2
+
+    def test_sorted_by_create_time(self):
+        ids = [t["suggestionId"] for t in sorted_suggestion_threads(_DOC)]
+        assert ids == ["suggest.done", "suggest.a", "suggest.b", "suggest.h"]
+
+    def test_find_thread(self):
+        assert find_suggestion_thread(_DOC, "suggest.b")["status"] == "OPEN"
+        assert find_suggestion_thread(_DOC, "suggest.zz") is None
+
+
+# --- decide_suggestion ------------------------------------------------------
+
+
+def _mock_docs_service(batch_response=None, batch_error=None):
+    service = MagicMock()
+    execute = service.documents.return_value.batchUpdate.return_value.execute
+    if batch_error is not None:
+        execute.side_effect = batch_error
+    else:
+        execute.return_value = batch_response if batch_response is not None else {}
+    return service
+
+
+def _batch_body(service):
+    return service.documents.return_value.batchUpdate.call_args.kwargs["body"]
+
+
+_ACCEPT_OK = {
+    "replies": [{}],
+    "writeControl": {"requiredRevisionId": "rev2"},
+    "suggestionResponses": [{"acceptedSuggestionIds": ["suggest.a"]}],
+    "commentUpdateState": "ALL_SAVED",
+}
+
+
+class TestDecideSuggestion:
+    @pytest.mark.parametrize(
+        "decision,key",
+        [
+            ("accept", "acceptSuggestion"),
+            ("reject", "rejectSuggestion"),
+            ("delete", "deleteSuggestion"),
+        ],
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_exact_request_body(self, mock_svc, decision, key):
+        response = {
+            "replies": [{}],
+            "suggestionResponses": [
+                {
+                    f"{decision}{'e' * (decision != 'delete')}dSuggestionIds": [
+                        "suggest.a"
+                    ]
+                }
+            ],
+            "commentUpdateState": "ALL_SAVED",
+        }
+        service = _mock_docs_service(response)
+        mock_svc.return_value = service
+        result = decide_suggestion("doc1", "suggest.a", decision, "rev1")
+        assert result is response
+        call = service.documents.return_value.batchUpdate.call_args
+        assert call.kwargs["documentId"] == "doc1"
+        assert call.kwargs["body"] == {
+            "requests": [{key: {"suggestionId": "suggest.a"}}],
+            "writeControl": {"requiredRevisionId": "rev1"},
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_empty_revision_never_sent(self, mock_svc):
+        with pytest.raises(GdocError, match="no revisionId"):
+            decide_suggestion("doc1", "suggest.a", "accept", "")
+        mock_svc.assert_not_called()
+
+    def test_unknown_decision_is_programming_error(self):
+        with pytest.raises(ValueError):
+            decide_suggestion("doc1", "suggest.a", "resolve", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_request_set_400_is_preview_unavailable(self, mock_svc):
+        # Live shape from project 856825977485 for acceptSuggestion.
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(
+                400,
+                b'{"error": {"code": 400, "message": "Invalid requests[0]: No '
+                b'request set.", "status": "INVALID_ARGUMENT"}}',
+            )
+        )
+        with pytest.raises(PreviewUnavailableError, match="acceptSuggestion"):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_unknown_name_400_is_preview_unavailable(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(
+                400,
+                b'{"error": {"message": "Unknown name \\"rejectSuggestion\\""}}',
+            )
+        )
+        with pytest.raises(PreviewUnavailableError):
+            decide_suggestion("doc1", "suggest.a", "reject", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_stale_revision_says_rerun(self, mock_svc):
+        # Live shape.
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(
+                400,
+                b'{"error": {"code": 400, "message": "The required revision ID '
+                b"'AIro' does not match the latest revision.\", "
+                b'"status": "FAILED_PRECONDITION"}}',
+            )
+        )
+        with pytest.raises(GdocError, match="document changed.*re-run"):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_other_400_carries_google_message(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(
+                400,
+                b'{"error": {"message": "Suggestion is not open."}}',
+                reason="Bad Request",
+            )
+        )
+        with pytest.raises(
+            GdocError,
+            match="cannot accept suggestion suggest.a: Suggestion is not open.",
+        ):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @pytest.mark.parametrize(
+        "decision,rule",
+        [
+            ("accept", "accept requires edit access"),
+            ("reject", "reject requires edit access or suggestion authorship"),
+            ("delete", "delete requires suggestion authorship"),
+        ],
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_403_names_the_permission_rule(self, mock_svc, decision, rule):
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(403))
+        with pytest.raises(GdocError, match=rule) as exc:
+            decide_suggestion("doc1", "suggest.a", decision, "rev1")
+        assert exc.value.exit_code == 1
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_for_suggestion_is_usage_error(self, mock_svc):
+        # Live shape: "Suggestion with ID suggest.x does not exist."
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(
+                404,
+                b'{"error": {"code": 404, "message": "Suggestion with ID '
+                b'suggest.a does not exist.", "status": "NOT_FOUND"}}',
+            )
+        )
+        with pytest.raises(GdocError, match="suggestion not found: suggest.a") as e:
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+        assert e.value.exit_code == 3
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_for_document_stays_document_error(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(
+                404,
+                b'{"error": {"message": "Requested entity was not found."}}',
+            )
+        )
+        with pytest.raises(GdocError, match="Document not found: doc1"):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_401_is_auth_error(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(401))
+        with pytest.raises(AuthError):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_partial_save_failure_is_an_error(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(
+            {
+                "replies": [{}],
+                "suggestionResponses": [{}],
+                "commentUpdateState": "ALL_FAILED_UNKNOWN_REASON",
+            }
+        )
+        with pytest.raises(
+            GdocError,
+            match="not saved \\(commentUpdateState=ALL_FAILED_UNKNOWN_REASON\\)",
+        ):
+            decide_suggestion("doc1", "suggest.a", "reject", "rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_missing_comment_update_state_is_an_error(self, mock_svc):
+        # A batch that must save a suggestion thread requires ALL_SAVED.
+        mock_svc.return_value = _mock_docs_service(
+            {
+                "replies": [{}],
+                "suggestionResponses": [{"acceptedSuggestionIds": ["suggest.a"]}],
+            }
+        )
+        with pytest.raises(GdocError, match="commentUpdateState=missing"):
+            decide_suggestion("doc1", "suggest.a", "accept", "rev1")
+
+    @pytest.mark.parametrize(
+        "decision,responses",
+        [
+            ("accept", [{}]),
+            ("accept", [{"acceptedSuggestionIds": ["suggest.other"]}]),
+            ("accept", [{"rejectedSuggestionIds": ["suggest.a"]}]),
+            ("reject", [{"acceptedSuggestionIds": ["suggest.a"]}]),
+            ("delete", None),
+        ],
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_response_must_name_the_id_under_the_decision(
+        self,
+        mock_svc,
+        decision,
+        responses,
+    ):
+        body = {"replies": [{}], "commentUpdateState": "ALL_SAVED"}
+        if responses is not None:
+            body["suggestionResponses"] = responses
+        mock_svc.return_value = _mock_docs_service(body)
+        with pytest.raises(GdocError, match="did not report suggest.a under"):
+            decide_suggestion("doc1", "suggest.a", decision, "rev1")
+
+    @pytest.mark.parametrize(
+        "decision,key",
+        [
+            ("reject", "rejectedSuggestionIds"),
+            ("delete", "deletedSuggestionIds"),
+        ],
+    )
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_reject_and_delete_response_keys(self, mock_svc, decision, key):
+        body = {
+            "replies": [{}],
+            "commentUpdateState": "ALL_SAVED",
+            "suggestionResponses": [{key: ["suggest.a"]}],
+        }
+        mock_svc.return_value = _mock_docs_service(body)
+        assert decide_suggestion("doc1", "suggest.a", decision, "rev1") is body
+
+
+# --- CLI: suggestions / suggestion-info -----------------------------------
+
+
+def _args(command, **overrides):
+    defaults = {
+        "command": command,
+        "doc": "doc1",
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": True,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+_LIST_PATCHES = (
+    patch("gdoc.state.update_state_after_command"),
+    patch("gdoc.notify.pre_flight", return_value=None),
+)
+
+
+class TestCmdSuggestions:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_terse_lists_open_sorted_with_locations(
+        self, _get, _pf, mock_update, capsys
+    ):
+        rc = cmd_suggestions(_args("suggestions", all=False))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert out == (
+            "#suggest.a [open] Alejo Acelas (me) 2026-08-26\n"
+            "  Add: “(added A)”\n"
+            "  @Tab 1 27-37 insert\n"
+            "#suggest.b [open] Alejandro Acelas 2026-08-26\n"
+            "  Delete: “beta text to delete”\n"
+            "  @Tab 1 73-92 delete\n"
+            "#suggest.h [open] Alejo Acelas (me) 2026-08-26\n"
+            "  Add: “(added H)”\n"
+            "  @Draft 18-28 insert\n"
+        )
+        assert "suggest.done" not in out
+        mock_update.assert_called_once()
+        assert mock_update.call_args.kwargs["command"] == "suggestions"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_all_includes_decided_threads_without_location(self, _get, _pf, _u, capsys):
+        cmd_suggestions(_args("suggestions", all=True))
+        out = capsys.readouterr().out
+        assert out.startswith(
+            "#suggest.done [accepted] Alejo Acelas (me) 2026-08-26\n"
+            "  Add: old\n  (no inline location found)\n"
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_verbose_shows_full_times_and_snippets(self, _get, _pf, _u, capsys):
+        cmd_suggestions(_args("suggestions", all=False, verbose=True))
+        out = capsys.readouterr().out
+        assert "#suggest.a [open] Alejo Acelas (me) 2026-08-26T17:23:54.236Z" in out
+        assert '  @Tab 1 27-37 insert " (added A)"' in out
+        assert "  Modified: 2026-08-26T17:23:54.236Z" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_plain_is_tab_separated(self, _get, _pf, _u, capsys):
+        cmd_suggestions(_args("suggestions", all=False, plain=True))
+        lines = capsys.readouterr().out.splitlines()
+        assert lines[0] == (
+            "suggest.a\topen\tAlejo Acelas\tAdd: “(added A)”\tt.0:27-37:insert"
+        )
+        assert lines[2] == (
+            "suggest.h\topen\tAlejo Acelas\tAdd: “(added H)”\tt.draft:18-28:insert"
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_json_keeps_raw_threads_and_separate_locations(self, _get, _pf, _u, capsys):
+        cmd_suggestions(_args("suggestions", all=False, json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data["ok"] is True
+        assert data["revisionId"] == "rev1"
+        assert [t["suggestionId"] for t in data["suggestions"]] == [
+            "suggest.a",
+            "suggest.b",
+            "suggest.h",
+        ]
+        # Raw thread untouched — no synthesized range fields.
+        assert data["suggestions"][0] == _thread("suggest.a")
+        assert set(data["locations"]) == {"suggest.a", "suggest.b", "suggest.h"}
+        assert data["locations"]["suggest.b"][0]["kind"] == "delete"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads")
+    def test_missing_status_is_unknown_not_open(self, mock_get, _pf, _u, capsys):
+        t = _thread("suggest.ns")
+        del t["status"]
+        mock_get.return_value = {**_DOC, "suggestions": [t]}
+        cmd_suggestions(_args("suggestions", all=False))
+        assert capsys.readouterr().out == "No open suggestions.\n"
+        cmd_suggestions(_args("suggestions", all=True))
+        assert capsys.readouterr().out.startswith("#suggest.ns [unknown]")
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads")
+    def test_segment_and_no_range_locations_render(self, mock_get, _pf, _u, capsys):
+        doc = {
+            "revisionId": "r",
+            "suggestions": [_thread("suggest.hd"), _thread("suggest.ds")],
+            "tabs": [
+                {
+                    "tabProperties": {"tabId": "t.0", "title": "Main"},
+                    "documentTab": {
+                        "body": {"content": []},
+                        "suggestedDocumentStyleChanges": {"suggest.ds": {}},
+                        "headers": {
+                            "h1": {
+                                "content": [
+                                    {
+                                        "startIndex": 0,
+                                        "endIndex": 4,
+                                        "paragraph": {
+                                            "elements": [
+                                                _text_run(
+                                                    0,
+                                                    4,
+                                                    "head",
+                                                    suggestedInsertionIds=[
+                                                        "suggest.hd"
+                                                    ],
+                                                )
+                                            ]
+                                        },
+                                    }
+                                ]
+                            }
+                        },
+                    },
+                }
+            ],
+        }
+        mock_get.return_value = doc
+        cmd_suggestions(_args("suggestions", all=False))
+        out = capsys.readouterr().out
+        assert "  @Main h1 0-4 insert\n" in out
+        assert "  @Main (no range) document-style\n" in out
+        cmd_suggestions(_args("suggestions", all=False, plain=True))
+        out = capsys.readouterr().out
+        assert "\tt.0/h1:0-4:insert\n" in out
+        assert "\tt.0:(no range):document-style\n" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads")
+    def test_empty_messages(self, mock_get, _pf, _u, capsys):
+        mock_get.return_value = {
+            **_DOC,
+            "suggestions": [_thread("s", status="REJECTED")],
+        }
+        cmd_suggestions(_args("suggestions", all=False))
+        assert capsys.readouterr().out == "No open suggestions.\n"
+        mock_get.return_value = {**_DOC, "suggestions": []}
+        cmd_suggestions(_args("suggestions", all=True))
+        assert capsys.readouterr().out == "No suggestions.\n"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch(
+        "gdoc.api.docs.get_document_threads",
+        side_effect=PreviewUnavailableError("suggestion threads are not available: x"),
+    )
+    def test_preview_unavailable_is_a_failure_not_a_fallback(
+        self, _get, _pf, mock_update
+    ):
+        with pytest.raises(GdocError, match="not available") as e:
+            cmd_suggestions(_args("suggestions", all=False))
+        assert e.value.exit_code == 1
+        mock_update.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    @patch("gdoc.notify.pre_flight")
+    def test_rejects_spreadsheets(self, mock_pf, mock_get, _u):
+        mock_pf.return_value = ChangeInfo(mime_type=SPREADSHEET_MIME)
+        with pytest.raises(GdocError, match="not a Google Doc"):
+            cmd_suggestions(_args("suggestions", all=False, quiet=False))
+        mock_get.assert_not_called()
+
+
+class TestCmdSuggestionInfo:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_terse(self, _get, _pf, mock_update, capsys):
+        rc = cmd_suggestion_info(_args("suggestion-info", suggestion_id="suggest.b"))
+        assert rc == 0
+        assert capsys.readouterr().out == (
+            "#suggest.b [open] Alejandro Acelas 2026-08-26\n"
+            "  Delete: “beta text to delete”\n"
+            "  @Tab 1 73-92 delete\n"
+        )
+        assert mock_update.call_args.kwargs["command"] == "suggestion-info"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_plain(self, _get, _pf, _u, capsys):
+        cmd_suggestion_info(
+            _args("suggestion-info", suggestion_id="suggest.a", plain=True)
+        )
+        assert capsys.readouterr().out == (
+            "id\tsuggest.a\nstatus\topen\nauthor\tAlejo Acelas\n"
+            "created\t2026-08-26T17:23:54.236Z\n"
+            "summary\tAdd: “(added A)”\n"
+            "location\tt.0:27-37:insert\n"
+            "replies\t0\n"
+        )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_json(self, _get, _pf, _u, capsys):
+        cmd_suggestion_info(
+            _args("suggestion-info", suggestion_id="suggest.h", json=True)
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert data["suggestion"] == _DOC["suggestions"][0]
+        assert data["locations"] == [
+            {
+                "tab": "Draft",
+                "tabId": "t.draft",
+                "segmentId": "",
+                "kind": "insert",
+                "startIndex": 18,
+                "endIndex": 28,
+                "text": " (added H)",
+            }
+        ]
+        assert data["revisionId"] == "rev1"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
+    def test_unknown_id_is_usage_error(self, _get, _pf, mock_update):
+        with pytest.raises(GdocError, match="suggestion not found: suggest.zz") as e:
+            cmd_suggestion_info(_args("suggestion-info", suggestion_id="suggest.zz"))
+        assert e.value.exit_code == 3
+        mock_update.assert_not_called()
+
+
+# --- CLI: accept / reject / delete ----------------------------------------
+
+
+def _after(sid, status):
+    """Document read back after a decision: thread in *status*, or gone."""
+    threads = [t for t in _DOC["suggestions"] if t["suggestionId"] != sid]
+    if status != "gone":
+        threads.append(_thread(sid, status=status))
+    return {**_DOC, "revisionId": "rev2", "suggestions": threads}
+
+
+def _decision_patches(after_status, sid="suggest.a", response=None):
+    """Patch read (before + after), write, version, state, pre-flight."""
+    return (
+        patch("gdoc.state.update_state_after_command"),
+        patch("gdoc.notify.pre_flight", return_value=None),
+        patch("gdoc.api.drive.get_file_version", return_value={"version": 50}),
+        patch(
+            "gdoc.api.docs.decide_suggestion",
+            return_value=response if response is not None else _ACCEPT_OK,
+        ),
+        patch(
+            "gdoc.api.docs.get_document_threads",
+            side_effect=[_DOC, _after(sid, after_status)],
+        ),
+    )
+
+
+class TestCmdDecisions:
+    def test_accept_terse_pins_revision_and_updates_state(self, capsys):
+        p = _decision_patches("ACCEPTED")
+        with p[0] as mock_update, p[1], p[2], p[3] as mock_decide, p[4] as mock_get:
+            rc = cmd_accept_suggestion(
+                _args("accept-suggestion", suggestion_id="suggest.a")
+            )
+        assert rc == 0
+        assert capsys.readouterr().out == "OK accepted suggestion #suggest.a\n"
+        mock_decide.assert_called_once_with("doc1", "suggest.a", "accept", "rev1")
+        assert mock_get.call_count == 2
+        kw = mock_update.call_args.kwargs
+        assert kw["command"] == "accept-suggestion"
+        assert kw["command_version"] == 50
+        assert "comment_state_patch" not in kw
+        assert not kw.get("full_doc_write")
+
+    def test_accept_json_includes_suggestion_responses(self, capsys):
+        p = _decision_patches("ACCEPTED")
+        with p[0], p[1], p[2], p[3], p[4]:
+            cmd_accept_suggestion(
+                _args("accept-suggestion", suggestion_id="suggest.a", json=True)
+            )
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True,
+            "id": "suggest.a",
+            "status": "accepted",
+            "threadStatus": "accepted",
+            "suggestionResponses": [{"acceptedSuggestionIds": ["suggest.a"]}],
+        }
+
+    def test_reject_plain(self, capsys):
+        p = _decision_patches(
+            "REJECTED",
+            response={
+                "replies": [{}],
+                "suggestionResponses": [{"rejectedSuggestionIds": ["suggest.a"]}],
+                "commentUpdateState": "ALL_SAVED",
+            },
+        )
+        with p[0], p[1], p[2], p[3] as mock_decide, p[4]:
+            rc = cmd_reject_suggestion(
+                _args("reject-suggestion", suggestion_id="suggest.a", plain=True)
+            )
+        assert rc == 0
+        assert capsys.readouterr().out == "id\tsuggest.a\nstatus\trejected\n"
+        mock_decide.assert_called_once_with("doc1", "suggest.a", "reject", "rev1")
+
+    def test_delete_with_force_expects_thread_gone(self, capsys):
+        p = _decision_patches(
+            "gone",
+            response={
+                "replies": [{}],
+                "suggestionResponses": [{"deletedSuggestionIds": ["suggest.a"]}],
+                "commentUpdateState": "ALL_SAVED",
+            },
+        )
+        with p[0], p[1], p[2], p[3] as mock_decide, p[4]:
+            rc = cmd_delete_suggestion(
+                _args(
+                    "delete-suggestion",
+                    suggestion_id="suggest.a",
+                    force=True,
+                    json=True,
+                )
+            )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "deleted"
+        assert data["threadStatus"] == "gone"
+        mock_decide.assert_called_once_with("doc1", "suggest.a", "delete", "rev1")
+
+    def test_delete_without_force_non_interactive_writes_nothing(self):
+        p = _decision_patches("gone")
+        with (
+            p[0] as mock_update,
+            p[1],
+            p[2],
+            p[3] as mock_decide,
+            p[4] as mock_get,
+            patch("sys.stdin") as stdin,
+        ):
+            stdin.isatty.return_value = False
+            with pytest.raises(
+                GdocError,
+                match="Refusing to delete suggestion #suggest.a without --force",
+            ) as e:
+                cmd_delete_suggestion(
+                    _args("delete-suggestion", suggestion_id="suggest.a", force=False)
+                )
+        assert e.value.exit_code == 3
+        mock_decide.assert_not_called()
+        mock_get.assert_not_called()
+        mock_update.assert_not_called()
+
+    def test_unknown_id_fails_before_write(self):
+        p = _decision_patches("ACCEPTED")
+        with p[0] as mock_update, p[1], p[2], p[3] as mock_decide, p[4]:
+            with pytest.raises(
+                GdocError, match="suggestion not found: suggest.zz"
+            ) as e:
+                cmd_accept_suggestion(
+                    _args("accept-suggestion", suggestion_id="suggest.zz")
+                )
+        assert e.value.exit_code == 3
+        mock_decide.assert_not_called()
+        mock_update.assert_not_called()
+
+    def test_already_decided_fails_before_write(self):
+        p = _decision_patches("ACCEPTED")
+        with p[0], p[1], p[2], p[3] as mock_decide, p[4]:
+            with pytest.raises(
+                GdocError, match="suggestion suggest.done is already accepted"
+            ) as e:
+                cmd_reject_suggestion(
+                    _args("reject-suggestion", suggestion_id="suggest.done")
+                )
+        assert e.value.exit_code == 3
+        mock_decide.assert_not_called()
+
+    def test_read_back_still_open_is_not_success(self, capsys):
+        p = _decision_patches("OPEN")
+        with p[0] as mock_update, p[1], p[2], p[3], p[4]:
+            with pytest.raises(
+                GdocError, match="reads back as open \\(expected accepted\\)"
+            ):
+                cmd_accept_suggestion(
+                    _args("accept-suggestion", suggestion_id="suggest.a")
+                )
+        assert capsys.readouterr().out == ""
+        mock_update.assert_not_called()
+
+    def test_read_back_wrong_state_is_not_success(self):
+        # A reject that reads back as accepted (or a delete that leaves the
+        # thread listed) must not be reported as done.
+        p = _decision_patches("ACCEPTED")
+        with p[0], p[1], p[2], p[3], p[4]:
+            with pytest.raises(
+                GdocError, match="reads back as accepted \\(expected rejected\\)"
+            ):
+                cmd_reject_suggestion(
+                    _args("reject-suggestion", suggestion_id="suggest.a")
+                )
+        p = _decision_patches("REJECTED")
+        with p[0], p[1], p[2], p[3], p[4]:
+            with pytest.raises(
+                GdocError, match="reads back as rejected \\(expected gone\\)"
+            ):
+                cmd_delete_suggestion(
+                    _args("delete-suggestion", suggestion_id="suggest.a", force=True)
+                )
+
+    def test_api_permission_error_propagates_without_state_update(self):
+        p = _decision_patches("ACCEPTED")
+        with p[0] as mock_update, p[1], p[2], p[3] as mock_decide, p[4] as mock_get:
+            mock_decide.side_effect = GdocError(
+                "Permission denied: cannot accept suggestion suggest.a "
+                "(accept requires edit access)"
+            )
+            with pytest.raises(GdocError, match="accept requires edit access"):
+                cmd_accept_suggestion(
+                    _args("accept-suggestion", suggestion_id="suggest.a")
+                )
+        assert mock_get.call_count == 1  # no read-back after a failed write
+        mock_update.assert_not_called()
+
+    def test_preview_unavailable_read_fails_before_write(self):
+        p = _decision_patches("ACCEPTED")
+        with p[0], p[1], p[2], p[3] as mock_decide, p[4] as mock_get:
+            mock_get.side_effect = PreviewUnavailableError(
+                "suggestion threads are not available"
+            )
+            with pytest.raises(PreviewUnavailableError):
+                cmd_accept_suggestion(
+                    _args("accept-suggestion", suggestion_id="suggest.a")
+                )
+        mock_decide.assert_not_called()
+
+    def test_pre_flight_runs_unless_quiet(self):
+        p = _decision_patches("ACCEPTED")
+        with p[0], p[1] as mock_pf, p[2], p[3], p[4]:
+            cmd_accept_suggestion(
+                _args("accept-suggestion", suggestion_id="suggest.a", quiet=False)
+            )
+        mock_pf.assert_called_once_with("doc1", quiet=False)
+
+
+# --- parser & MCP exposure --------------------------------------------------
+
+
+class TestParserAndMcp:
+    @pytest.mark.parametrize(
+        "argv,expected",
+        [
+            (["suggestions", "D"], ("cmd_suggestions", {"all": False})),
+            (["suggestions", "D", "--all"], ("cmd_suggestions", {"all": True})),
+            (
+                ["suggestion-info", "D", "suggest.x"],
+                ("cmd_suggestion_info", {"suggestion_id": "suggest.x"}),
+            ),
+            (["accept-suggestion", "D", "suggest.x"], ("cmd_accept_suggestion", {})),
+            (["reject-suggestion", "D", "suggest.x"], ("cmd_reject_suggestion", {})),
+            (
+                ["delete-suggestion", "D", "suggest.x", "--force"],
+                ("cmd_delete_suggestion", {"force": True}),
+            ),
+        ],
+    )
+    def test_parses(self, argv, expected):
+        from gdoc.cli import build_parser
+
+        args = build_parser().parse_args(argv)
+        func_name, attrs = expected
+        assert args.func.__name__ == func_name
+        assert args.doc == "D"
+        for k, v in attrs.items():
+            assert getattr(args, k) == v
+
+    def test_mcp_exposure(self):
+        assert mcp.EXPOSED_COMMANDS["suggestions"] is True
+        assert mcp.EXPOSED_COMMANDS["suggestion-info"] is True
+        assert mcp.EXPOSED_COMMANDS["accept-suggestion"] is False
+        assert mcp.EXPOSED_COMMANDS["reject-suggestion"] is False
+        assert mcp.EXPOSED_COMMANDS["delete-suggestion"] is False
+
+    def test_mcp_delete_suggestion_requires_force(self):
+        schema = mcp.build_tools(allow={"delete-suggestion"})["gdoc_delete_suggestion"][
+            "inputSchema"
+        ]
+        assert "force" in schema["required"]
+        with pytest.raises(ValueError, match="`force: true` is required"):
+            mcp.call_command("delete-suggestion", {"doc": "D", "suggestion_id": "s"})

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1139,6 +1139,20 @@ class TestCmdSuggestionInfo:
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_threads")
+    def test_plain_sanitizes_summary_row(self, mock_get, _pf, _u, capsys):
+        thread = {
+            **find_suggestion_thread(_DOC, "suggest.a"),
+            "summaryText": "first\tpart\nsecond line",
+        }
+        mock_get.return_value = {**_DOC, "suggestions": [thread]}
+        cmd_suggestion_info(
+            _args("suggestion-info", suggestion_id="suggest.a", plain=True)
+        )
+        assert "summary\tfirst part second line\n" in capsys.readouterr().out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
     @patch("gdoc.api.docs.get_document_threads", return_value=_DOC)
     def test_json(self, _get, _pf, _u, capsys):
         cmd_suggestion_info(


### PR DESCRIPTION
## Summary

Second preview PR (after anchored comments in #40): list Google's **native suggestion threads** and decide them. Independent of the pending `gdoc suggest` (PR 1) and native comment-post work (PR 3) — branched from `origin/main` @ 31b4309.

```
gdoc suggestions DOC [--all]           # open threads (+ accepted/rejected with --all)
gdoc suggestion-info DOC SUGGESTION_ID
gdoc accept-suggestion DOC SUGGESTION_ID   # edit access
gdoc reject-suggestion DOC SUGGESTION_ID   # edit access or author
gdoc delete-suggestion DOC SUGGESTION_ID [--force]   # author only; confirm_destructive
```

- **Read** — `get_document_threads` (`gdoc/api/docs.py`) fetches `documents.get` with `includeTabsContent=true`, `suggestionsViewMode=SUGGESTIONS_INLINE`, `commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`. The public Discovery document does not list `commentsViewMode`, so the discovery-built client rejects it client-side (`Got an unexpected keyword argument`); the read goes through the service's authorized transport (`googleapiclient.http.HttpRequest`) and still surfaces `HttpError` for the usual translation. Raw `suggestions[]` threads are passed through untouched in `--json`.
- **Locations** — `SuggestionThread` has no range fields (live-confirmed: `suggestionId, headPost{postId, author, createTime, updateTime, suggestionAction}, status, summaryText, summaryHtml`). `collect_suggestion_locations` walks every tab (incl. `childTabs`, tables) and collects `suggestedInsertionIds` / `suggestedDeletionIds` (and the singular `suggestedInsertionId` on objects/lists), `Paragraph.suggestedPositionedObjectIds` (a map keyed by suggestion ID), and every `suggested*Changes` map (text/paragraph/bullet/table/object/list/date/document/named styles) keyed by ID into `{tab, tabId, segmentId, kind, startIndex, endIndex, text}` using the nearest enclosing element's UTF-16 indexes. Header/footer/footnote marks carry their `segmentId` (their indexes restart at 0); marks with no indexes at all (document/named styles, object maps) report `null` indexes / `(no range)` instead of a fake `0-0`; the `suggestedTextStyleChanges` mirror Google adds to every inserted run is dropped so a plain insertion is one location, and an object marked both on its ranged element and in the `inlineObjects`/`positionedObjects` map yields the ranged entry only (unrelated property changes are kept). Kept **separate** from the raw thread (`locations` key in JSON; `@Tab start-end kind` lines in terse) per the design note that the preview schema may change. A thread with no inline marks prints `(no inline location found)` rather than inventing one.
- **Decide** — `decide_suggestion` sends exactly one `acceptSuggestion`/`rejectSuggestion`/`deleteSuggestion` with `writeControl.requiredRevisionId` from the read that was just made. Google only documents `revisionId` for edit access, while reject/delete are also open to the suggestion's author (possibly a commenter): **accept** refuses to run without a revision; **reject/delete** go unpinned only when the read returned none (neither depends on coordinates). An empty `requiredRevisionId` is never sent. It requires `commentUpdateState == ALL_SAVED` **and** that `suggestionResponses[0].{accepted|rejected|deleted}SuggestionIds` names the ID (both observed live), then the CLI **reads back** and only prints `OK` if the thread is in the requested state (accepted/rejected stay listed with that status; deleted threads disappear — both observed live). Unknown or already-decided IDs fail with exit 3 *before* any write.
- **No fallback.** Unlike `comment --quote`, a project without preview access gets `PreviewUnavailableError` → `ERR: … not enrolled …` (exit 1) and nothing is mutated. 403s name Google's rule for that decision; stale revision → the existing "document changed … re-run" message; API 404 for the ID → `suggestion not found` (exit 3).
- **State** — pre-flight + `update_state_after_command` like `comment-info`/`delete-comment`; decisions record `command_version` and do not advance the read baseline (partial write). MCP: `suggestions`/`suggestion-info` read-only, the three decisions as writes, `delete-suggestion` requires `force: true` like `delete-comment`.
- Docs: README "Suggestions" section, CHANGELOG 0.21.0, version bump in `pyproject.toml` / `gdoc/__init__.py` / `uv.lock`, CLAUDE.md API-layer note.

Design: `03-cli-design.md` §"PR 2: list and decide suggestion threads" (kept external, not in the repo).

## Tests

- `uv run pytest tests/test_suggestions.py -v` — **83 passed**: exact `documents.get` params and raw URI; every live-observed error shape (unenrolled 400 `Unknown name "comments_view_mode"` / `No request set.`, stale revision 400, 403 per decision with its rule, 404 suggestion vs 404 document, 401, `ALL_FAILED_UNKNOWN_REASON`, missing `commentUpdateState`, `suggestionResponses` missing / naming another ID / naming the wrong decision); exact request bodies for all three decisions incl. `requiredRevisionId`; empty-revision refusal with no API call; location derivation for insert/delete/style, paragraph-style enclosing range, tables, structural insertions, child tabs, header/footer/footnote segment IDs, object/list maps with singular IDs and no fake range, date-element properties, positioned-object paragraph anchors, object-map mirror dedupe, emoji-containing UTF-16 runs; unpinned reject/delete request bodies when no revision is available; terse/plain/json/verbose output; `--all`; sort order; read-back-still-open / wrong-state → error and no state update; unknown / already-decided IDs fail before write; `--force` refusal writes nothing; MCP exposure and `force` requirement; parser wiring.
- `uv run pytest tests/ -v` — **1500 passed**.
- `uv run ruff check gdoc/ tests/` — 198 findings on both `origin/main` and this branch (all pre-existing; new code and `tests/test_suggestions.py` are clean).
- `bash scripts/check-no-stubs.sh` — OK.

## Live evidence (scratch document, 26 Aug 2026)

All through `gdoc` itself unless noted; no credentials recorded. Scratch doc created with `gdoc new`, two tabs (`Tab 1`, `Draft`), an emoji before the first target, owned by a personal account (editor) and shared to a Workspace account as **commenter**. Both tokens use registered project `1009200210134`. Fixture suggestions were created with `writeMode: SUGGEST` **only on this scratch doc** (7 threads: insert/delete/style in Tab 1, insert in Draft, three commenter inserts); the response carried `suggestionResponses[].createdSuggestionIds` and `commentUpdateState: ALL_SAVED`; commenters *did* receive `revisionId` (re-confirmed after the Codex fix: the scratch doc's commenter still gets one, so the unpinned reject/delete path could not be exercised live and is covered by request-body tests only).

| Operation | Identity | Result |
|---|---|---|
| `suggestions` / `--all` / `--plain` / `--json` / `--verbose` | editor, commenter | 7 threads, correct tab names and UTF-16 ranges (emoji-offset insertion at 27–37), `(me)` marker; a style-only suggestion lists as `style`, a plain insertion as one `insert` |
| `accept-suggestion` | editor | `OK`; JSON `suggestionResponses: [{acceptedSuggestionIds:[…]}]`, `threadStatus: accepted`; `cat` shows text applied |
| `accept-suggestion` again | editor | exit 3 `is already accepted` (no write) |
| `accept-suggestion` | commenter | exit 1 `Permission denied … (accept requires edit access)` |
| `reject-suggestion` (own) | commenter (author) | `OK`; `rejectedSuggestionIds` |
| `reject-suggestion` | editor | `OK` (plain output) |
| `delete-suggestion` (someone else's) | editor (non-author) | exit 1 `… (delete requires suggestion authorship)` |
| `delete-suggestion` no `--force`, stdin not a tty | commenter | exit 3 `Refusing to delete … without --force` |
| `delete-suggestion --force` (own) | commenter, editor | `OK`; `deletedSuggestionIds`, `threadStatus: gone` |
| stale `requiredRevisionId` (raw) | editor | 400 `The required revision ID … does not match the latest revision.` → `document changed while the command was running; re-run it` |
| unknown ID (raw) | editor | 404 `Suggestion with ID … does not exist.` |
| `suggestion-info` unknown ID | editor | exit 3 `suggestion not found` |
| doc not shared | other account | exit 1 `Permission denied: <id>` |
| **Unregistered project `856825977485`** (`80k-control` client), preview read | Workspace account | HTTP 400 `Unknown name "comments_view_mode" … could not be found in request message` (plain read without the field: 200, no `suggestions` key) |
| **Unregistered project `856825977485`**, `acceptSuggestion` on a nonexistent ID (non-mutating) | Workspace account | HTTP 400 `Invalid requests[0]: No request set.` — no `writeMode: SUGGEST` was attempted there |
| Regression: `edit`, `comment --quote` (anchored: true), `comments`, `structure --suggestions-view-mode`, non-quiet pre-flight banner | editor | unchanged |

Not live-tested: suggestion threads with replies (`replies`/`posts` counted defensively, none existed), `ALL_FAILED_UNKNOWN_REASON` (unit-tested only), headers/footers/footnote suggestions (walker covers them generically; unit-tested for tables/child tabs/structural elements).

## Local pre-review

Before pushing, an independent read-only reviewer inspected the whole diff against the design docs. Adopted (all in the initial commit, each with tests): header/footer/footnote `segmentId`; singular `suggestedInsertionId` + `suggestedListPropertiesChanges`; no fake `0-0` ranges; drop the insertion's mirrored `style` entry; require `ALL_SAVED` **and** the decision's `suggestionResponses` ID (a missing state was previously tolerated); read-back mismatch message says the decision may have applied; `tabId` (not title) in `--plain`; a missing thread `status` is `unknown`, not open; `PreviewUnavailableError` docstring. Declined: widening `_raise_if_stale_revision`'s match (pre-existing helper shared with images; out of scope).

## Review rounds

- **Codex (independent audit of 512b27e, coordinated externally — GitHub-native Codex is not connected for this account)**: 3 findings, all valid, fixed in the `codex review fixes` commit with regression tests: (1) HIGH — reject/delete unconditionally required `revisionId`; (2) MED — `suggestedDateElementPropertiesChanges` and `Paragraph.suggestedPositionedObjectIds` were not extracted; (3) MED — an object suggestion was reported twice (ranged element + no-range object-map mirror).
- **CodeRabbit (512b27e)**: 1 finding — MD022 blank line after `### Added` in CHANGELOG. Declined: every existing entry in `CHANGELOG.md` puts the list directly under its `###` heading and the repo has no markdownlint configuration; matching the file's convention wins over a linter it doesn't run.

- **Codex closure audit of d2ea744 (external)**: 1 code defect + docs drift, fixed in `codex closure fixes` (2ef0e36): `Paragraph.suggestedPositionedObjectIds` is a *map* keyed by suggestion ID, which the walker did not read (the test fixture used a non-API list) — the real shape now yields the paragraph-ranged `positioned-object` entry, with the fixture corrected; README/CHANGELOG now state that accept is always revision-pinned while reject/delete are unpinned only when no `revisionId` was returned.

## Limitations (v1)

- One suggestion ID per command (atomic, auditable); no bulk accept.
- Locations are derived from the inline structure; when Google merges a new edit into an existing thread the same ID can have several entries — all are listed.
- Reply threads on suggestions are counted but not printed; posting/deleting replies is PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
