### PR TITLE
feat: native comment assignment and post operations (Docs API preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to `gdoc` are documented here. This project follows
   `comment --quote TEXT --assign EMAIL` creates an anchored comment assigned
   to a user (`insertComment.assigneeEmailAddress`; requires `--quote`, no
   Drive fallback). `reply --reassign EMAIL` hands an already-assigned thread
-  on and refuses (exit 3) before writing when the thread has no assignee;
+  on and refuses (exit 3) before writing when the thread's head post has
+  no assignee;
   `reply --suggestion` replies on a suggestion thread. New `edit-comment`,
   `edit-suggestion-reply`, `delete-reply` and `delete-suggestion-reply`
   commands edit or remove a single post you wrote (`updateCommentPost`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `gdoc` are documented here. This project follows
 ## [Unreleased]
 
 ### Added
+
 - **Native comment assignment and post operations (developer preview).**
   `comment --quote TEXT --assign EMAIL` creates an anchored comment assigned
   to a user (`insertComment.assigneeEmailAddress`; requires `--quote`, no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Native comment assignment and post operations (developer preview).**
+  `comment --quote TEXT --assign EMAIL` creates an anchored comment assigned
+  to a user (`insertComment.assigneeEmailAddress`; requires `--quote`, no
+  Drive fallback). `reply --reassign EMAIL` hands an already-assigned thread
+  on and refuses (exit 3) before writing when the thread has no assignee;
+  `reply --suggestion` replies on a suggestion thread. New `edit-comment`,
+  `edit-suggestion-reply`, `delete-reply` and `delete-suggestion-reply`
+  commands edit or remove a single post you wrote (`updateCommentPost`,
+  `deleteCommentReply`), with pre-write refusals for a suggestion's
+  generated head post and for action/assignment replies. Each native write
+  requires `commentUpdateState: ALL_SAVED` and is verified by reading the
+  thread back. Ordinary comment reads and writes, and the awareness system,
+  stay on the Drive API. The four new commands are exposed over MCP as
+  writes; the delete commands require `force: true` there.
+
 ## [0.21.0] — 2026-08-26
 
 ### Added
@@ -54,7 +72,6 @@ All notable changes to `gdoc` are documented here. This project follows
   once at call entry** instead of per service access, so a
   `gdoc auth --set-default` made while a command runs can no longer hand
   the same command's read and write to different accounts.
-
 ## [0.20.1] — 2026-08-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -226,12 +226,16 @@ gdoc cat 1aBcDeFg...
 | Command | Description |
 |---------|-------------|
 | `comments DOC` | List all open comments (`--all` to include resolved) |
-| `comment DOC TEXT` | Add a comment (`--quote` to anchor it to text — see below) |
+| `comment DOC TEXT` | Add a comment (`--quote` to anchor it to text — see below; `--assign EMAIL` to assign it, preview) |
 | `comment-info DOC ID` | Get a single comment with full detail |
-| `reply DOC COMMENT_ID TEXT` | Reply to a comment |
+| `reply DOC COMMENT_ID TEXT` | Reply to a comment (`--suggestion` for a suggestion thread, `--reassign EMAIL` to hand an assigned comment on — preview) |
 | `resolve DOC COMMENT_ID` | Resolve a comment (`--message` to include a note) |
 | `reopen DOC COMMENT_ID` | Reopen a resolved comment |
 | `delete-comment DOC ID` | Delete a comment (`--force` to skip confirmation) |
+| `edit-comment DOC COMMENT_ID POST_ID TEXT` | Edit a comment or reply you wrote (preview) |
+| `edit-suggestion-reply DOC SUGGESTION_ID POST_ID TEXT` | Edit a reply you wrote on a suggestion thread (preview) |
+| `delete-reply DOC COMMENT_ID POST_ID` | Delete one reply you wrote (`--force` to skip confirmation; preview) |
+| `delete-suggestion-reply DOC SUGGESTION_ID POST_ID` | Delete one reply you wrote on a suggestion thread (`--force`; preview) |
 
 `comment --quote "some doc text"` anchors the comment to the first occurrence
 of that text (all tabs are searched). When the OAuth client's Cloud project is
@@ -248,6 +252,36 @@ transparently to the Drive API path: the comment is created unanchored
 the Docs UI does not highlight. Same command either way — anchoring problems
 never fail the comment (though unrelated API errors, like a missing doc or
 expired auth, still do).
+
+#### Native thread operations (developer preview)
+
+Ordinary comment reads and writes stay on the Drive API. A few operations
+only exist in the Docs API's native comment threads, and the commands marked
+*preview* above use them — there is no Drive fallback, so they require an
+enrolled Cloud project and fail with a message naming the reason otherwise:
+
+- `comment DOC TEXT --quote "doc text" --assign EMAIL` creates an anchored
+  comment assigned to `EMAIL` (`insertComment.assigneeEmailAddress`). It
+  requires `--quote` and never degrades to an unassigned comment.
+- `reply DOC COMMENT_ID TEXT --reassign EMAIL` hands an **already assigned**
+  thread to someone else. The thread is read first and the command stops
+  (exit 3) if it has no assignee — Google rejects reassignment of an
+  unassigned thread — so start with `comment --assign`.
+- `reply DOC SUGGESTION_ID TEXT --suggestion` replies on a suggestion
+  thread. The flag, not the ID, selects the namespace; suggestion IDs look
+  like `suggest.xxxx` and are refused without the flag.
+- `edit-comment` / `edit-suggestion-reply` change the text of a post you
+  wrote; `delete-reply` / `delete-suggestion-reply` remove one reply you
+  wrote. `POST_ID` is the reply ID shown by `comment-info` (native post IDs
+  and Drive reply IDs are the same; a comment's head post ID equals its
+  comment ID). A suggestion's generated head post cannot be edited, and
+  replies that carry a resolve/reopen action or an assignment cannot be
+  deleted — both are refused before any write.
+
+Every native write requires `commentUpdateState: ALL_SAVED` and is verified
+by reading the thread back; `--json` reports `postId` (plus `assignee` for
+`--assign`/`--reassign`). The awareness system is unchanged: comment threads
+keep their Drive IDs, and suggestion-thread posts are not tracked as comments.
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -265,18 +265,18 @@ enrolled Cloud project and fail with a message naming the reason otherwise:
   requires `--quote` and never degrades to an unassigned comment.
 - `reply DOC COMMENT_ID TEXT --reassign EMAIL` hands an **already assigned**
   thread to someone else. The thread is read first and the command stops
-  (exit 3) if it has no assignee — Google rejects reassignment of an
-  unassigned thread — so start with `comment --assign`.
+  (exit 3) unless its head post carries an assignee — Google rejects
+  reassignment of an unassigned thread — so start with `comment --assign`.
 - `reply DOC SUGGESTION_ID TEXT --suggestion` replies on a suggestion
-  thread. The flag, not the ID, selects the namespace; suggestion IDs look
-  like `suggest.xxxx` and are refused without the flag.
+  thread. IDs are opaque: the flag (or the `*-suggestion-reply` command),
+  never the ID's shape, selects the namespace.
 - `edit-comment` / `edit-suggestion-reply` change the text of a post you
   wrote; `delete-reply` / `delete-suggestion-reply` remove one reply you
   wrote. `POST_ID` is the reply ID shown by `comment-info` (native post IDs
   and Drive reply IDs are the same; a comment's head post ID equals its
-  comment ID). A suggestion's generated head post cannot be edited, and
+  comment ID). A suggestion's generated head post cannot be edited,
   replies that carry a resolve/reopen action or an assignment cannot be
-  deleted — both are refused before any write.
+  deleted, and an already-deleted post is refused — all before any write.
 
 Every native write requires `commentUpdateState: ALL_SAVED` and is verified
 by reading the thread back (an assignment must appear on the thread, not

--- a/README.md
+++ b/README.md
@@ -279,8 +279,9 @@ enrolled Cloud project and fail with a message naming the reason otherwise:
   deleted — both are refused before any write.
 
 Every native write requires `commentUpdateState: ALL_SAVED` and is verified
-by reading the thread back; `--json` reports `postId` (plus `assignee` for
-`--assign`/`--reassign`). The awareness system is unchanged: comment threads
+by reading the thread back (an assignment must appear on the thread, not
+just in the response); `--json` reports `postId` (comment-thread replies also
+keep `replyId`, the same value) plus `assignee` for `--assign`/`--reassign`. The awareness system is unchanged: comment threads
 keep their Drive IDs, and suggestion-thread posts are not tracked as comments.
 
 ### Other

--- a/gdoc.md
+++ b/gdoc.md
@@ -33,6 +33,11 @@ gdoc comments DOC_ID                         # List open comments
 gdoc comments DOC_ID --all                   # Include resolved
 gdoc comment DOC_ID "comment text"           # Add unanchored comment
 gdoc reply DOC_ID COMMENT_ID "reply text"    # Reply to a comment
+gdoc comment DOC_ID "text" --quote "doc text" --assign EMAIL   # Assigned anchored comment (preview)
+gdoc reply DOC_ID COMMENT_ID "text" --reassign EMAIL          # Reassign an assigned thread (preview)
+gdoc reply DOC_ID SUGGESTION_ID "text" --suggestion           # Reply on a suggestion thread (preview)
+gdoc edit-comment DOC_ID COMMENT_ID POST_ID "new text"        # Edit a post you wrote (preview)
+gdoc delete-reply DOC_ID COMMENT_ID POST_ID --force           # Delete a reply you wrote (preview)
 gdoc resolve DOC_ID COMMENT_ID              # Resolve a comment
 gdoc reopen DOC_ID COMMENT_ID               # Reopen a resolved comment
 

--- a/gdoc.md
+++ b/gdoc.md
@@ -37,7 +37,9 @@ gdoc comment DOC_ID "text" --quote "doc text" --assign EMAIL   # Assigned anchor
 gdoc reply DOC_ID COMMENT_ID "text" --reassign EMAIL          # Reassign an assigned thread (preview)
 gdoc reply DOC_ID SUGGESTION_ID "text" --suggestion           # Reply on a suggestion thread (preview)
 gdoc edit-comment DOC_ID COMMENT_ID POST_ID "new text"        # Edit a post you wrote (preview)
+gdoc edit-suggestion-reply DOC_ID SUGGESTION_ID POST_ID "new"  # Same, on a suggestion thread (preview)
 gdoc delete-reply DOC_ID COMMENT_ID POST_ID --force           # Delete a reply you wrote (preview)
+gdoc delete-suggestion-reply DOC_ID SUGGESTION_ID POST_ID --force  # Same, on a suggestion thread (preview)
 gdoc resolve DOC_ID COMMENT_ID              # Resolve a comment
 gdoc reopen DOC_ID COMMENT_ID               # Reopen a resolved comment
 

--- a/gdoc.md
+++ b/gdoc.md
@@ -372,7 +372,7 @@ No other dependencies. Intentionally minimal.
 
 3. **`edit` is the workhorse for agents** — mirrors Claude Code's Edit tool. Agents `cat` the doc, find the text to change, and `edit` it with an exact unique match. No index math needed.
 
-4. **Comments use Drive API, not Docs API** — The Docs API can read comments embedded in the document structure, but CRUD operations on comments are exclusively through the Drive API v3.
+4. **Ordinary comment CRUD uses the Drive API; a few operations use the Docs API preview** — Listing, creating, replying, resolving, reopening and deleting comments go through Drive v3 `comments`/`replies`. Anchored comments (`comment --quote`), assignment (`--assign`, `reply --reassign`), suggestion-thread replies, and editing or deleting a single post use the Docs API's native comment threads (`documents.batchUpdate` `insertComment` / `addCommentReply` / `updateCommentPost` / `deleteCommentReply`, Workspace Developer Preview), verified by `documents.get` with `commentsViewMode`. Drive reply IDs and native post IDs are the same values.
 
 5. **`write` is destructive** — Full doc replacement. Blocked when doc changed since last read unless `--force` is passed. Agents should prefer `edit` for targeted edits.
 

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -133,12 +133,10 @@ def insert_comment(
     if revision_id:
         body["writeControl"] = {"requiredRevisionId": revision_id}
     try:
-        service = get_docs_service()
-        result = (
-            service.documents()
-            .batchUpdate(documentId=doc_id, body=body)
-            .execute()
-        )
+        # 5xx/transport failures raise GdocError (outcome uncertain) here
+        # and are deliberately not PreviewUnavailableError: falling back to
+        # a Drive comment could duplicate one Google already created.
+        result = _dispatch_native_write(doc_id, body, "insertComment")
     except HttpError as e:
         status = int(e.resp.status)
         # A non-enrolled project sees insertComment as an unknown field:
@@ -392,6 +390,48 @@ def post_is_action(post: dict) -> bool:
     return bool(post.get("assigneeEmail"))
 
 
+_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    ConnectionError, TimeoutError, OSError,  # socket/ssl errors are OSErrors
+)
+
+
+def _dispatch_native_write(doc_id: str, body: dict, what: str) -> dict:
+    """Send one native-thread batchUpdate and return the raw response.
+
+    Definite rejections (4xx) propagate as HttpError for the caller to
+    diagnose (preview, permission, concurrency). A 5xx or a transport
+    failure (timeout, dropped connection, TLS error) after the request
+    was dispatched is mutation-ambiguous — Google may have applied it
+    before the response was lost — so it is reported as such, never as a
+    plain failure a caller might retry or fall back from (which could
+    duplicate the comment or reply).
+    """
+    import httplib2
+
+    service = get_docs_service()
+    try:
+        return (
+            service.documents()
+            .batchUpdate(documentId=doc_id, body=body)
+            .execute()
+        )
+    except HttpError as e:
+        if int(e.resp.status) >= 500:
+            raise GdocError(
+                f"{what} outcome uncertain: the Docs API returned "
+                f"{e.resp.status} after the request was sent. The write may "
+                "have succeeded; inspect the document's comments before "
+                "retrying."
+            ) from e
+        raise
+    except (*_TRANSPORT_ERRORS, httplib2.HttpLib2Error) as e:
+        raise GdocError(
+            f"{what} outcome uncertain: the connection failed after the "
+            f"request was sent ({type(e).__name__}: {e}). The write may have "
+            "succeeded; inspect the document's comments before retrying."
+        ) from e
+
+
 def _run_thread_request(doc_id: str, request: dict) -> dict:
     """Send one comment-thread batchUpdate request and return its reply.
 
@@ -402,13 +442,9 @@ def _run_thread_request(doc_id: str, request: dict) -> dict:
     reply fail on a stale revision).
     """
     body = {"requests": [request]}
+    what = next(iter(request))
     try:
-        service = get_docs_service()
-        result = (
-            service.documents()
-            .batchUpdate(documentId=doc_id, body=body)
-            .execute()
-        )
+        result = _dispatch_native_write(doc_id, body, what)
     except HttpError as e:
         if _preview_parse_error(e):
             raise GdocError(_PREVIEW_UNAVAILABLE_MSG)

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -164,23 +164,23 @@ def insert_comment(
         _translate_http_error(e, doc_id)
 
     # Comment saves can fail even when the batchUpdate itself returns 200.
-    # An assigned comment has no fallback, so it also needs the state to be
-    # present: a response that doesn't say ALL_SAVED can't prove the save.
     state = result.get("commentUpdateState", "")
-    if state != "ALL_SAVED" and (state or assignee_email):
-        raise PreviewUnavailableError(
-            f"comment not saved (commentUpdateState={state or 'missing'})"
-        )
     replies = result.get("replies", [])
     thread = (replies[0] if replies else {}).get(
         "insertComment", {},
     ).get("commentThread", {})
     comment_id = thread.get("commentId", "")
-    if not comment_id:
-        raise PreviewUnavailableError(
-            "no comment thread in insertComment response"
-        )
     if assignee_email:
+        # No fallback exists for an assigned comment, and a 2xx whose state
+        # is not ALL_SAVED (or that names no thread) is mutation-ambiguous:
+        # a comment may or may not exist. Never call that "not created".
+        if state != "ALL_SAVED" or not comment_id:
+            raise GdocError(
+                "assigned comment outcome uncertain (commentUpdateState="
+                f"{state or 'missing'}, thread id "
+                f"{comment_id or 'missing'}): a comment may have been "
+                "created; inspect the document's comments before retrying"
+            )
         # The assignment is the point of the request; verify it landed
         # rather than echoing the requested address back as fact.
         doc = get_document_threads(doc_id)
@@ -190,6 +190,13 @@ def insert_comment(
                 f"comment #{comment_id} was created but the read-back does "
                 f"not show it assigned to {assignee_email}; inspect the thread"
             )
+        return comment_id
+    if state and state != "ALL_SAVED":
+        raise PreviewUnavailableError(f"comment not saved ({state})")
+    if not comment_id:
+        raise PreviewUnavailableError(
+            "no comment thread in insertComment response"
+        )
     return comment_id
 
 
@@ -309,8 +316,8 @@ def thread_kind(suggestion: bool) -> str:
 def find_thread(doc: dict, thread_id: str, suggestion: bool) -> dict | None:
     """Locate a native thread by ID in the namespace the caller named.
 
-    A comment ID is never looked up among suggestions or vice versa: the
-    two namespaces are distinct request fields and are kept explicit.
+    IDs are opaque; the caller's flag/command selects the namespace. A
+    comment ID is never looked up among suggestions or vice versa.
     """
     key = thread_kind(suggestion)
     threads = doc.get("suggestions" if suggestion else "comments") or []
@@ -340,17 +347,18 @@ def find_post(thread: dict, post_id: str) -> dict | None:
 def thread_assignee(thread: dict) -> str:
     """Current assignee email of a comment thread, or "" when unassigned.
 
-    Google reports assignment as ``assigneeEmail`` on the post that made
-    it (the head post for ``insertComment.assigneeEmailAddress``, a reply
-    for a reassignment — observed live), so the latest post carrying one
-    is the authority. Anything else is treated as unassigned (fail closed).
+    Per the API contract the thread's assignee is ``headPost.assigneeEmail``
+    (observed live for ``insertComment.assigneeEmailAddress``). A reply
+    that carries ``assigneeEmail`` records the reassignment event, not the
+    current state, so it is not consulted: an unassigned head fails closed.
     """
-    latest = ""
-    for post in thread_posts(thread):
-        value = post.get("assigneeEmail")
-        if isinstance(value, str) and value:
-            latest = value
-    return latest
+    value = (thread.get("headPost") or {}).get("assigneeEmail")
+    return value if isinstance(value, str) else ""
+
+
+def post_is_deleted(post: dict) -> bool:
+    """True for a tombstone: Google keeps deleted posts with ``deleted``."""
+    return bool(post.get("deleted"))
 
 
 def post_is_action(post: dict) -> bool:
@@ -508,7 +516,8 @@ def delete_comment_reply(
     """Delete one reply post (deleteCommentReply) and verify it is gone.
 
     Only the reply's author can delete it, and action or assignment
-    replies cannot be deleted; Google enforces this with a 400.
+    replies cannot be deleted; Google enforces this with a 400. The
+    read-back accepts either a missing post or a ``deleted`` tombstone.
     """
     request = {
         "deleteCommentReply": {
@@ -519,7 +528,9 @@ def delete_comment_reply(
     _run_thread_request(doc_id, request)
     doc = get_document_threads(doc_id)
     thread = find_thread(doc, thread_id, suggestion)
-    if thread is not None and find_post(thread, post_id) is not None:
+    post = find_post(thread, post_id) if thread is not None else None
+    # Gone, or kept as a tombstone (``deleted: true``), both mean deleted.
+    if post is not None and not post_is_deleted(post):
         raise GdocError(
             f"reply #{post_id} deletion was reported saved but the post "
             "is still on the thread; inspect the thread"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -183,7 +183,7 @@ def insert_comment(
             )
         # The assignment is the point of the request; verify it landed
         # rather than echoing the requested address back as fact.
-        doc = get_document_threads(doc_id)
+        doc = _read_back_threads(doc_id, f"assigned comment #{comment_id}")
         created = find_thread(doc, comment_id, suggestion=False)
         if created is None or thread_assignee(created) != assignee_email:
             raise GdocError(
@@ -306,6 +306,25 @@ def get_document_threads(doc_id: str) -> dict:
     doc.setdefault("comments", [])
     doc.setdefault("suggestions", [])
     return doc
+
+
+def _read_back_threads(doc_id: str, what: str) -> dict:
+    """Verification read after a write that Google reported as ALL_SAVED.
+
+    Any failure here (preview parameter rejected, transient API error,
+    expired auth) is mutation-ambiguous: the write may well have landed.
+    Re-raise with that framing — never the pre-write "No change was made"
+    message — and keep the original exit code.
+    """
+    try:
+        return get_document_threads(doc_id)
+    except GdocError as e:
+        raise GdocError(
+            f"{what} was reported saved (commentUpdateState=ALL_SAVED) but "
+            f"the verification read failed: {e} The write may have "
+            "succeeded; inspect the thread before retrying.",
+            exit_code=e.exit_code,
+        ) from e
 
 
 def thread_kind(suggestion: bool) -> str:
@@ -459,7 +478,7 @@ def add_comment_reply(
             "retrying"
         )
     # Read back: the reply must be durable on the thread we named.
-    doc = get_document_threads(doc_id)
+    doc = _read_back_threads(doc_id, f"reply #{post_id}")
     thread = find_thread(doc, thread_id, suggestion)
     saved = find_post(thread, post_id) if thread else None
     if saved is None:
@@ -496,7 +515,7 @@ def update_comment_post(
         }
     }
     _run_thread_request(doc_id, request)
-    doc = get_document_threads(doc_id)
+    doc = _read_back_threads(doc_id, f"edit of post #{post_id}")
     thread = find_thread(doc, thread_id, suggestion)
     post = find_post(thread, post_id) if thread else None
     # Google may normalize surrounding whitespace; compare stripped text.
@@ -526,7 +545,7 @@ def delete_comment_reply(
         }
     }
     _run_thread_request(doc_id, request)
-    doc = get_document_threads(doc_id)
+    doc = _read_back_threads(doc_id, f"deletion of reply #{post_id}")
     thread = find_thread(doc, thread_id, suggestion)
     post = find_post(thread, post_id) if thread is not None else None
     # Gone, or kept as a tombstone (``deleted: true``), both mean deleted.

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -141,27 +141,25 @@ def insert_comment(
         )
     except HttpError as e:
         status = int(e.resp.status)
-        detail = str(e)
         # A non-enrolled project sees insertComment as an unknown field:
         # either rejected by name ("Unknown name"/"Cannot find field") or
         # silently dropped, leaving an empty request union ("No request
         # set" — the observed live behavior). We always set insertComment,
         # so an empty union can only mean the server didn't recognize it.
+        if _preview_parse_error(e):
+            raise PreviewUnavailableError(
+                "insertComment not available (preview not enabled)"
+            )
         # A revision mismatch means the doc changed between our read and
         # this write; the caller's unanchored fallback is still correct.
-        if status == 400 and (
-            "Unknown name" in detail
-            or "Cannot find field" in detail
-            or "No request set" in detail
-            or "revision" in detail.lower()
-        ):
+        if status == 400 and "revision" in str(e).lower():
             raise PreviewUnavailableError(
-                "insertComment not available or not applicable "
-                "(preview not enabled, or the document changed)"
+                "the document changed since it was read; re-run to retry"
             )
         if status == 403:
             raise PreviewUnavailableError(
-                "insertComment not permitted for this user"
+                "insertComment not permitted for this user "
+                "(comment-only access cannot batchUpdate)"
             )
         _translate_http_error(e, doc_id)
 
@@ -182,6 +180,16 @@ def insert_comment(
         raise PreviewUnavailableError(
             "no comment thread in insertComment response"
         )
+    if assignee_email:
+        # The assignment is the point of the request; verify it landed
+        # rather than echoing the requested address back as fact.
+        doc = get_document_threads(doc_id)
+        created = find_thread(doc, comment_id, suggestion=False)
+        if created is None or thread_assignee(created) != assignee_email:
+            raise GdocError(
+                f"comment #{comment_id} was created but the read-back does "
+                f"not show it assigned to {assignee_email}; inspect the thread"
+            )
     return comment_id
 
 
@@ -241,7 +249,10 @@ def _documents_get_raw(service, doc_id: str, params: dict) -> dict:
 
     Bypasses the discovery-generated method so preview query parameters
     the public Discovery document doesn't list (``commentsViewMode``) can
-    be sent. Raises HttpError on non-2xx exactly like a discovery call.
+    be sent: the generated ``documents().get`` rejects them client-side
+    ("Got an unexpected keyword argument"). Uses the service's authorized
+    transport (``service._http``, the same object every discovery call
+    uses) and raises HttpError on non-2xx exactly like a discovery call.
     """
     from urllib.parse import quote, urlencode
 
@@ -279,6 +290,11 @@ def get_document_threads(doc_id: str) -> dict:
         if _preview_parse_error(e):
             raise GdocError(_PREVIEW_UNAVAILABLE_MSG)
         _translate_http_error(e, doc_id)
+    # A registered project echoes the view mode. If the parameter was
+    # silently dropped instead of rejected, the response has no thread
+    # lists at all — that must not read as "no threads".
+    if doc.get("commentsViewMode") != COMMENTS_VIEW_MODE_INCLUDED:
+        raise GdocError(_PREVIEW_UNAVAILABLE_MSG)
     doc = dict(doc)
     doc.setdefault("comments", [])
     doc.setdefault("suggestions", [])
@@ -324,26 +340,16 @@ def find_post(thread: dict, post_id: str) -> dict | None:
 def thread_assignee(thread: dict) -> str:
     """Current assignee email of a comment thread, or "" when unassigned.
 
-    Google reports assignment on the thread (``assigneeEmail`` /
-    ``assignee``) and echoes each (re)assignment on the post that made it,
-    so the latest post carrying an assignee is the authority when the
-    thread-level field is absent.
+    Google reports assignment as ``assigneeEmail`` on the post that made
+    it (the head post for ``insertComment.assigneeEmailAddress``, a reply
+    for a reassignment — observed live), so the latest post carrying one
+    is the authority. Anything else is treated as unassigned (fail closed).
     """
-    for key in ("assigneeEmail", "assigneeEmailAddress"):
-        if thread.get(key):
-            return thread[key]
-    assignee = thread.get("assignee")
-    if isinstance(assignee, dict):
-        for key in ("emailAddress", "email", "user"):
-            if assignee.get(key):
-                return assignee[key]
-    elif isinstance(assignee, str) and assignee:
-        return assignee
     latest = ""
     for post in thread_posts(thread):
-        for key in ("assigneeEmail", "assigneeEmailAddress"):
-            if post.get(key):
-                latest = post[key]
+        value = post.get("assigneeEmail")
+        if isinstance(value, str) and value:
+            latest = value
     return latest
 
 
@@ -356,7 +362,7 @@ def post_is_action(post: dict) -> bool:
     action = post.get("commentAction") or post.get("suggestionAction") or ""
     if action and not action.startswith("NO_"):
         return True
-    return bool(post.get("assigneeEmail") or post.get("assigneeEmailAddress"))
+    return bool(post.get("assigneeEmail"))
 
 
 def _run_thread_request(doc_id: str, request: dict) -> dict:
@@ -447,12 +453,18 @@ def add_comment_reply(
     # Read back: the reply must be durable on the thread we named.
     doc = get_document_threads(doc_id)
     thread = find_thread(doc, thread_id, suggestion)
-    if thread is None or find_post(thread, post_id) is None:
+    saved = find_post(thread, post_id) if thread else None
+    if saved is None:
         raise GdocError(
             f"reply #{post_id} was reported saved but is not on "
             f"{thread_kind(suggestion)} {thread_id}; inspect the thread"
         )
-    return new_post
+    if assignee_email and saved.get("assigneeEmail") != assignee_email:
+        raise GdocError(
+            f"reply #{post_id} was saved but the read-back does not show "
+            f"the thread reassigned to {assignee_email}; inspect the thread"
+        )
+    return saved
 
 
 def update_comment_post(
@@ -479,7 +491,8 @@ def update_comment_post(
     doc = get_document_threads(doc_id)
     thread = find_thread(doc, thread_id, suggestion)
     post = find_post(thread, post_id) if thread else None
-    if post is None or post.get("content") != content:
+    # Google may normalize surrounding whitespace; compare stripped text.
+    if post is None or (post.get("content") or "").strip() != content.strip():
         raise GdocError(
             f"post #{post_id} edit was reported saved but the read-back "
             "does not show the new text; inspect the thread"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -320,6 +320,7 @@ def _read_back_threads(doc_id: str, what: str) -> dict:
     message — and keep the original exit code.
     """
     import httplib2
+    from google.auth.exceptions import GoogleAuthError
 
     try:
         return get_document_threads(doc_id)
@@ -330,7 +331,7 @@ def _read_back_threads(doc_id: str, what: str) -> dict:
             "succeeded; inspect the thread before retrying.",
             exit_code=e.exit_code,
         ) from e
-    except (*_TRANSPORT_ERRORS, httplib2.HttpLib2Error) as e:
+    except (*_TRANSPORT_ERRORS, httplib2.HttpLib2Error, GoogleAuthError) as e:
         raise GdocError(
             f"{what} was reported saved (commentUpdateState=ALL_SAVED) but "
             f"the verification read failed ({type(e).__name__}: {e}). The "

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -183,7 +183,7 @@ def insert_comment(
         # rather than echoing the requested address back as fact.
         doc = _read_back_threads(doc_id, f"assigned comment #{comment_id}")
         created = find_thread(doc, comment_id, suggestion=False)
-        if created is None or thread_assignee(created) != assignee_email:
+        if created is None or head_post_assignee(created) != assignee_email:
             raise GdocError(
                 f"comment #{comment_id} was created but the read-back does "
                 f"not show it assigned to {assignee_email}; inspect the thread"
@@ -306,6 +306,11 @@ def get_document_threads(doc_id: str) -> dict:
     return doc
 
 
+_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    ConnectionError, TimeoutError, OSError,  # socket/ssl errors are OSErrors
+)
+
+
 def _read_back_threads(doc_id: str, what: str) -> dict:
     """Verification read after a write that Google reported as ALL_SAVED.
 
@@ -314,6 +319,8 @@ def _read_back_threads(doc_id: str, what: str) -> dict:
     Re-raise with that framing — never the pre-write "No change was made"
     message — and keep the original exit code.
     """
+    import httplib2
+
     try:
         return get_document_threads(doc_id)
     except GdocError as e:
@@ -322,6 +329,12 @@ def _read_back_threads(doc_id: str, what: str) -> dict:
             f"the verification read failed: {e} The write may have "
             "succeeded; inspect the thread before retrying.",
             exit_code=e.exit_code,
+        ) from e
+    except (*_TRANSPORT_ERRORS, httplib2.HttpLib2Error) as e:
+        raise GdocError(
+            f"{what} was reported saved (commentUpdateState=ALL_SAVED) but "
+            f"the verification read failed ({type(e).__name__}: {e}). The "
+            "write may have succeeded; inspect the thread before retrying."
         ) from e
 
 
@@ -361,13 +374,15 @@ def find_post(thread: dict, post_id: str) -> dict | None:
     return None
 
 
-def thread_assignee(thread: dict) -> str:
-    """Current assignee email of a comment thread, or "" when unassigned.
+def head_post_assignee(thread: dict) -> str:
+    """``headPost.assigneeEmail`` of a comment thread, or "" when absent.
 
-    Per the API contract the thread's assignee is ``headPost.assigneeEmail``
-    (observed live for ``insertComment.assigneeEmailAddress``). A reply
-    that carries ``assigneeEmail`` records the reassignment event, not the
-    current state, so it is not consulted: an unassigned head fails closed.
+    This is the precondition Google enforces for ``Post.assigneeEmail`` on
+    a reply (400 on an unassigned parent) and the field a fresh
+    ``insertComment.assigneeEmailAddress`` lands on. Assignment history is
+    event-sourced: a reassignment reply carries the new ``assigneeEmail``
+    while the head post keeps the original (observed live), so this
+    function makes no claim about the thread's *current* assignee.
     """
     value = (thread.get("headPost") or {}).get("assigneeEmail")
     return value if isinstance(value, str) else ""
@@ -388,11 +403,6 @@ def post_is_action(post: dict) -> bool:
     if action and not action.startswith("NO_"):
         return True
     return bool(post.get("assigneeEmail"))
-
-
-_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
-    ConnectionError, TimeoutError, OSError,  # socket/ssl errors are OSErrors
-)
 
 
 def _dispatch_native_write(doc_id: str, body: dict, what: str) -> dict:

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -95,6 +95,7 @@ def insert_comment(
     end_index: int,
     tab_id: str | None = None,
     revision_id: str = "",
+    assignee_email: str | None = None,
 ) -> str:
     """Insert a comment anchored to a text range (Docs API insertComment).
 
@@ -115,6 +116,9 @@ def insert_comment(
         tab_id: Tab the range lives in (omitted → first tab).
         revision_id: If non-empty, sent as writeControl.requiredRevisionId
             so the anchor can't land on stale coordinates.
+        assignee_email: If given, sent as ``assigneeEmailAddress`` so the
+            new thread is created assigned to that user (a Docs-native
+            concept the Drive comments API cannot express).
 
     Returns:
         The new comment thread ID (same ID space as Drive API comments).
@@ -122,11 +126,10 @@ def insert_comment(
     range_: dict = {"startIndex": start_index, "endIndex": end_index}
     if tab_id:
         range_["tabId"] = tab_id
-    body: dict = {
-        "requests": [
-            {"insertComment": {"content": content, "range": range_}}
-        ]
-    }
+    request: dict = {"content": content, "range": range_}
+    if assignee_email:
+        request["assigneeEmailAddress"] = assignee_email
+    body: dict = {"requests": [{"insertComment": request}]}
     if revision_id:
         body["writeControl"] = {"requiredRevisionId": revision_id}
     try:
@@ -163,9 +166,13 @@ def insert_comment(
         _translate_http_error(e, doc_id)
 
     # Comment saves can fail even when the batchUpdate itself returns 200.
+    # An assigned comment has no fallback, so it also needs the state to be
+    # present: a response that doesn't say ALL_SAVED can't prove the save.
     state = result.get("commentUpdateState", "")
-    if state and state != "ALL_SAVED":
-        raise PreviewUnavailableError(f"comment not saved ({state})")
+    if state != "ALL_SAVED" and (state or assignee_email):
+        raise PreviewUnavailableError(
+            f"comment not saved (commentUpdateState={state or 'missing'})"
+        )
     replies = result.get("replies", [])
     thread = (replies[0] if replies else {}).get(
         "insertComment", {},
@@ -176,6 +183,334 @@ def insert_comment(
             "no comment thread in insertComment response"
         )
     return comment_id
+
+
+# --- Native comment/suggestion threads (Docs API developer preview) ---
+#
+# Drive v3 remains gdoc's default read and mutation path for ordinary
+# comments (listing, pagination, tombstones and the awareness system all
+# depend on it). The helpers below are used only for what Drive cannot
+# express: assignment, replies on suggestion threads, editing a post, and
+# deleting a single reply. Both ID spaces are explicit: callers say whether
+# a thread ID names a CommentThread or a SuggestionThread; nothing guesses.
+
+_DOCS_BASE_URL = "https://docs.googleapis.com/v1/documents/"
+SUGGESTIONS_VIEW_MODE_INLINE = "SUGGESTIONS_INLINE"
+COMMENTS_VIEW_MODE_INCLUDED = "COMMENTS_VIEW_MODE_INCLUDED"
+
+_PREVIEW_UNAVAILABLE_MSG = (
+    "native comment threads are not available: the OAuth client's Cloud "
+    "project is not enrolled in the Google Workspace Developer Preview "
+    "(the Docs API rejected the preview field). No change was made."
+)
+
+
+def _preview_parse_error(e: HttpError) -> bool:
+    """True when a 400 says the server didn't understand a preview field.
+
+    A project not enrolled in the Developer Preview sees preview fields as
+    unknown — rejected by name ("Unknown name", "Cannot find field") or
+    silently dropped so the request union is empty ("No request set").
+    """
+    if int(e.resp.status) != 400:
+        return False
+    detail = str(e)
+    return (
+        "Unknown name" in detail
+        or "Cannot find field" in detail
+        or "No request set" in detail
+    )
+
+
+def _http_error_message(e: HttpError) -> str:
+    """Google's human-readable error message from an HttpError body."""
+    try:
+        import json
+
+        payload = json.loads(e.content.decode("utf-8"))
+        msg = payload.get("error", {}).get("message", "")
+        if msg:
+            return msg
+    except (ValueError, AttributeError, UnicodeDecodeError):
+        pass
+    return e.reason or str(e)
+
+
+def _documents_get_raw(service, doc_id: str, params: dict) -> dict:
+    """documents.get through the service's authorized transport.
+
+    Bypasses the discovery-generated method so preview query parameters
+    the public Discovery document doesn't list (``commentsViewMode``) can
+    be sent. Raises HttpError on non-2xx exactly like a discovery call.
+    """
+    from urllib.parse import quote, urlencode
+
+    from googleapiclient.http import HttpRequest
+    from googleapiclient.model import JsonModel
+
+    uri = f"{_DOCS_BASE_URL}{quote(doc_id, safe='')}?{urlencode(params)}"
+    request = HttpRequest(
+        service._http, JsonModel().response, uri, method="GET",
+    )
+    return request.execute()
+
+
+def get_document_threads(doc_id: str) -> dict:
+    """Fetch the document with its native comment and suggestion threads.
+
+    Reads with includeTabsContent=true, suggestionsViewMode=
+    SUGGESTIONS_INLINE and commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED,
+    so the response carries ``comments[]`` and ``suggestions[]`` (each a
+    thread with ``headPost`` and ``replies[]`` of Posts) plus
+    ``revisionId``. Both lists are always present in the result.
+
+    Raises GdocError (exit 1) naming preview enrollment when Google rejects
+    ``commentsViewMode``; other HttpErrors are translated as usual.
+    """
+    params = {
+        "includeTabsContent": "true",
+        "suggestionsViewMode": SUGGESTIONS_VIEW_MODE_INLINE,
+        "commentsViewMode": COMMENTS_VIEW_MODE_INCLUDED,
+    }
+    try:
+        service = get_docs_service()
+        doc = _documents_get_raw(service, doc_id, params)
+    except HttpError as e:
+        if _preview_parse_error(e):
+            raise GdocError(_PREVIEW_UNAVAILABLE_MSG)
+        _translate_http_error(e, doc_id)
+    doc = dict(doc)
+    doc.setdefault("comments", [])
+    doc.setdefault("suggestions", [])
+    return doc
+
+
+def thread_kind(suggestion: bool) -> str:
+    """Request/response field naming the thread ID for its namespace."""
+    return "suggestionId" if suggestion else "commentId"
+
+
+def find_thread(doc: dict, thread_id: str, suggestion: bool) -> dict | None:
+    """Locate a native thread by ID in the namespace the caller named.
+
+    A comment ID is never looked up among suggestions or vice versa: the
+    two namespaces are distinct request fields and are kept explicit.
+    """
+    key = thread_kind(suggestion)
+    threads = doc.get("suggestions" if suggestion else "comments") or []
+    for thread in threads:
+        if thread.get(key) == thread_id:
+            return thread
+    return None
+
+
+def thread_posts(thread: dict) -> list[dict]:
+    """Head post followed by replies, in thread order."""
+    posts = []
+    head = thread.get("headPost")
+    if head:
+        posts.append(head)
+    posts.extend(thread.get("replies") or [])
+    return posts
+
+
+def find_post(thread: dict, post_id: str) -> dict | None:
+    for post in thread_posts(thread):
+        if post.get("postId") == post_id:
+            return post
+    return None
+
+
+def thread_assignee(thread: dict) -> str:
+    """Current assignee email of a comment thread, or "" when unassigned.
+
+    Google reports assignment on the thread (``assigneeEmail`` /
+    ``assignee``) and echoes each (re)assignment on the post that made it,
+    so the latest post carrying an assignee is the authority when the
+    thread-level field is absent.
+    """
+    for key in ("assigneeEmail", "assigneeEmailAddress"):
+        if thread.get(key):
+            return thread[key]
+    assignee = thread.get("assignee")
+    if isinstance(assignee, dict):
+        for key in ("emailAddress", "email", "user"):
+            if assignee.get(key):
+                return assignee[key]
+    elif isinstance(assignee, str) and assignee:
+        return assignee
+    latest = ""
+    for post in thread_posts(thread):
+        for key in ("assigneeEmail", "assigneeEmailAddress"):
+            if post.get(key):
+                latest = post[key]
+    return latest
+
+
+def post_is_action(post: dict) -> bool:
+    """True when a post records a resolve/reopen action or an assignment.
+
+    Such posts cannot be deleted through deleteCommentReply (Google
+    returns 400), so callers refuse before writing.
+    """
+    action = post.get("commentAction") or post.get("suggestionAction") or ""
+    if action and not action.startswith("NO_"):
+        return True
+    return bool(post.get("assigneeEmail") or post.get("assigneeEmailAddress"))
+
+
+def _run_thread_request(doc_id: str, request: dict) -> dict:
+    """Send one comment-thread batchUpdate request and return its reply.
+
+    Requires HTTP success and ``commentUpdateState == ALL_SAVED``: a
+    thread write that the server accepted but did not save is an error,
+    never a success. Post operations carry no document ranges, so no
+    ``writeControl`` is sent (a concurrent text edit must not make a
+    reply fail on a stale revision).
+    """
+    body = {"requests": [request]}
+    try:
+        service = get_docs_service()
+        result = (
+            service.documents()
+            .batchUpdate(documentId=doc_id, body=body)
+            .execute()
+        )
+    except HttpError as e:
+        if _preview_parse_error(e):
+            raise GdocError(_PREVIEW_UNAVAILABLE_MSG)
+        status = int(e.resp.status)
+        if status in (400, 403):
+            # Google's author/assignee rules (not the post's author, head
+            # post of a suggestion, action or assignment reply, unassigned
+            # parent for a reassignment) surface as 400/403 with a
+            # descriptive message. Preserve it rather than collapsing it
+            # into a generic permission error.
+            raise GdocError(
+                f"Docs API rejected the request ({status}): "
+                f"{_http_error_message(e)}"
+            )
+        if status == 404:
+            raise GdocError(
+                f"Not found: document {doc_id}, or the thread/post named in "
+                "the request"
+            )
+        _translate_http_error(e, doc_id)
+    state = result.get("commentUpdateState", "")
+    if state != "ALL_SAVED":
+        raise GdocError(
+            f"comment thread update not saved (commentUpdateState="
+            f"{state or 'missing'}); inspect the thread before retrying"
+        )
+    replies = result.get("replies") or [{}]
+    return replies[0] or {}
+
+
+def add_comment_reply(
+    doc_id: str,
+    thread_id: str,
+    content: str = "",
+    suggestion: bool = False,
+    assignee_email: str | None = None,
+) -> dict:
+    """Reply to a native comment or suggestion thread (addCommentReply).
+
+    Args:
+        thread_id: CommentThread ID (``suggestion=False``) or
+            SuggestionThread ID (``suggestion=True``).
+        content: Reply text (plain). May be empty only when the post
+            carries an assignment.
+        assignee_email: If given, the post reassigns the thread
+            (``post.assigneeEmail``). Google rejects this on a thread that
+            has no assignee yet; callers preflight that.
+
+    Returns:
+        The new reply Post as returned by Google (``postId`` is required
+        and verified against a read-back of the thread).
+    """
+    post: dict = {}
+    if content:
+        post["content"] = content
+    if assignee_email:
+        post["assigneeEmail"] = assignee_email
+    request = {
+        "addCommentReply": {thread_kind(suggestion): thread_id, "post": post}
+    }
+    reply = _run_thread_request(doc_id, request)
+    new_post = reply.get("addCommentReply", {}).get("post") or {}
+    post_id = new_post.get("postId", "")
+    if not post_id:
+        raise GdocError(
+            "addCommentReply returned no post; inspect the thread before "
+            "retrying"
+        )
+    # Read back: the reply must be durable on the thread we named.
+    doc = get_document_threads(doc_id)
+    thread = find_thread(doc, thread_id, suggestion)
+    if thread is None or find_post(thread, post_id) is None:
+        raise GdocError(
+            f"reply #{post_id} was reported saved but is not on "
+            f"{thread_kind(suggestion)} {thread_id}; inspect the thread"
+        )
+    return new_post
+
+
+def update_comment_post(
+    doc_id: str,
+    thread_id: str,
+    post_id: str,
+    content: str,
+    suggestion: bool = False,
+) -> None:
+    """Edit a post's text (updateCommentPost) and verify it took effect.
+
+    Only the post's author can edit it; a suggestion thread's generated
+    head post cannot be edited. Google enforces both with a 400, which is
+    surfaced with its message; callers preflight the head-post case.
+    """
+    request = {
+        "updateCommentPost": {
+            thread_kind(suggestion): thread_id,
+            "postId": post_id,
+            "content": content,
+        }
+    }
+    _run_thread_request(doc_id, request)
+    doc = get_document_threads(doc_id)
+    thread = find_thread(doc, thread_id, suggestion)
+    post = find_post(thread, post_id) if thread else None
+    if post is None or post.get("content") != content:
+        raise GdocError(
+            f"post #{post_id} edit was reported saved but the read-back "
+            "does not show the new text; inspect the thread"
+        )
+
+
+def delete_comment_reply(
+    doc_id: str,
+    thread_id: str,
+    post_id: str,
+    suggestion: bool = False,
+) -> None:
+    """Delete one reply post (deleteCommentReply) and verify it is gone.
+
+    Only the reply's author can delete it, and action or assignment
+    replies cannot be deleted; Google enforces this with a 400.
+    """
+    request = {
+        "deleteCommentReply": {
+            thread_kind(suggestion): thread_id,
+            "postId": post_id,
+        }
+    }
+    _run_thread_request(doc_id, request)
+    doc = get_document_threads(doc_id)
+    thread = find_thread(doc, thread_id, suggestion)
+    if thread is not None and find_post(thread, post_id) is not None:
+        raise GdocError(
+            f"reply #{post_id} deletion was reported saved but the post "
+            "is still on the thread; inspect the thread"
+        )
 
 
 def set_page_mode(doc_id: str, pageless: bool) -> None:

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2347,7 +2347,12 @@ def cmd_comment(args) -> int:
     quiet = getattr(args, "quiet", False)
 
     quote = getattr(args, "quote", "") or ""
-    assignee = (getattr(args, "assign", "") or "").strip()
+    assign_raw = getattr(args, "assign", None)
+    assignee = (assign_raw or "").strip()
+    if assign_raw is not None and not assignee:
+        # A supplied but blank --assign must not silently become an
+        # unassigned Drive comment.
+        raise GdocError("--assign requires an email address", exit_code=3)
     if assignee:
         # Assignment is Docs-native only (insertComment.assigneeEmailAddress),
         # and insertComment needs a range, so --assign implies --quote and
@@ -2383,8 +2388,11 @@ def cmd_comment(args) -> int:
         result = create_comment(doc_id, args.text, quote=quote)
         new_id = result["id"]
 
-    from gdoc.api.drive import get_file_version
-    command_version = get_file_version(doc_id).get("version")
+    if assignee:
+        command_version = _post_write_version(doc_id)
+    else:
+        from gdoc.api.drive import get_file_version
+        command_version = get_file_version(doc_id).get("version")
 
     from gdoc.format import get_output_mode, format_json
     mode = get_output_mode(args)
@@ -2413,6 +2421,28 @@ def cmd_comment(args) -> int:
     )
 
     return 0
+
+
+def _post_write_version(doc_id: str) -> int | None:
+    """Drive version after a verified native write, best-effort.
+
+    The write has already been confirmed by read-back; failing the command
+    here would invite a duplicate retry. Warn on stderr and record no
+    version instead (the next pre-flight re-baselines from Drive).
+    """
+    import sys
+
+    from gdoc.api.drive import get_file_version
+
+    try:
+        return get_file_version(doc_id).get("version")
+    except Exception as e:  # noqa: BLE001 - any failure is non-fatal here
+        print(
+            f"WARN: write succeeded but the Drive version lookup failed "
+            f"({type(e).__name__}: {e}); awareness state not versioned",
+            file=sys.stderr,
+        )
+        return None
 
 
 def _native_thread_or_fail(doc_id: str, thread_id: str, suggestion: bool) -> dict:
@@ -2450,14 +2480,14 @@ def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
     reassign = (getattr(args, "reassign", "") or "").strip()
     text = args.text or ""
 
-    from gdoc.api.docs import add_comment_reply, thread_assignee, thread_kind
+    from gdoc.api.docs import add_comment_reply, head_post_assignee, thread_kind
 
     if reassign:
         # Preflight: Google rejects Post.assigneeEmail on a thread whose
         # head post has no assignee, so read the native thread and fail
         # before writing. Only headPost.assigneeEmail counts (fail closed).
         thread = _native_thread_or_fail(doc_id, thread_id, suggestion=False)
-        if not thread_assignee(thread):
+        if not head_post_assignee(thread):
             raise GdocError(
                 f"comment #{thread_id} has no assignee on its head post; "
                 "--reassign can only move an existing assignment. Create the "
@@ -2471,8 +2501,7 @@ def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
     )
     post_id = post.get("postId", "")
 
-    from gdoc.api.drive import get_file_version
-    command_version = get_file_version(doc_id).get("version")
+    command_version = _post_write_version(doc_id)
 
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)
@@ -2715,8 +2744,7 @@ def _cmd_edit_post(args, suggestion: bool) -> int:
 
     update_comment_post(doc_id, thread_id, post_id, text, suggestion=suggestion)
 
-    from gdoc.api.drive import get_file_version
-    command_version = get_file_version(doc_id).get("version")
+    command_version = _post_write_version(doc_id)
 
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)
@@ -2798,8 +2826,7 @@ def _cmd_delete_post(args, suggestion: bool) -> int:
 
     delete_comment_reply(doc_id, thread_id, post_id, suggestion=suggestion)
 
-    from gdoc.api.drive import get_file_version
-    command_version = get_file_version(doc_id).get("version")
+    command_version = _post_write_version(doc_id)
 
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2427,32 +2427,6 @@ def _native_thread_or_fail(doc_id: str, thread_id: str, suggestion: bool) -> dic
     return thread
 
 
-_SUGGESTION_ID_PREFIX = "suggest."
-
-
-def _check_thread_namespace(thread_id: str, suggestion: bool) -> None:
-    """Refuse an ID that visibly belongs to the other thread namespace.
-
-    Native suggestion IDs are prefixed ``suggest.`` (observed live);
-    comment IDs are not. The flag, not the ID, chooses the request field,
-    so an obvious mismatch is a usage error before any API call.
-    """
-    looks_like_suggestion = thread_id.startswith(_SUGGESTION_ID_PREFIX)
-    if suggestion and not looks_like_suggestion:
-        raise GdocError(
-            f"{thread_id} does not look like a suggestion ID "
-            f"(expected a '{_SUGGESTION_ID_PREFIX}' prefix); drop "
-            "--suggestion for a comment thread",
-            exit_code=3,
-        )
-    if not suggestion and looks_like_suggestion:
-        raise GdocError(
-            f"{thread_id} is a suggestion thread ID; use the "
-            "suggestion-thread form of this command",
-            exit_code=3,
-        )
-
-
 def _validate_native_reply_args(args, thread_id: str) -> None:
     """Usage checks for `reply --suggestion` / `--reassign`, before any I/O."""
     suggestion = bool(getattr(args, "suggestion", False))
@@ -2463,7 +2437,6 @@ def _validate_native_reply_args(args, thread_id: str) -> None:
             "thread has no assignee",
             exit_code=3,
         )
-    _check_thread_namespace(thread_id, suggestion)
     _validate_post_text(args.text or "", "reply text")
 
 
@@ -2477,13 +2450,13 @@ def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
     from gdoc.api.docs import add_comment_reply, thread_assignee, thread_kind
 
     if reassign:
-        # Preflight: Google rejects Post.assigneeEmail on a thread with no
-        # assignee, so read the native thread and fail before writing. An
-        # unrecognised or missing assignee field fails closed.
+        # Preflight: Google rejects Post.assigneeEmail on a thread whose
+        # head post has no assignee, so read the native thread and fail
+        # before writing. Only headPost.assigneeEmail counts (fail closed).
         thread = _native_thread_or_fail(doc_id, thread_id, suggestion=False)
         if not thread_assignee(thread):
             raise GdocError(
-                f"comment #{thread_id} has no assignee (or none is reported); "
+                f"comment #{thread_id} has no assignee on its head post; "
                 "--reassign can only move an existing assignment. Create the "
                 "thread with `comment --quote ... --assign EMAIL` instead.",
                 exit_code=3,
@@ -2546,10 +2519,6 @@ def cmd_reply(args) -> int:
     )
     if native:
         _validate_native_reply_args(args, comment_id)
-    else:
-        # Drive path: a suggestion thread is not a Drive comment, so a bare
-        # suggestion ID would only produce a misleading Drive 404.
-        _check_thread_namespace(comment_id, suggestion=False)
 
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
@@ -2701,13 +2670,17 @@ def _cmd_edit_post(args, suggestion: bool) -> int:
     thread_id = args.thread_id
     post_id = args.post_id
     text = args.text or ""
-    _check_thread_namespace(thread_id, suggestion)
     _validate_post_text(text, "new text")
 
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
 
-    from gdoc.api.docs import find_post, thread_kind, update_comment_post
+    from gdoc.api.docs import (
+        find_post,
+        post_is_deleted,
+        thread_kind,
+        update_comment_post,
+    )
 
     thread = _native_thread_or_fail(doc_id, thread_id, suggestion)
     post = find_post(thread, post_id)
@@ -2715,6 +2688,10 @@ def _cmd_edit_post(args, suggestion: bool) -> int:
         raise GdocError(
             f"post {post_id} not found on {thread_kind(suggestion)} {thread_id}",
             exit_code=3,
+        )
+    if post_is_deleted(post):
+        raise GdocError(
+            f"post {post_id} on #{thread_id} has been deleted", exit_code=3,
         )
     head_id = (thread.get("headPost") or {}).get("postId")
     if suggestion and post_id == head_id:
@@ -2763,7 +2740,6 @@ def _cmd_delete_post(args, suggestion: bool) -> int:
     thread_id = args.thread_id
     post_id = args.post_id
     force = getattr(args, "force", False)
-    _check_thread_namespace(thread_id, suggestion)
 
     from gdoc.util import confirm_destructive
     confirm_destructive(f"delete reply {post_id} on #{thread_id}", force=force)
@@ -2775,6 +2751,7 @@ def _cmd_delete_post(args, suggestion: bool) -> int:
         delete_comment_reply,
         find_post,
         post_is_action,
+        post_is_deleted,
         thread_kind,
     )
 
@@ -2784,6 +2761,10 @@ def _cmd_delete_post(args, suggestion: bool) -> int:
         raise GdocError(
             f"post {post_id} not found on {thread_kind(suggestion)} {thread_id}",
             exit_code=3,
+        )
+    if post_is_deleted(post):
+        raise GdocError(
+            f"post {post_id} on #{thread_id} is already deleted", exit_code=3,
         )
     head_id = (thread.get("headPost") or {}).get("postId")
     if post_id == head_id:

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2262,7 +2262,25 @@ def cmd_comments(args) -> int:
     return 0
 
 
-def _try_anchored_comment(doc_id: str, text: str, quote: str) -> str:
+_POST_MAX_UTF8 = 2048
+
+
+def _validate_post_text(text: str, what: str = "comment text") -> None:
+    """Native comment posts are plain text, non-empty, <= 2048 UTF-8 bytes."""
+    if not text or not text.strip():
+        raise GdocError(f"{what} must not be empty", exit_code=3)
+    size = len(text.encode("utf-8"))
+    if size > _POST_MAX_UTF8:
+        raise GdocError(
+            f"{what} is {size} UTF-8 bytes; the Docs API limit is "
+            f"{_POST_MAX_UTF8}",
+            exit_code=3,
+        )
+
+
+def _try_anchored_comment(
+    doc_id: str, text: str, quote: str, assignee_email: str | None = None,
+) -> str:
     """Create a truly anchored comment via the Docs API preview, if possible.
 
     Searches every tab for the first occurrence of *quote* (exact match
@@ -2272,6 +2290,11 @@ def _try_anchored_comment(doc_id: str, text: str, quote: str) -> str:
     should fall back to the Drive quotedFileContent path: quote text not
     found, or the preview request unavailable (project not enrolled,
     comment-only access, or the doc changed since the read).
+
+    With *assignee_email* there is no fallback — the Drive API cannot
+    assign a comment — so a missing quote is a usage error (exit 3) and an
+    unavailable preview is an error naming the reason, never a silent
+    unassigned comment.
     """
     from gdoc.api.docs import (
         find_text_in_document,
@@ -2293,14 +2316,29 @@ def _try_anchored_comment(doc_id: str, text: str, quote: str) -> str:
             )
             if not matches:
                 continue
+            kwargs = {"tab_id": tab["id"], "revision_id": revision_id}
+            if assignee_email:
+                kwargs["assignee_email"] = assignee_email
             try:
                 return insert_comment(
                     doc_id, text,
                     matches[0]["startIndex"], matches[0]["endIndex"],
-                    tab_id=tab["id"], revision_id=revision_id,
+                    **kwargs,
                 )
-            except PreviewUnavailableError:
+            except PreviewUnavailableError as e:
+                if assignee_email:
+                    raise GdocError(
+                        f"cannot create an assigned comment: {e}. Assigned "
+                        "comments need the Docs API developer preview and "
+                        "edit access; no comment was created."
+                    )
                 return ""
+    if assignee_email:
+        raise GdocError(
+            f"Quote text not found in document: {quote!r}. An assigned "
+            "comment must be anchored; no comment was created.",
+            exit_code=3,
+        )
     return ""
 
 
@@ -2313,8 +2351,24 @@ def cmd_comment(args) -> int:
     change_info = pre_flight(doc_id, quiet=quiet)
 
     quote = getattr(args, "quote", "") or ""
+    assignee = (getattr(args, "assign", "") or "").strip()
+    if assignee:
+        # Assignment is Docs-native only (insertComment.assigneeEmailAddress),
+        # and insertComment needs a range, so --assign implies --quote and
+        # never falls back to an unassigned Drive comment.
+        if not quote:
+            raise GdocError(
+                "--assign requires --quote: an assigned comment is created "
+                "through the Docs API and must be anchored to document text",
+                exit_code=3,
+            )
+        _validate_post_text(args.text)
     new_id = ""
-    if quote:
+    if quote and assignee:
+        new_id = _try_anchored_comment(
+            doc_id, args.text, quote, assignee_email=assignee,
+        )
+    elif quote:
         new_id = _try_anchored_comment(doc_id, args.text, quote)
     anchored = bool(new_id)
     if not anchored:
@@ -2329,13 +2383,19 @@ def cmd_comment(args) -> int:
     mode = get_output_mode(args)
     if mode == "json":
         extra = {"anchored": anchored} if quote else {}
+        if assignee:
+            extra["assignee"] = assignee
         print(format_json(id=new_id, status="created", **extra))
     elif mode == "plain":
         print(f"id\t{new_id}")
         if quote:
             print(f"anchored\t{'true' if anchored else 'false'}")
+        if assignee:
+            print(f"assignee\t{assignee}")
     else:
         suffix = " (anchored)" if anchored else ""
+        if assignee:
+            suffix = f" (anchored, assigned to {assignee})"
         print(f"OK comment #{new_id}{suffix}")
 
     from gdoc.state import update_state_after_command
@@ -2348,6 +2408,113 @@ def cmd_comment(args) -> int:
     return 0
 
 
+def _native_thread_or_fail(doc_id: str, thread_id: str, suggestion: bool) -> dict:
+    """Read the native threads and return the named one, or exit 3."""
+    from gdoc.api.docs import find_thread, get_document_threads
+
+    doc = get_document_threads(doc_id)
+    thread = find_thread(doc, thread_id, suggestion)
+    if thread is None:
+        kind = "suggestion" if suggestion else "comment"
+        raise GdocError(f"{kind} thread not found: {thread_id}", exit_code=3)
+    return thread
+
+
+_SUGGESTION_ID_PREFIX = "suggest."
+
+
+def _check_thread_namespace(thread_id: str, suggestion: bool) -> None:
+    """Refuse an ID that visibly belongs to the other thread namespace.
+
+    Native suggestion IDs are prefixed ``suggest.`` (observed live);
+    comment IDs are not. The flag, not the ID, chooses the request field,
+    so an obvious mismatch is a usage error before any API call.
+    """
+    looks_like_suggestion = thread_id.startswith(_SUGGESTION_ID_PREFIX)
+    if suggestion and not looks_like_suggestion:
+        raise GdocError(
+            f"{thread_id} does not look like a suggestion ID "
+            f"(expected a '{_SUGGESTION_ID_PREFIX}' prefix); drop "
+            "--suggestion for a comment thread",
+            exit_code=3,
+        )
+    if not suggestion and looks_like_suggestion:
+        raise GdocError(
+            f"{thread_id} is a suggestion thread ID; use the "
+            "suggestion-thread form of this command",
+            exit_code=3,
+        )
+
+
+def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
+    """`gdoc reply --suggestion` / `--reassign`: Docs-native addCommentReply."""
+    quiet = getattr(args, "quiet", False)
+    suggestion = bool(getattr(args, "suggestion", False))
+    reassign = (getattr(args, "reassign", "") or "").strip()
+    text = args.text or ""
+    if suggestion and reassign:
+        raise GdocError(
+            "--reassign applies to comment threads only; a suggestion "
+            "thread has no assignee",
+            exit_code=3,
+        )
+    _check_thread_namespace(thread_id, suggestion)
+    _validate_post_text(text, "reply text")
+
+    from gdoc.api.docs import add_comment_reply, thread_assignee, thread_kind
+
+    if reassign:
+        # Preflight: Google rejects Post.assigneeEmail on a thread with no
+        # assignee, so read the native thread and fail before writing. An
+        # unrecognised or missing assignee field fails closed.
+        thread = _native_thread_or_fail(doc_id, thread_id, suggestion=False)
+        if not thread_assignee(thread):
+            raise GdocError(
+                f"comment #{thread_id} has no assignee (or none is reported); "
+                "--reassign can only move an existing assignment. Create the "
+                "thread with `comment --quote ... --assign EMAIL` instead.",
+                exit_code=3,
+            )
+
+    post = add_comment_reply(
+        doc_id, thread_id, content=text, suggestion=suggestion,
+        assignee_email=reassign or None,
+    )
+    post_id = post.get("postId", "")
+
+    from gdoc.api.drive import get_file_version
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    id_key = thread_kind(suggestion)
+    if mode == "json":
+        extra = {"assignee": reassign} if reassign else {}
+        print(format_json(
+            **{id_key: thread_id}, postId=post_id, status="created", **extra,
+        ))
+    elif mode == "plain":
+        print(f"{id_key}\t{thread_id}")
+        print(f"postId\t{post_id}")
+        if reassign:
+            print(f"assignee\t{reassign}")
+    else:
+        what = "suggestion " if suggestion else ""
+        suffix = f" (reassigned to {reassign})" if reassign else ""
+        print(f"OK reply on {what}#{thread_id}{suffix}")
+
+    from gdoc.state import update_state_after_command
+    # Comment-thread IDs are shared with the Drive comments API (the
+    # awareness system tracks them); suggestion threads are not Drive
+    # comments, so only the version is recorded for them.
+    patch = None if suggestion else {"add_comment_id": thread_id}
+    update_state_after_command(
+        doc_id, change_info, command="reply", quiet=quiet,
+        command_version=command_version, comment_state_patch=patch,
+    )
+    return 0
+
+
 def cmd_reply(args) -> int:
     """Handler for `gdoc reply`."""
     doc_id = _resolve_doc_id(args.doc)
@@ -2356,6 +2523,12 @@ def cmd_reply(args) -> int:
 
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
+
+    if getattr(args, "suggestion", False) or getattr(args, "reassign", None):
+        return _native_reply(args, doc_id, change_info, comment_id)
+    # Drive path: a suggestion thread is not a Drive comment, so a bare
+    # suggestion ID would only produce a misleading Drive 404.
+    _check_thread_namespace(comment_id, suggestion=False)
 
     from gdoc.api.comments import create_reply
     result = create_reply(doc_id, comment_id, content=args.text)
@@ -2492,6 +2665,167 @@ def cmd_delete_comment(args) -> int:
     )
 
     return 0
+
+
+def _cmd_edit_post(args, suggestion: bool) -> int:
+    """Shared body of `edit-comment` and `edit-suggestion-reply`."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    thread_id = args.thread_id
+    post_id = args.post_id
+    text = args.text or ""
+    _check_thread_namespace(thread_id, suggestion)
+    _validate_post_text(text, "new text")
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+
+    from gdoc.api.docs import find_post, thread_kind, update_comment_post
+
+    thread = _native_thread_or_fail(doc_id, thread_id, suggestion)
+    post = find_post(thread, post_id)
+    if post is None:
+        raise GdocError(
+            f"post {post_id} not found on {thread_kind(suggestion)} {thread_id}",
+            exit_code=3,
+        )
+    head_id = (thread.get("headPost") or {}).get("postId")
+    if suggestion and post_id == head_id:
+        raise GdocError(
+            "the head post of a suggestion thread is generated by Google "
+            "and cannot be edited; name a reply post instead",
+            exit_code=3,
+        )
+    if post.get("author", {}).get("me") is False:
+        raise GdocError(
+            f"post {post_id} was written by another user; only its author "
+            "can edit it",
+            exit_code=3,
+        )
+
+    update_comment_post(doc_id, thread_id, post_id, text, suggestion=suggestion)
+
+    from gdoc.api.drive import get_file_version
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    id_key = thread_kind(suggestion)
+    if mode == "json":
+        print(format_json(**{id_key: thread_id}, postId=post_id, status="updated"))
+    elif mode == "plain":
+        print(f"{id_key}\t{thread_id}")
+        print(f"postId\t{post_id}")
+        print("status\tupdated")
+    else:
+        print(f"OK updated post {post_id} on #{thread_id}")
+
+    from gdoc.state import update_state_after_command
+    patch = None if suggestion else {"add_comment_id": thread_id}
+    update_state_after_command(
+        doc_id, change_info, command=args.command, quiet=quiet,
+        command_version=command_version, comment_state_patch=patch,
+    )
+    return 0
+
+
+def _cmd_delete_post(args, suggestion: bool) -> int:
+    """Shared body of `delete-reply` and `delete-suggestion-reply`."""
+    doc_id = _resolve_doc_id(args.doc)
+    quiet = getattr(args, "quiet", False)
+    thread_id = args.thread_id
+    post_id = args.post_id
+    force = getattr(args, "force", False)
+    _check_thread_namespace(thread_id, suggestion)
+
+    from gdoc.util import confirm_destructive
+    confirm_destructive(f"delete reply {post_id} on #{thread_id}", force=force)
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+
+    from gdoc.api.docs import (
+        delete_comment_reply,
+        find_post,
+        post_is_action,
+        thread_kind,
+    )
+
+    thread = _native_thread_or_fail(doc_id, thread_id, suggestion)
+    post = find_post(thread, post_id)
+    if post is None:
+        raise GdocError(
+            f"post {post_id} not found on {thread_kind(suggestion)} {thread_id}",
+            exit_code=3,
+        )
+    head_id = (thread.get("headPost") or {}).get("postId")
+    if post_id == head_id:
+        hint = (
+            "use `delete-comment` to delete the whole thread"
+            if not suggestion else "reject or delete the suggestion instead"
+        )
+        raise GdocError(
+            f"post {post_id} is the head post of #{thread_id}, not a reply; "
+            f"{hint}",
+            exit_code=3,
+        )
+    if post_is_action(post):
+        raise GdocError(
+            f"post {post_id} records a resolve/reopen action or an "
+            "assignment; Google does not allow deleting such replies",
+            exit_code=3,
+        )
+    if post.get("author", {}).get("me") is False:
+        raise GdocError(
+            f"post {post_id} was written by another user; only its author "
+            "can delete it",
+            exit_code=3,
+        )
+
+    delete_comment_reply(doc_id, thread_id, post_id, suggestion=suggestion)
+
+    from gdoc.api.drive import get_file_version
+    command_version = get_file_version(doc_id).get("version")
+
+    from gdoc.format import format_json, get_output_mode
+    mode = get_output_mode(args)
+    id_key = thread_kind(suggestion)
+    if mode == "json":
+        print(format_json(**{id_key: thread_id}, postId=post_id, status="deleted"))
+    elif mode == "plain":
+        print(f"{id_key}\t{thread_id}")
+        print(f"postId\t{post_id}")
+        print("status\tdeleted")
+    else:
+        print(f"OK deleted reply {post_id} from #{thread_id}")
+
+    from gdoc.state import update_state_after_command
+    patch = None if suggestion else {"add_comment_id": thread_id}
+    update_state_after_command(
+        doc_id, change_info, command=args.command, quiet=quiet,
+        command_version=command_version, comment_state_patch=patch,
+    )
+    return 0
+
+
+def cmd_edit_comment(args) -> int:
+    """Handler for `gdoc edit-comment`."""
+    return _cmd_edit_post(args, suggestion=False)
+
+
+def cmd_edit_suggestion_reply(args) -> int:
+    """Handler for `gdoc edit-suggestion-reply`."""
+    return _cmd_edit_post(args, suggestion=True)
+
+
+def cmd_delete_reply(args) -> int:
+    """Handler for `gdoc delete-reply`."""
+    return _cmd_delete_post(args, suggestion=False)
+
+
+def cmd_delete_suggestion_reply(args) -> int:
+    """Handler for `gdoc delete-suggestion-reply`."""
+    return _cmd_delete_post(args, suggestion=True)
 
 
 def cmd_comment_info(args) -> int:
@@ -4237,6 +4571,14 @@ def build_parser() -> GdocArgumentParser:
         ),
     )
     comment_p.add_argument(
+        "--assign",
+        metavar="EMAIL",
+        help=(
+            "Assign the new comment to this user (Docs API preview; "
+            "requires --quote, no Drive fallback)"
+        ),
+    )
+    comment_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     comment_p.set_defaults(func=cmd_comment)
@@ -4244,8 +4586,22 @@ def build_parser() -> GdocArgumentParser:
     # reply
     reply_p = sub.add_parser("reply", parents=[output_parent], help="Reply to a comment")
     reply_p.add_argument("doc", help="Document ID or URL")
-    reply_p.add_argument("comment_id", help="Comment ID to reply to")
+    reply_p.add_argument(
+        "comment_id",
+        help="Comment ID to reply to (a suggestion ID with --suggestion)",
+    )
     reply_p.add_argument("text", help="Reply text")
+    reply_p.add_argument(
+        "--suggestion", action="store_true",
+        help="The ID names a suggestion thread (Docs API preview)",
+    )
+    reply_p.add_argument(
+        "--reassign", metavar="EMAIL",
+        help=(
+            "Reassign an already-assigned comment thread to this user "
+            "(Docs API preview)"
+        ),
+    )
     reply_p.add_argument(
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
@@ -4286,6 +4642,48 @@ def build_parser() -> GdocArgumentParser:
         "--quiet", action="store_true", help="Skip pre-flight checks",
     )
     del_comment_p.set_defaults(func=cmd_delete_comment)
+
+    # edit-comment / edit-suggestion-reply (Docs API preview)
+    for name, kind, help_text in (
+        ("edit-comment", "comment", "Edit the text of a comment or reply you wrote"),
+        (
+            "edit-suggestion-reply", "suggestion",
+            "Edit the text of a reply you wrote on a suggestion thread",
+        ),
+    ):
+        ep = sub.add_parser(name, parents=[output_parent], help=help_text)
+        ep.add_argument("doc", help="Document ID or URL")
+        ep.add_argument("thread_id", help=f"{kind.capitalize()} thread ID")
+        ep.add_argument("post_id", help="Post ID within the thread")
+        ep.add_argument("text", help="New text")
+        ep.add_argument(
+            "--quiet", action="store_true", help="Skip pre-flight checks"
+        )
+        ep.set_defaults(
+            func=cmd_edit_comment if kind == "comment" else cmd_edit_suggestion_reply
+        )
+
+    # delete-reply / delete-suggestion-reply (Docs API preview)
+    for name, kind, help_text in (
+        ("delete-reply", "comment", "Delete one reply you wrote on a comment"),
+        (
+            "delete-suggestion-reply", "suggestion",
+            "Delete one reply you wrote on a suggestion thread",
+        ),
+    ):
+        dp = sub.add_parser(name, parents=[output_parent], help=help_text)
+        dp.add_argument("doc", help="Document ID or URL")
+        dp.add_argument("thread_id", help=f"{kind.capitalize()} thread ID")
+        dp.add_argument("post_id", help="Reply post ID to delete")
+        dp.add_argument(
+            "--force", action="store_true", help="Skip confirmation prompt",
+        )
+        dp.add_argument(
+            "--quiet", action="store_true", help="Skip pre-flight checks",
+        )
+        dp.set_defaults(
+            func=cmd_delete_reply if kind == "comment" else cmd_delete_suggestion_reply
+        )
 
     # comment-info
     ci_p = sub.add_parser(

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2328,9 +2328,8 @@ def _try_anchored_comment(
             except PreviewUnavailableError as e:
                 if assignee_email:
                     raise GdocError(
-                        f"cannot create an assigned comment: {e}. Assigned "
-                        "comments need the Docs API developer preview and "
-                        "edit access; no comment was created."
+                        f"cannot create an assigned comment: {e}. "
+                        "No Drive fallback was attempted."
                     )
                 return ""
     if assignee_email:
@@ -2347,9 +2346,6 @@ def cmd_comment(args) -> int:
     doc_id = _resolve_doc_id(args.doc)
     quiet = getattr(args, "quiet", False)
 
-    from gdoc.notify import pre_flight
-    change_info = pre_flight(doc_id, quiet=quiet)
-
     quote = getattr(args, "quote", "") or ""
     assignee = (getattr(args, "assign", "") or "").strip()
     if assignee:
@@ -2363,6 +2359,10 @@ def cmd_comment(args) -> int:
                 exit_code=3,
             )
         _validate_post_text(args.text)
+
+    from gdoc.notify import pre_flight
+    change_info = pre_flight(doc_id, quiet=quiet)
+
     new_id = ""
     if quote and assignee:
         new_id = _try_anchored_comment(
@@ -2371,6 +2371,13 @@ def cmd_comment(args) -> int:
     elif quote:
         new_id = _try_anchored_comment(doc_id, args.text, quote)
     anchored = bool(new_id)
+    if not anchored and assignee:
+        # Unreachable by construction (the assigned path returns an ID or
+        # raises); guard the one Drive write this command must never make.
+        raise GdocError(
+            "internal error: assigned comment path returned no thread; "
+            "no comment was created"
+        )
     if not anchored:
         from gdoc.api.comments import create_comment
         result = create_comment(doc_id, args.text, quote=quote)
@@ -2446,12 +2453,10 @@ def _check_thread_namespace(thread_id: str, suggestion: bool) -> None:
         )
 
 
-def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
-    """`gdoc reply --suggestion` / `--reassign`: Docs-native addCommentReply."""
-    quiet = getattr(args, "quiet", False)
+def _validate_native_reply_args(args, thread_id: str) -> None:
+    """Usage checks for `reply --suggestion` / `--reassign`, before any I/O."""
     suggestion = bool(getattr(args, "suggestion", False))
     reassign = (getattr(args, "reassign", "") or "").strip()
-    text = args.text or ""
     if suggestion and reassign:
         raise GdocError(
             "--reassign applies to comment threads only; a suggestion "
@@ -2459,7 +2464,15 @@ def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
             exit_code=3,
         )
     _check_thread_namespace(thread_id, suggestion)
-    _validate_post_text(text, "reply text")
+    _validate_post_text(args.text or "", "reply text")
+
+
+def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
+    """`gdoc reply --suggestion` / `--reassign`: Docs-native addCommentReply."""
+    quiet = getattr(args, "quiet", False)
+    suggestion = bool(getattr(args, "suggestion", False))
+    reassign = (getattr(args, "reassign", "") or "").strip()
+    text = args.text or ""
 
     from gdoc.api.docs import add_comment_reply, thread_assignee, thread_kind
 
@@ -2488,13 +2501,20 @@ def _native_reply(args, doc_id: str, change_info, thread_id: str) -> int:
     from gdoc.format import format_json, get_output_mode
     mode = get_output_mode(args)
     id_key = thread_kind(suggestion)
+    # Comment-thread replies keep the Drive `reply` key (`replyId`; the ID
+    # spaces are the same) and add `postId`, the name the edit/delete
+    # commands take; suggestion threads have only `postId`.
+    ids = {} if suggestion else {"replyId": post_id}
     if mode == "json":
         extra = {"assignee": reassign} if reassign else {}
         print(format_json(
-            **{id_key: thread_id}, postId=post_id, status="created", **extra,
+            **{id_key: thread_id}, **ids, postId=post_id, status="created",
+            **extra,
         ))
     elif mode == "plain":
         print(f"{id_key}\t{thread_id}")
+        if not suggestion:
+            print(f"replyId\t{post_id}")
         print(f"postId\t{post_id}")
         if reassign:
             print(f"assignee\t{reassign}")
@@ -2521,14 +2541,21 @@ def cmd_reply(args) -> int:
     quiet = getattr(args, "quiet", False)
     comment_id = args.comment_id
 
+    native = bool(
+        getattr(args, "suggestion", False) or getattr(args, "reassign", None)
+    )
+    if native:
+        _validate_native_reply_args(args, comment_id)
+    else:
+        # Drive path: a suggestion thread is not a Drive comment, so a bare
+        # suggestion ID would only produce a misleading Drive 404.
+        _check_thread_namespace(comment_id, suggestion=False)
+
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
 
-    if getattr(args, "suggestion", False) or getattr(args, "reassign", None):
+    if native:
         return _native_reply(args, doc_id, change_info, comment_id)
-    # Drive path: a suggestion thread is not a Drive comment, so a bare
-    # suggestion ID would only produce a misleading Drive 404.
-    _check_thread_namespace(comment_id, suggestion=False)
 
     from gdoc.api.comments import create_reply
     result = create_reply(doc_id, comment_id, content=args.text)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -2427,10 +2427,13 @@ def _native_thread_or_fail(doc_id: str, thread_id: str, suggestion: bool) -> dic
     return thread
 
 
-def _validate_native_reply_args(args, thread_id: str) -> None:
+def _validate_native_reply_args(args) -> None:
     """Usage checks for `reply --suggestion` / `--reassign`, before any I/O."""
     suggestion = bool(getattr(args, "suggestion", False))
-    reassign = (getattr(args, "reassign", "") or "").strip()
+    reassign_raw = getattr(args, "reassign", None)
+    reassign = (reassign_raw or "").strip()
+    if reassign_raw is not None and not reassign:
+        raise GdocError("--reassign requires an email address", exit_code=3)
     if suggestion and reassign:
         raise GdocError(
             "--reassign applies to comment threads only; a suggestion "
@@ -2514,11 +2517,14 @@ def cmd_reply(args) -> int:
     quiet = getattr(args, "quiet", False)
     comment_id = args.comment_id
 
+    # Any --reassign value (even blank) selects the native path so that a
+    # blank one is a usage error rather than a silent Drive reply.
     native = bool(
-        getattr(args, "suggestion", False) or getattr(args, "reassign", None)
+        getattr(args, "suggestion", False)
+        or getattr(args, "reassign", None) is not None
     )
     if native:
-        _validate_native_reply_args(args, comment_id)
+        _validate_native_reply_args(args)
 
     from gdoc.notify import pre_flight
     change_info = pre_flight(doc_id, quiet=quiet)
@@ -2700,7 +2706,7 @@ def _cmd_edit_post(args, suggestion: bool) -> int:
             "and cannot be edited; name a reply post instead",
             exit_code=3,
         )
-    if post.get("author", {}).get("me") is False:
+    if (post.get("author") or {}).get("me") is False:
         raise GdocError(
             f"post {post_id} was written by another user; only its author "
             "can edit it",
@@ -2783,7 +2789,7 @@ def _cmd_delete_post(args, suggestion: bool) -> int:
             "assignment; Google does not allow deleting such replies",
             exit_code=3,
         )
-    if post.get("author", {}).get("me") is False:
+    if (post.get("author") or {}).get("me") is False:
         raise GdocError(
             f"post {post_id} was written by another user; only its author "
             "can delete it",

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -169,6 +169,11 @@ _DESCRIPTION_NOTES: dict[str, str] = {
         "suggested edit for review, not a direct change; inline markdown "
         "only."
     ),
+    "comment": "`assign` requires `quote` (Docs API preview, no Drive fallback).",
+    "reply": (
+        "`suggestion` and `reassign` are mutually exclusive; `reassign` "
+        "needs a thread that already has an assignee (Docs API preview)."
+    ),
 }
 
 # `new` imports markdown images: extract_images() resolves non-http(s)

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -263,6 +263,10 @@ def _schema_for(command: str, parser: argparse.ArgumentParser) -> dict[str, Any]
             prop["enum"] = [c for c in prop["enum"] if c not in removed]
         if action.dest in extra_required and prop.get("type") == "array":
             prop["minItems"] = 1
+        if action.dest == "force" and command in _FORCE_REQUIRED:
+            # `required` alone would admit `force: false`, which always
+            # fails at runtime; say in the schema that only true is valid.
+            prop["const"] = True
         properties[action.dest] = prop
 
         is_positional = not action.option_strings

--- a/gdoc/mcp.py
+++ b/gdoc/mcp.py
@@ -73,6 +73,10 @@ EXPOSED_COMMANDS: dict[str, bool] = {
     "resolve": False,
     "reopen": False,
     "delete-comment": False,
+    "edit-comment": False,
+    "edit-suggestion-reply": False,
+    "delete-reply": False,
+    "delete-suggestion-reply": False,
     "new": False,
     "cp": False,
     "mkdir": False,
@@ -140,7 +144,14 @@ _EXTRA_REQUIRED: dict[str, tuple[str, ...]] = {
     # --old-file/--new-file are hidden over MCP and suggest has no cell
     # mode, so the text pair is the only way to supply the replacement
     "suggest": ("old_text", "new_text"),
+    "delete-reply": ("force",),
+    "delete-suggestion-reply": ("force",),
 }
+
+# Commands whose `force` must be true over MCP (see _EXTRA_REQUIRED).
+_FORCE_REQUIRED = frozenset(
+    cmd for cmd, params in _EXTRA_REQUIRED.items() if "force" in params
+)
 
 # Cross-parameter requirements JSON Schema could only express with a
 # root-level oneOf/anyOf, which several MCP clients reject or ignore.
@@ -456,7 +467,7 @@ def call_command(
 
     # Schema `required` cannot force a boolean to be true, so guard here:
     # with stdin detached, confirm_destructive() can never prompt.
-    if command == "delete-comment" and not arguments.get("force"):
+    if command in _FORCE_REQUIRED and not arguments.get("force"):
         raise ValueError(
             "`force: true` is required: deletion cannot prompt for "
             "confirmation over MCP"

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -662,13 +662,12 @@ _TABS_DOC = {
 
 
 def _transport_errors():
-    import socket
     import ssl
 
     import httplib2
 
     return [
-        socket.timeout("timed out"),
+        TimeoutError("timed out"),  # socket.timeout is an alias since 3.10
         ConnectionResetError(104, "Connection reset by peer"),
         ssl.SSLError("EOF occurred in violation of protocol"),
         httplib2.HttpLib2Error("connection dropped"),

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -1019,6 +1019,23 @@ class TestCmdReplyNative:
         assert ei.value.exit_code == 3
         mock_add.assert_not_called()
 
+    @patch("gdoc.api.comments.create_reply")
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_blank_reassign_is_usage_error(
+        self, mock_add, mock_drive, _ver, mock_pf, _update, capsys,
+    ):
+        # Whitespace-only --reassign: neither a Drive reply nor a native one.
+        for value in ("", "   "):
+            args = _make_args("reply", comment_id="c1", text="t", suggestion=False,
+                              reassign=value, quiet=False)
+            with pytest.raises(GdocError, match="requires an email") as ei:
+                cmd_reply(args)
+            assert ei.value.exit_code == 3
+        mock_add.assert_not_called()
+        mock_drive.assert_not_called()
+        mock_pf.assert_not_called()
+        assert capsys.readouterr().out == ""
+
     @patch("gdoc.api.docs.add_comment_reply")
     def test_native_reply_validates_text(self, mock_add, _ver, _pf, _update):
         args = _make_args("reply", comment_id="suggest.s1", text="",
@@ -1118,6 +1135,14 @@ class TestEditPost:
             cmd_edit_comment(args)
         assert ei.value.exit_code == 3
         mock_update_post.assert_not_called()
+
+    def test_edit_null_author_does_not_crash(
+        self, mock_read, mock_update_post, _ver, _pf, _state,
+    ):
+        post = dict(_post("r1", "old"), author=None)
+        mock_read.return_value = _doc(comments=[_comment_thread("c1", replies=[post])])
+        args = _make_args("edit-comment", thread_id="c1", post_id="r1", text="new")
+        assert cmd_edit_comment(args) == 0  # authorship enforced by Google
 
     def test_edit_other_users_post_refused(
         self, mock_read, mock_update_post, _ver, _pf, _state,
@@ -1240,6 +1265,14 @@ class TestDeletePost:
         assert ei.value.exit_code == 3
         mock_delete.assert_not_called()
 
+    def test_delete_null_author_does_not_crash(
+        self, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        post = dict(_post("r1"), author=None)
+        mock_read.return_value = _doc(comments=[_comment_thread("c1", replies=[post])])
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=True)
+        assert cmd_delete_reply(args) == 0
+
     def test_delete_other_users_reply_refused(
         self, mock_read, mock_delete, _ver, _pf, _state,
     ):
@@ -1278,6 +1311,12 @@ class TestDeletePost:
 
 
 class TestParserAndMcp:
+    @pytest.fixture(autouse=True)
+    def _no_allow_env(self, monkeypatch):
+        # build_tools honours GDOC_ALLOW_COMMANDS; a developer shell must
+        # not turn these into KeyErrors.
+        monkeypatch.delenv("GDOC_ALLOW_COMMANDS", raising=False)
+
     def test_parser_flags(self):
         from gdoc.cli import build_parser
 

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -14,6 +14,7 @@ the thread ID. Drive reply IDs equal native post IDs.
 """
 
 import json
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -174,6 +175,14 @@ class TestThreadHelpers:
         assert thread_assignee(_comment_thread()) == ""
         assert thread_assignee(_comment_thread(replies=[_post("r1")])) == ""
 
+    def test_thread_assignee_ignores_unknown_shapes(self):
+        # Fail closed: only a string assigneeEmail on a post counts.
+        thread = _comment_thread()
+        thread["assigneeEmail"] = ME
+        thread["headPost"]["assignee"] = {"emailAddress": ME}
+        thread["replies"] = [dict(_post("r1"), assigneeEmail={"user": ME})]
+        assert thread_assignee(thread) == ""
+
     def test_post_is_action(self):
         assert post_is_action(_post("r1", assignee=ME))
         assert post_is_action(_post("r1", action="RESOLVE"))
@@ -191,7 +200,10 @@ class TestGetDocumentThreads:
     @patch("gdoc.api.docs._documents_get_raw")
     @patch("gdoc.api.docs.get_docs_service")
     def test_sends_preview_view_modes(self, _svc, mock_raw):
-        mock_raw.return_value = {"documentId": "abc123"}
+        mock_raw.return_value = {
+            "documentId": "abc123",
+            "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+        }
         doc = get_document_threads("abc123")
         params = mock_raw.call_args.args[2]
         assert params == {
@@ -215,6 +227,26 @@ class TestGetDocumentThreads:
 
     @patch("gdoc.api.docs._documents_get_raw")
     @patch("gdoc.api.docs.get_docs_service")
+    def test_silently_dropped_view_mode_is_preview_unavailable(self, _svc, mock_raw):
+        # No 400, but no echo and no thread lists: must not read as "no threads".
+        mock_raw.return_value = {"documentId": "abc123", "revisionId": "r"}
+        with pytest.raises(GdocError, match="not enrolled"):
+            get_document_threads("abc123")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_raw_get_builds_preview_uri(self, mock_svc):
+        from gdoc.api.docs import _documents_get_raw
+
+        service = MagicMock()
+        with patch("googleapiclient.http.HttpRequest") as mock_req:
+            mock_req.return_value.execute.return_value = {"documentId": "d"}
+            _documents_get_raw(service, "doc/1", {"commentsViewMode": "X"})
+        uri = mock_req.call_args.args[2]
+        assert uri == "https://docs.googleapis.com/v1/documents/doc%2F1?commentsViewMode=X"
+        assert mock_req.call_args.kwargs["method"] == "GET"
+
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
     def test_404_is_document_not_found(self, _svc, mock_raw):
         mock_raw.side_effect = _http_error(404)
         with pytest.raises(GdocError, match="Document not found"):
@@ -231,10 +263,12 @@ _INSERT_OK = {
 
 
 class TestInsertCommentAssignee:
+    @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
-    def test_assignee_sent_as_assignee_email_address(self, mock_svc):
+    def test_assignee_sent_as_assignee_email_address(self, mock_svc, mock_read):
         service = _mock_docs_service(_INSERT_OK)
         mock_svc.return_value = service
+        mock_read.return_value = _doc(comments=[_comment_thread("c_new", assignee=ME)])
         cid = insert_comment(
             "abc123", "hi", 5, 9, tab_id="t.0", revision_id="rev1",
             assignee_email=ME,
@@ -248,9 +282,20 @@ class TestInsertCommentAssignee:
             }}],
             "writeControl": {"requiredRevisionId": "rev1"},
         }
+        mock_read.assert_called_once_with("abc123")
 
+    @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
-    def test_no_assignee_leaves_request_unchanged(self, mock_svc):
+    def test_assignee_missing_on_read_back_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_INSERT_OK)
+        mock_read.return_value = _doc(comments=[_comment_thread("c_new")])
+        with pytest.raises(GdocError, match="does not show it assigned") as ei:
+            insert_comment("abc123", "hi", 5, 9, assignee_email=ME)
+        assert not isinstance(ei.value, PreviewUnavailableError)
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_assignee_leaves_request_unchanged(self, mock_svc, mock_read):
         service = _mock_docs_service(_INSERT_OK)
         mock_svc.return_value = service
         insert_comment("abc123", "hi", 5, 9)
@@ -259,6 +304,26 @@ class TestInsertCommentAssignee:
                 "content": "hi", "range": {"startIndex": 5, "endIndex": 9},
             }}],
         }
+        mock_read.assert_not_called()
+
+    @pytest.mark.parametrize("message, expect", [
+        ('Unknown name "insert_comment"', "preview not enabled"),
+        ("Invalid requests[0]: No request set.", "preview not enabled"),
+        ("The revision id does not match", "document changed"),
+    ])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_distinct_preview_reasons(self, mock_svc, message, expect):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(400, message)
+        )
+        with pytest.raises(PreviewUnavailableError, match=expect):
+            insert_comment("abc123", "hi", 5, 9, revision_id="rev1")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_403_reason(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(403))
+        with pytest.raises(PreviewUnavailableError, match="not permitted"):
+            insert_comment("abc123", "hi", 5, 9)
 
     @patch("gdoc.api.docs.get_docs_service")
     def test_assigned_requires_comment_update_state(self, mock_svc):
@@ -342,6 +407,18 @@ class TestAddCommentReply:
         assert _batch_body(service)["requests"][0]["addCommentReply"]["post"] == {
             "content": "t", "assigneeEmail": OTHER,
         }
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_reassign_not_shown_on_read_back_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(
+            _reply_ok("p_new", "t", assignee=OTHER)
+        )
+        mock_read.return_value = _doc(comments=[_comment_thread(
+            "c1", assignee=ME, replies=[_post("p_new", "t")],
+        )])
+        with pytest.raises(GdocError, match="not show the thread reassigned"):
+            add_comment_reply("abc123", "c1", content="t", assignee_email=OTHER)
 
     @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
@@ -453,6 +530,15 @@ class TestUpdateCommentPost:
         update_comment_post("abc123", "suggest.s1", "r1", "new", suggestion=True)
         request = _batch_body(service)["requests"][0]["updateCommentPost"]
         assert "suggestionId" in request
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_read_back_tolerates_whitespace_normalization(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1", "new text")])]
+        )
+        update_comment_post("abc123", "c1", "r1", "new text\n")  # no raise
 
     @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
@@ -577,11 +663,13 @@ class TestCmdCommentAssign:
     @patch("gdoc.api.comments.create_comment")
     @patch("gdoc.api.docs.get_document_with_tabs")
     def test_assign_requires_quote(
-        self, mock_get, mock_create, _ver, _pf, _update, capsys,
+        self, mock_get, mock_create, _ver, mock_pf, _update, capsys,
     ):
         with pytest.raises(GdocError, match="requires --quote") as ei:
-            cmd_comment(_make_args("comment", text="p", quote=None, assign=ME))
+            cmd_comment(_make_args("comment", text="p", quote=None, assign=ME,
+                                   quiet=False))
         assert ei.value.exit_code == 3
+        mock_pf.assert_not_called()
         mock_get.assert_not_called()
         mock_create.assert_not_called()
         assert capsys.readouterr().out == ""
@@ -610,6 +698,21 @@ class TestCmdCommentAssign:
         with pytest.raises(GdocError, match="cannot create an assigned comment") as ei:
             cmd_comment(_make_args("comment", text="p", quote="quick", assign=ME))
         assert ei.value.exit_code == 1
+        mock_create.assert_not_called()
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_assign_failure_message_keeps_reason(
+        self, _get, mock_create, _ver, _pf, _update,
+    ):
+        for reason in ("document changed since it was read",
+                       "comment not saved (commentUpdateState=PARTIAL)",
+                       "not permitted for this user"):
+            with patch("gdoc.api.docs.insert_comment",
+                       side_effect=PreviewUnavailableError(reason)):
+                with pytest.raises(GdocError, match=re.escape(reason)):
+                    cmd_comment(_make_args("comment", text="p", quote="quick",
+                                           assign=ME))
         mock_create.assert_not_called()
 
     @patch("gdoc.api.comments.create_comment", return_value={"id": "c_drive"})
@@ -708,8 +811,8 @@ class TestCmdReplyNative:
             assignee_email=OTHER,
         )
         assert json.loads(capsys.readouterr().out) == {
-            "ok": True, "commentId": "c1", "postId": "p9", "status": "created",
-            "assignee": OTHER,
+            "ok": True, "commentId": "c1", "replyId": "p9", "postId": "p9",
+            "status": "created", "assignee": OTHER,
         }
         assert mock_update.call_args.kwargs["comment_state_patch"] == {
             "add_comment_id": "c1",
@@ -745,9 +848,11 @@ class TestCmdReplyNative:
 
     @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.add_comment_reply")
-    def test_reassign_runs_preflight_even_with_quiet(
-        self, mock_add, mock_read, _ver, mock_pf, _update,
+    def test_reassign_reads_thread_even_with_quiet(
+        self, mock_add, mock_read, _ver, mock_pf, mock_update,
     ):
+        # --quiet skips only the awareness pre-flight; the precondition read
+        # is a correctness gate and always runs.
         mock_read.return_value = _doc(comments=[_comment_thread("c1")])
         args = _make_args("reply", comment_id="c1", text="t", suggestion=False,
                           reassign=OTHER, quiet=True)
@@ -755,6 +860,28 @@ class TestCmdReplyNative:
             cmd_reply(args)
         mock_pf.assert_called_once_with("abc123", quiet=True)
         mock_read.assert_called_once()
+        mock_read.return_value = _doc(comments=[_comment_thread("c1", assignee=ME)])
+        mock_add.return_value = _post("p9", "t", assignee=OTHER)
+        cmd_reply(args)
+        assert mock_update.call_args.kwargs["quiet"] is True
+
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_usage_errors_precede_preflight(self, mock_add, _ver, mock_pf, _update):
+        for kwargs in (
+            {"comment_id": "suggest.s1", "text": "t", "suggestion": True,
+             "reassign": OTHER},
+            {"comment_id": "AAACabc", "text": "t", "suggestion": True,
+             "reassign": None},
+            {"comment_id": "suggest.s1", "text": "", "suggestion": True,
+             "reassign": None},
+            {"comment_id": "suggest.s1", "text": "t", "suggestion": False,
+             "reassign": None},
+        ):
+            with pytest.raises(GdocError) as ei:
+                cmd_reply(_make_args("reply", quiet=False, **kwargs))
+            assert ei.value.exit_code == 3
+        mock_pf.assert_not_called()
+        mock_add.assert_not_called()
 
     @patch("gdoc.api.docs.add_comment_reply")
     def test_suggestion_and_reassign_conflict(self, mock_add, _ver, _pf, _update):
@@ -1075,6 +1202,13 @@ class TestParserAndMcp:
         names = set(build_tools())
         assert {"gdoc_edit_comment", "gdoc_delete_suggestion_reply"} <= names
         assert "gdoc_delete_reply" not in build_tools(read_only=True)
+
+    def test_mcp_descriptions_state_cross_parameter_rules(self):
+        from gdoc.mcp import build_tools
+
+        tools = build_tools()
+        assert "`assign` requires `quote`" in tools["gdoc_comment"]["description"]
+        assert "mutually exclusive" in tools["gdoc_reply"]["description"]
 
     def test_mcp_delete_reply_requires_force(self):
         from gdoc.mcp import build_tools, call_command

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -164,12 +164,16 @@ class TestThreadHelpers:
     def test_thread_assignee_from_head_post(self):
         assert thread_assignee(_comment_thread(assignee=ME)) == ME
 
-    def test_thread_assignee_latest_reassignment_wins(self):
+    def test_thread_assignee_is_head_post_only(self):
+        # A reply's assigneeEmail records a reassignment event; the current
+        # assignee per the API contract is headPost.assigneeEmail.
         thread = _comment_thread(
             assignee=ME,
             replies=[_post("r1", assignee=OTHER), _post("r2")],
         )
-        assert thread_assignee(thread) == OTHER
+        assert thread_assignee(thread) == ME
+        unassigned_head = _comment_thread(replies=[_post("r1", assignee=OTHER)])
+        assert thread_assignee(unassigned_head) == ""
 
     def test_thread_assignee_unassigned_is_empty(self):
         assert thread_assignee(_comment_thread()) == ""
@@ -182,6 +186,12 @@ class TestThreadHelpers:
         thread["headPost"]["assignee"] = {"emailAddress": ME}
         thread["replies"] = [dict(_post("r1"), assigneeEmail={"user": ME})]
         assert thread_assignee(thread) == ""
+
+    def test_post_is_deleted(self):
+        from gdoc.api.docs import post_is_deleted
+
+        assert post_is_deleted(dict(_post("r1"), deleted=True))
+        assert not post_is_deleted(_post("r1"))
 
     def test_post_is_action(self):
         assert post_is_action(_post("r1", assignee=ME))
@@ -325,12 +335,25 @@ class TestInsertCommentAssignee:
         with pytest.raises(PreviewUnavailableError, match="not permitted"):
             insert_comment("abc123", "hi", 5, 9)
 
+    @pytest.mark.parametrize("response", [
+        {"replies": _INSERT_OK["replies"]},  # state missing
+        dict(_INSERT_OK, commentUpdateState="ALL_FAILED_UNKNOWN_REASON"),
+        {"commentUpdateState": "ALL_SAVED", "replies": [{"insertComment": {}}]},
+    ])
+    @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
-    def test_assigned_requires_comment_update_state(self, mock_svc):
-        response = {"replies": _INSERT_OK["replies"]}  # state missing
+    def test_assigned_ambiguous_outcome_says_inspect(
+        self, mock_svc, mock_read, response,
+    ):
+        # 2xx without ALL_SAVED, or ALL_SAVED without a thread id, may or may
+        # not have created a comment: never "not created", never a fallback.
         mock_svc.return_value = _mock_docs_service(response)
-        with pytest.raises(PreviewUnavailableError, match="missing"):
+        with pytest.raises(GdocError, match="outcome uncertain") as ei:
             insert_comment("abc123", "hi", 5, 9, assignee_email=ME)
+        assert not isinstance(ei.value, PreviewUnavailableError)
+        assert "inspect" in str(ei.value)
+        assert "not created" not in str(ei.value).lower()
+        mock_read.assert_not_called()
 
     @patch("gdoc.api.docs.get_docs_service")
     def test_unassigned_tolerates_missing_state(self, mock_svc):
@@ -340,12 +363,24 @@ class TestInsertCommentAssignee:
         assert insert_comment("abc123", "hi", 5, 9) == "c_new"
 
     @patch("gdoc.api.docs.get_docs_service")
-    def test_partial_failure_state_is_error(self, mock_svc):
+    def test_unassigned_partial_failure_still_falls_back(self, mock_svc):
         response = dict(
             _INSERT_OK, commentUpdateState="ALL_FAILED_UNKNOWN_REASON",
         )
         mock_svc.return_value = _mock_docs_service(response)
         with pytest.raises(PreviewUnavailableError, match="ALL_FAILED"):
+            insert_comment("abc123", "hi", 5, 9)
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_assignee_on_reply_only_does_not_verify_insert(
+        self, mock_svc, mock_read,
+    ):
+        mock_svc.return_value = _mock_docs_service(_INSERT_OK)
+        mock_read.return_value = _doc(comments=[
+            _comment_thread("c_new", replies=[_post("r1", assignee=ME)]),
+        ])
+        with pytest.raises(GdocError, match="does not show it assigned"):
             insert_comment("abc123", "hi", 5, 9, assignee_email=ME)
 
 
@@ -590,6 +625,15 @@ class TestDeleteCommentReply:
         )
         with pytest.raises(GdocError, match="still on the thread"):
             delete_comment_reply("abc123", "c1", "r1")
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_tombstone_after_delete_counts_as_deleted(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+        mock_read.return_value = _doc(comments=[
+            _comment_thread("c1", replies=[dict(_post("r1"), deleted=True)]),
+        ])
+        delete_comment_reply("abc123", "c1", "r1")  # no raise
 
     @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
@@ -870,11 +914,7 @@ class TestCmdReplyNative:
         for kwargs in (
             {"comment_id": "suggest.s1", "text": "t", "suggestion": True,
              "reassign": OTHER},
-            {"comment_id": "AAACabc", "text": "t", "suggestion": True,
-             "reassign": None},
             {"comment_id": "suggest.s1", "text": "", "suggestion": True,
-             "reassign": None},
-            {"comment_id": "suggest.s1", "text": "t", "suggestion": False,
              "reassign": None},
         ):
             with pytest.raises(GdocError) as ei:
@@ -892,25 +932,45 @@ class TestCmdReplyNative:
         assert ei.value.exit_code == 3
         mock_add.assert_not_called()
 
+    @patch("gdoc.api.docs.add_comment_reply", return_value=_post("p9", "t"))
+    def test_suggestion_ids_are_opaque(self, mock_add, _ver, _pf, _update, capsys):
+        # No shape check: the flag alone selects the suggestionId namespace.
+        args = _make_args("reply", comment_id="AAACopaque", text="t",
+                          suggestion=True, reassign=None, json=True)
+        assert cmd_reply(args) == 0
+        mock_add.assert_called_once_with(
+            "abc123", "AAACopaque", content="t", suggestion=True,
+            assignee_email=None,
+        )
+        assert json.loads(capsys.readouterr().out)["suggestionId"] == "AAACopaque"
+
     @patch("gdoc.api.docs.add_comment_reply")
-    def test_suggestion_flag_rejects_comment_looking_id(
-        self, mock_add, _ver, _pf, _update,
+    @patch("gdoc.api.comments.get_drive_service")
+    @patch("gdoc.api.comments.create_reply", return_value={"id": "r1"})
+    def test_drive_path_ignores_id_shape(
+        self, mock_drive, _svc, mock_add, _ver, _pf, _update,
     ):
-        args = _make_args("reply", comment_id="AAACabc", text="t",
-                          suggestion=True, reassign=None)
-        with pytest.raises(GdocError, match="does not look like a suggestion") as ei:
+        args = _make_args("reply", comment_id="suggest.looking", text="t",
+                          suggestion=False, reassign=None)
+        assert cmd_reply(args) == 0
+        mock_drive.assert_called_once_with("abc123", "suggest.looking", content="t")
+        mock_add.assert_not_called()
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_reassign_requires_head_post_assignee(
+        self, mock_add, mock_read, _ver, _pf, _update,
+    ):
+        # Head unassigned, later reply carries assigneeEmail: still no write.
+        mock_read.return_value = _doc(comments=[
+            _comment_thread("c1", replies=[_post("r1", assignee=ME)]),
+        ])
+        args = _make_args("reply", comment_id="c1", text="t", suggestion=False,
+                          reassign=OTHER)
+        with pytest.raises(GdocError, match="head post") as ei:
             cmd_reply(args)
         assert ei.value.exit_code == 3
         mock_add.assert_not_called()
-
-    @patch("gdoc.api.comments.create_reply")
-    def test_drive_path_rejects_suggestion_id(self, mock_drive, _ver, _pf, _update):
-        args = _make_args("reply", comment_id="suggest.s1", text="t",
-                          suggestion=False, reassign=None)
-        with pytest.raises(GdocError, match="suggestion thread ID") as ei:
-            cmd_reply(args)
-        assert ei.value.exit_code == 3
-        mock_drive.assert_not_called()
 
     @patch("gdoc.api.docs.add_comment_reply")
     def test_native_reply_validates_text(self, mock_add, _ver, _pf, _update):
@@ -1032,16 +1092,17 @@ class TestEditPost:
             cmd_edit_comment(args)
         mock_read.assert_not_called()
 
-    def test_edit_comment_rejects_suggestion_id(
+    def test_edit_deleted_post_refused(
         self, mock_read, mock_update_post, _ver, _pf, _state,
     ):
-        args = _make_args(
-            "edit-comment", thread_id="suggest.s1", post_id="r1", text="x",
-        )
-        with pytest.raises(GdocError, match="suggestion thread ID") as ei:
+        mock_read.return_value = _doc(comments=[
+            _comment_thread("c1", replies=[dict(_post("r1"), deleted=True)]),
+        ])
+        args = _make_args("edit-comment", thread_id="c1", post_id="r1", text="x")
+        with pytest.raises(GdocError, match="has been deleted") as ei:
             cmd_edit_comment(args)
         assert ei.value.exit_code == 3
-        mock_read.assert_not_called()
+        mock_update_post.assert_not_called()
 
 
 # --- delete-reply / delete-suggestion-reply -------------------------------
@@ -1153,14 +1214,17 @@ class TestDeletePost:
         assert ei.value.exit_code == 3
         mock_delete.assert_not_called()
 
-    def test_delete_reply_rejects_suggestion_id(
+    def test_delete_already_deleted_post_refused(
         self, mock_read, mock_delete, _ver, _pf, _state,
     ):
-        args = _make_args("delete-reply", thread_id="suggest.s1", post_id="r1",
-                          force=True)
-        with pytest.raises(GdocError, match="suggestion thread ID"):
+        mock_read.return_value = _doc(comments=[
+            _comment_thread("c1", replies=[dict(_post("r1"), deleted=True)]),
+        ])
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=True)
+        with pytest.raises(GdocError, match="already deleted") as ei:
             cmd_delete_reply(args)
-        mock_read.assert_not_called()
+        assert ei.value.exit_code == 3
+        mock_delete.assert_not_called()
 
 
 # --- parser and MCP exposure ---------------------------------------------
@@ -1214,8 +1278,14 @@ class TestParserAndMcp:
         from gdoc.mcp import build_tools, call_command
 
         tools = build_tools()
-        for name in ("gdoc_delete_reply", "gdoc_delete_suggestion_reply"):
-            assert "force" in tools[name]["inputSchema"]["required"]
+        for name in ("gdoc_delete_reply", "gdoc_delete_suggestion_reply",
+                     "gdoc_delete_comment"):
+            schema = tools[name]["inputSchema"]
+            assert "force" in schema["required"]
+            assert schema["properties"]["force"]["const"] is True
+        assert "const" not in tools["gdoc_edit"]["inputSchema"]["properties"].get(
+            "all", {},
+        )
         with pytest.raises(ValueError, match="force: true"):
             call_command(
                 "delete-reply", {"doc": "d", "thread_id": "c1", "post_id": "p"},

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import httplib2
 import pytest
+from google.auth.exceptions import RefreshError, TransportError
 from googleapiclient.errors import HttpError
 
 from gdoc.api.docs import (
@@ -764,6 +765,8 @@ class TestReadBackFailureIsAmbiguous:
         TimeoutError("timed out"),
         ConnectionResetError(104, "Connection reset by peer"),
         __import__("httplib2").HttpLib2Error("connection dropped"),
+        RefreshError("token refresh failed"),
+        TransportError("credential transport failed"),
     ])
     @pytest.mark.parametrize("operation", ["insert", "reply", "edit", "delete"])
     @patch("gdoc.api.docs.get_document_threads")

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -643,6 +643,109 @@ class TestDeleteCommentReply:
         delete_comment_reply("abc123", "c1", "r1")  # no raise
 
 
+# --- dispatch failures after the request was sent are mutation-ambiguous ---
+
+
+_TABS_DOC = {
+    "revisionId": "rev1",
+    "tabs": [{
+        "tabProperties": {"tabId": "t.0", "title": "Tab 1"},
+        "documentTab": {"body": {"content": [{
+            "startIndex": 1, "endIndex": 20,
+            "paragraph": {"elements": [{
+                "startIndex": 1, "endIndex": 20,
+                "textRun": {"content": "the quick brown fox\n"},
+            }]},
+        }]}},
+    }],
+}
+
+
+def _transport_errors():
+    import socket
+    import ssl
+
+    import httplib2
+
+    return [
+        socket.timeout("timed out"),
+        ConnectionResetError(104, "Connection reset by peer"),
+        ssl.SSLError("EOF occurred in violation of protocol"),
+        httplib2.HttpLib2Error("connection dropped"),
+    ]
+
+
+class TestDispatchFailureIsAmbiguous:
+    """A 5xx or transport error from batchUpdate may follow a write Google
+    already applied: report uncertainty, never fall back or invite a retry."""
+
+    @pytest.mark.parametrize("error", [
+        *[_http_error(status) for status in (500, 502, 503)],
+        *_transport_errors(),
+    ])
+    @pytest.mark.parametrize("operation", ["insert", "insert_assigned", "reply",
+                                           "edit", "delete"])
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_5xx_and_transport_errors_say_may_have_succeeded(
+        self, mock_svc, mock_read, operation, error,
+    ):
+        mock_svc.return_value = _mock_docs_service(batch_error=error)
+        calls = {
+            "insert": lambda: insert_comment("abc123", "hi", 5, 9),
+            "insert_assigned": lambda: insert_comment(
+                "abc123", "hi", 5, 9, assignee_email=ME,
+            ),
+            "reply": lambda: add_comment_reply("abc123", "c1", content="x"),
+            "edit": lambda: update_comment_post("abc123", "c1", "r1", "x"),
+            "delete": lambda: delete_comment_reply("abc123", "c1", "r1"),
+        }
+        with pytest.raises(GdocError) as ei:
+            calls[operation]()
+        msg = str(ei.value)
+        assert "outcome uncertain" in msg and "may have succeeded" in msg
+        assert "inspect" in msg
+        # Not the fallback sentinel: comment --quote must not degrade to a
+        # Drive comment that could duplicate an anchored one.
+        assert not isinstance(ei.value, PreviewUnavailableError)
+        assert ei.value.exit_code == 1
+        mock_read.assert_not_called()
+        assert mock_svc.return_value.documents.return_value.batchUpdate.call_count == 1
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_4xx_diagnostics_unchanged(self, mock_svc):
+        # Definite rejections keep their specific diagnosis.
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(400, 'Unknown name "insert_comment"')
+        )
+        with pytest.raises(PreviewUnavailableError, match="preview not enabled"):
+            insert_comment("abc123", "hi", 5, 9)
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(400, "Only the author can edit this post.")
+        )
+        with pytest.raises(GdocError, match="Only the author") as ei:
+            update_comment_post("abc123", "c1", "r1", "x")
+        assert "uncertain" not in str(ei.value)
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(404))
+        with pytest.raises(GdocError, match="Not found"):
+            add_comment_reply("abc123", "c1", content="x")
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.insert_comment", side_effect=GdocError(
+        "insertComment outcome uncertain: … may have succeeded; inspect …"
+    ))
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_cmd_comment_quote_does_not_fall_back_on_uncertain_outcome(
+        self, _get, _insert, mock_create,
+    ):
+        with patch("gdoc.notify.pre_flight", return_value=None), \
+                patch("gdoc.api.drive.get_file_version"), \
+                patch("gdoc.state.update_state_after_command"):
+            with pytest.raises(GdocError, match="outcome uncertain"):
+                cmd_comment(_make_args("comment", text="p", quote="quick", assign=None))
+        mock_create.assert_not_called()
+
+
 # --- post-write verification failures are mutation-ambiguous ---------------
 
 
@@ -693,19 +796,6 @@ class TestReadBackFailureIsAmbiguous:
 # --- cmd_comment --assign -------------------------------------------------
 
 
-_TABS_DOC = {
-    "revisionId": "rev1",
-    "tabs": [{
-        "tabProperties": {"tabId": "t.0", "title": "Tab 1"},
-        "documentTab": {"body": {"content": [{
-            "startIndex": 1, "endIndex": 20,
-            "paragraph": {"elements": [{
-                "startIndex": 1, "endIndex": 20,
-                "textRun": {"content": "the quick brown fox\n"},
-            }]},
-        }]}},
-    }],
-}
 
 
 @patch("gdoc.state.update_state_after_command")

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -28,9 +28,9 @@ from gdoc.api.docs import (
     find_post,
     find_thread,
     get_document_threads,
+    head_post_assignee,
     insert_comment,
     post_is_action,
-    thread_assignee,
     update_comment_post,
 )
 from gdoc.cli import (
@@ -161,31 +161,32 @@ class TestThreadHelpers:
         assert find_post(thread, "r1")["postId"] == "r1"
         assert find_post(thread, "nope") is None
 
-    def test_thread_assignee_from_head_post(self):
-        assert thread_assignee(_comment_thread(assignee=ME)) == ME
+    def test_head_post_assignee_from_head_post(self):
+        assert head_post_assignee(_comment_thread(assignee=ME)) == ME
 
-    def test_thread_assignee_is_head_post_only(self):
-        # A reply's assigneeEmail records a reassignment event; the current
-        # assignee per the API contract is headPost.assigneeEmail.
+    def test_head_post_assignee_is_head_post_only(self):
+        # A reply's assigneeEmail records a reassignment event (observed
+        # live: the head keeps the original); the preflight fact Google
+        # requires is headPost.assigneeEmail.
         thread = _comment_thread(
             assignee=ME,
             replies=[_post("r1", assignee=OTHER), _post("r2")],
         )
-        assert thread_assignee(thread) == ME
+        assert head_post_assignee(thread) == ME
         unassigned_head = _comment_thread(replies=[_post("r1", assignee=OTHER)])
-        assert thread_assignee(unassigned_head) == ""
+        assert head_post_assignee(unassigned_head) == ""
 
-    def test_thread_assignee_unassigned_is_empty(self):
-        assert thread_assignee(_comment_thread()) == ""
-        assert thread_assignee(_comment_thread(replies=[_post("r1")])) == ""
+    def test_head_post_assignee_unassigned_is_empty(self):
+        assert head_post_assignee(_comment_thread()) == ""
+        assert head_post_assignee(_comment_thread(replies=[_post("r1")])) == ""
 
-    def test_thread_assignee_ignores_unknown_shapes(self):
+    def test_head_post_assignee_ignores_unknown_shapes(self):
         # Fail closed: only a string assigneeEmail on a post counts.
         thread = _comment_thread()
         thread["assigneeEmail"] = ME
         thread["headPost"]["assignee"] = {"emailAddress": ME}
         thread["replies"] = [dict(_post("r1"), assigneeEmail={"user": ME})]
-        assert thread_assignee(thread) == ""
+        assert head_post_assignee(thread) == ""
 
     def test_post_is_deleted(self):
         from gdoc.api.docs import post_is_deleted
@@ -433,6 +434,8 @@ class TestAddCommentReply:
     @patch("gdoc.api.docs.get_document_threads")
     @patch("gdoc.api.docs.get_docs_service")
     def test_reassign_sends_assignee_email_in_same_post(self, mock_svc, mock_read):
+        # Event-sourced verification: the head keeps ME, the new reply
+        # carries OTHER — that is a verified reassignment.
         service = _mock_docs_service(_reply_ok("p_new", "t", assignee=OTHER))
         mock_svc.return_value = service
         mock_read.return_value = _doc(comments=[_comment_thread(
@@ -758,6 +761,9 @@ class TestReadBackFailureIsAmbiguous:
         ),
         GdocError("API error (503): Backend Error"),
         AuthError("Authentication expired. Run `gdoc auth`."),
+        TimeoutError("timed out"),
+        ConnectionResetError(104, "Connection reset by peer"),
+        __import__("httplib2").HttpLib2Error("connection dropped"),
     ])
     @pytest.mark.parametrize("operation", ["insert", "reply", "edit", "delete"])
     @patch("gdoc.api.docs.get_document_threads")
@@ -786,7 +792,8 @@ class TestReadBackFailureIsAmbiguous:
         assert "may have succeeded" in msg and "inspect" in msg
         assert "reported saved" in msg
         assert "No change was made" not in msg.split("verification read failed")[0]
-        assert ei.value.exit_code == error.exit_code
+        expected_code = getattr(error, "exit_code", 1)
+        assert ei.value.exit_code == expected_code
         assert not isinstance(ei.value, PreviewUnavailableError)
         # The write itself was sent exactly once; nothing is retried.
         assert mock_svc.return_value.documents.return_value.batchUpdate.call_count == 1
@@ -1149,6 +1156,67 @@ class TestCmdReplyNative:
         assert mock_update.call_args.kwargs["comment_state_patch"] == {
             "add_comment_id": "c1",
         }
+
+
+# --- post-write Drive version lookup is best-effort -------------------------
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.notify.pre_flight", return_value=None)
+@patch("gdoc.api.drive.get_file_version", side_effect=GdocError("API error (503)"))
+class TestPostWriteVersionBestEffort:
+    """A verified native write must not fail on the awareness version
+    lookup: that would invite a duplicate retry."""
+
+    @patch("gdoc.api.docs.insert_comment", return_value="c_assigned")
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_assigned_insert(self, _get, _ins, _ver, _pf, mock_update, capsys):
+        args = _make_args("comment", text="p", quote="quick", assign=ME, json=True)
+        assert cmd_comment(args) == 0
+        out, err = capsys.readouterr()
+        assert json.loads(out)["id"] == "c_assigned"
+        assert "WARN: write succeeded" in err
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs["command_version"] is None
+        assert kwargs["comment_state_patch"] == {"add_comment_id": "c_assigned"}
+
+    @patch("gdoc.api.docs.add_comment_reply", return_value=_post("p9", "hi"))
+    def test_native_reply(self, _add, _ver, _pf, mock_update, capsys):
+        args = _make_args("reply", comment_id="s1", text="hi", suggestion=True,
+                          reassign=None)
+        assert cmd_reply(args) == 0
+        out, err = capsys.readouterr()
+        assert "OK reply on suggestion #s1" in out and "WARN" in err
+        assert mock_update.call_args.kwargs["command_version"] is None
+
+    @patch("gdoc.api.docs.update_comment_post")
+    @patch("gdoc.api.docs.get_document_threads")
+    def test_edit(self, mock_read, _upd, _ver, _pf, mock_update, capsys):
+        thread = _comment_thread("c1", replies=[_post("r1")])
+        mock_read.return_value = _doc(comments=[thread])
+        args = _make_args("edit-comment", thread_id="c1", post_id="r1", text="new")
+        assert cmd_edit_comment(args) == 0
+        assert "WARN" in capsys.readouterr().err
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs["command_version"] is None
+        assert kwargs["comment_state_patch"] == {"add_comment_id": "c1"}
+
+    @patch("gdoc.api.docs.delete_comment_reply")
+    @patch("gdoc.api.docs.get_document_threads")
+    def test_delete(self, mock_read, _del, _ver, _pf, mock_update, capsys):
+        thread = _comment_thread("c1", replies=[_post("r1")])
+        mock_read.return_value = _doc(comments=[thread])
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=True)
+        assert cmd_delete_reply(args) == 0
+        assert "WARN" in capsys.readouterr().err
+        assert mock_update.call_args.kwargs["command_version"] is None
+
+    @patch("gdoc.api.comments.get_drive_service")
+    @patch("gdoc.api.comments.create_comment", return_value={"id": "c_drive"})
+    def test_drive_comment_path_unchanged(self, _create, _svc, _ver, _pf, _update):
+        # Ordinary Drive comment creation keeps its existing contract.
+        with pytest.raises(GdocError, match="API error"):
+            cmd_comment(_make_args("comment", text="p", quote=None, assign=None))
 
 
 # --- edit-comment / edit-suggestion-reply ---------------------------------

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -42,7 +42,7 @@ from gdoc.cli import (
     cmd_edit_suggestion_reply,
     cmd_reply,
 )
-from gdoc.util import GdocError, PreviewUnavailableError
+from gdoc.util import AuthError, GdocError, PreviewUnavailableError
 
 ME = "me@example.com"
 OTHER = "other@example.com"
@@ -641,6 +641,53 @@ class TestDeleteCommentReply:
         mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
         mock_read.return_value = _doc()
         delete_comment_reply("abc123", "c1", "r1")  # no raise
+
+
+# --- post-write verification failures are mutation-ambiguous ---------------
+
+
+class TestReadBackFailureIsAmbiguous:
+    """After ALL_SAVED, a failing verification read must never claim
+    "No change was made": the write may have landed."""
+
+    @pytest.mark.parametrize("error", [
+        GdocError(
+            "native comment threads are not available: … No change was made."
+        ),
+        GdocError("API error (503): Backend Error"),
+        AuthError("Authentication expired. Run `gdoc auth`."),
+    ])
+    @pytest.mark.parametrize("operation", ["insert", "reply", "edit", "delete"])
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_read_back_error_says_may_have_succeeded(
+        self, mock_svc, mock_read, operation, error,
+    ):
+        mock_read.side_effect = error
+        if operation == "insert":
+            mock_svc.return_value = _mock_docs_service(_INSERT_OK)
+            call = lambda: insert_comment(  # noqa: E731
+                "abc123", "hi", 5, 9, assignee_email=ME,
+            )
+        elif operation == "reply":
+            mock_svc.return_value = _mock_docs_service(_reply_ok("p_new"))
+            call = lambda: add_comment_reply("abc123", "c1", content="x")  # noqa: E731
+        elif operation == "edit":
+            mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+            call = lambda: update_comment_post("abc123", "c1", "r1", "x")  # noqa: E731
+        else:
+            mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+            call = lambda: delete_comment_reply("abc123", "c1", "r1")  # noqa: E731
+        with pytest.raises(GdocError) as ei:
+            call()
+        msg = str(ei.value)
+        assert "may have succeeded" in msg and "inspect" in msg
+        assert "reported saved" in msg
+        assert "No change was made" not in msg.split("verification read failed")[0]
+        assert ei.value.exit_code == error.exit_code
+        assert not isinstance(ei.value, PreviewUnavailableError)
+        # The write itself was sent exactly once; nothing is retried.
+        assert mock_svc.return_value.documents.return_value.batchUpdate.call_count == 1
 
 
 # --- cmd_comment --assign -------------------------------------------------

--- a/tests/test_comment_posts.py
+++ b/tests/test_comment_posts.py
@@ -1,0 +1,1088 @@
+"""Tests for native comment assignment and post operations (Docs API preview).
+
+Covers `comment --assign`, `reply --suggestion` / `--reassign`,
+`edit-comment`, `edit-suggestion-reply`, `delete-reply` and
+`delete-suggestion-reply`. Drive v3 stays the path for ordinary comments;
+these commands use Docs-native threads only for what Drive cannot express.
+
+Fixture shapes mirror live responses from a preview-enrolled project:
+``comments[]`` threads carry ``commentId``, ``headPost`` and ``replies[]``
+of Posts (``postId``, ``content``, ``author.me``, ``commentAction``,
+optional ``assigneeEmail``); ``suggestions[]`` threads carry
+``suggestionId`` and a generated ``headPost`` whose ``postId`` differs from
+the thread ID. Drive reply IDs equal native post IDs.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+from gdoc.api.docs import (
+    add_comment_reply,
+    delete_comment_reply,
+    find_post,
+    find_thread,
+    get_document_threads,
+    insert_comment,
+    post_is_action,
+    thread_assignee,
+    update_comment_post,
+)
+from gdoc.cli import (
+    _try_anchored_comment,
+    cmd_comment,
+    cmd_delete_reply,
+    cmd_delete_suggestion_reply,
+    cmd_edit_comment,
+    cmd_edit_suggestion_reply,
+    cmd_reply,
+)
+from gdoc.util import GdocError, PreviewUnavailableError
+
+ME = "me@example.com"
+OTHER = "other@example.com"
+
+
+def _http_error(status, message="Error", content=None):
+    resp = httplib2.Response({"status": str(status)})
+    resp.reason = "Error"
+    if content is None:
+        content = json.dumps(
+            {"error": {"code": status, "message": message}}
+        ).encode()
+    return HttpError(resp, content, uri="")
+
+
+def _post(post_id, content="text", me=True, assignee=None, action=None):
+    post = {
+        "postId": post_id,
+        "content": content,
+        "author": {"displayName": "Someone", "me": me},
+        "createTime": "2026-08-26T18:00:00Z",
+        "updateTime": "2026-08-26T18:00:00Z",
+        "commentAction": action or "NO_COMMENT_ACTION_CHANGE",
+    }
+    if assignee:
+        post["assigneeEmail"] = assignee
+    return post
+
+
+def _comment_thread(cid="c1", assignee=None, replies=None):
+    return {
+        "commentId": cid,
+        "anchorId": "kix.abc",
+        "headPost": _post(cid, "head", assignee=assignee),
+        "replies": replies or [],
+        "status": "OPEN",
+        "plainTextQuote": "quoted",
+    }
+
+
+def _suggestion_thread(sid="suggest.s1", replies=None):
+    head = {
+        "postId": "p_head",
+        "author": {"displayName": "Someone", "me": True},
+        "createTime": "2026-08-26T18:00:00Z",
+        "updateTime": "2026-08-26T18:00:00Z",
+        "suggestionAction": "NO_SUGGESTION_ACTION_CHANGE",
+    }
+    return {
+        "suggestionId": sid,
+        "headPost": head,
+        "replies": replies or [],
+        "status": "OPEN",
+        "summaryText": "Replace: a with b",
+    }
+
+
+def _doc(comments=None, suggestions=None):
+    return {
+        "documentId": "abc123",
+        "revisionId": "rev1",
+        "comments": comments or [],
+        "suggestions": suggestions or [],
+        "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+    }
+
+
+def _mock_docs_service(batch_response=None, batch_error=None):
+    service = MagicMock()
+    execute = service.documents.return_value.batchUpdate.return_value.execute
+    if batch_error is not None:
+        execute.side_effect = batch_error
+    else:
+        execute.return_value = (
+            batch_response if batch_response is not None else {}
+        )
+    return service
+
+
+def _batch_body(service):
+    return service.documents.return_value.batchUpdate.call_args.kwargs["body"]
+
+
+def _make_args(command, **overrides):
+    defaults = {
+        "command": command,
+        "doc": "abc123",
+        "json": False,
+        "verbose": False,
+        "plain": False,
+        "quiet": True,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# --- thread helpers -------------------------------------------------------
+
+
+class TestThreadHelpers:
+    def test_find_thread_keeps_namespaces_separate(self):
+        doc = _doc(
+            comments=[_comment_thread("shared")],
+            suggestions=[_suggestion_thread("shared")],
+        )
+        found = find_thread(doc, "shared", suggestion=False)
+        assert found["commentId"] == "shared"
+        found = find_thread(doc, "shared", suggestion=True)
+        assert found["suggestionId"] == "shared"
+        assert find_thread(doc, "missing", suggestion=False) is None
+        assert find_thread(_doc(), "shared", suggestion=True) is None
+
+    def test_find_post_covers_head_and_replies(self):
+        thread = _comment_thread("c1", replies=[_post("r1")])
+        assert find_post(thread, "c1")["content"] == "head"
+        assert find_post(thread, "r1")["postId"] == "r1"
+        assert find_post(thread, "nope") is None
+
+    def test_thread_assignee_from_head_post(self):
+        assert thread_assignee(_comment_thread(assignee=ME)) == ME
+
+    def test_thread_assignee_latest_reassignment_wins(self):
+        thread = _comment_thread(
+            assignee=ME,
+            replies=[_post("r1", assignee=OTHER), _post("r2")],
+        )
+        assert thread_assignee(thread) == OTHER
+
+    def test_thread_assignee_unassigned_is_empty(self):
+        assert thread_assignee(_comment_thread()) == ""
+        assert thread_assignee(_comment_thread(replies=[_post("r1")])) == ""
+
+    def test_post_is_action(self):
+        assert post_is_action(_post("r1", assignee=ME))
+        assert post_is_action(_post("r1", action="RESOLVE"))
+        assert post_is_action(_post("r1", action="REOPEN"))
+        assert not post_is_action(_post("r1"))
+        assert not post_is_action(
+            {"postId": "p", "suggestionAction": "NO_SUGGESTION_ACTION_CHANGE"}
+        )
+
+
+# --- get_document_threads -------------------------------------------------
+
+
+class TestGetDocumentThreads:
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_sends_preview_view_modes(self, _svc, mock_raw):
+        mock_raw.return_value = {"documentId": "abc123"}
+        doc = get_document_threads("abc123")
+        params = mock_raw.call_args.args[2]
+        assert params == {
+            "includeTabsContent": "true",
+            "suggestionsViewMode": "SUGGESTIONS_INLINE",
+            "commentsViewMode": "COMMENTS_VIEW_MODE_INCLUDED",
+        }
+        assert doc["comments"] == [] and doc["suggestions"] == []
+
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_unknown_field_means_preview_unavailable(self, _svc, mock_raw):
+        mock_raw.side_effect = _http_error(
+            400,
+            'Invalid JSON payload received. Unknown name "comments_view_mode"',
+        )
+        with pytest.raises(GdocError, match="not enrolled") as ei:
+            get_document_threads("abc123")
+        assert not isinstance(ei.value, PreviewUnavailableError)
+        assert ei.value.exit_code == 1
+
+    @patch("gdoc.api.docs._documents_get_raw")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_is_document_not_found(self, _svc, mock_raw):
+        mock_raw.side_effect = _http_error(404)
+        with pytest.raises(GdocError, match="Document not found"):
+            get_document_threads("abc123")
+
+
+# --- insert_comment with assignee ----------------------------------------
+
+
+_INSERT_OK = {
+    "commentUpdateState": "ALL_SAVED",
+    "replies": [{"insertComment": {"commentThread": {"commentId": "c_new"}}}],
+}
+
+
+class TestInsertCommentAssignee:
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_assignee_sent_as_assignee_email_address(self, mock_svc):
+        service = _mock_docs_service(_INSERT_OK)
+        mock_svc.return_value = service
+        cid = insert_comment(
+            "abc123", "hi", 5, 9, tab_id="t.0", revision_id="rev1",
+            assignee_email=ME,
+        )
+        assert cid == "c_new"
+        assert _batch_body(service) == {
+            "requests": [{"insertComment": {
+                "content": "hi",
+                "range": {"startIndex": 5, "endIndex": 9, "tabId": "t.0"},
+                "assigneeEmailAddress": ME,
+            }}],
+            "writeControl": {"requiredRevisionId": "rev1"},
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_no_assignee_leaves_request_unchanged(self, mock_svc):
+        service = _mock_docs_service(_INSERT_OK)
+        mock_svc.return_value = service
+        insert_comment("abc123", "hi", 5, 9)
+        assert _batch_body(service) == {
+            "requests": [{"insertComment": {
+                "content": "hi", "range": {"startIndex": 5, "endIndex": 9},
+            }}],
+        }
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_assigned_requires_comment_update_state(self, mock_svc):
+        response = {"replies": _INSERT_OK["replies"]}  # state missing
+        mock_svc.return_value = _mock_docs_service(response)
+        with pytest.raises(PreviewUnavailableError, match="missing"):
+            insert_comment("abc123", "hi", 5, 9, assignee_email=ME)
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_unassigned_tolerates_missing_state(self, mock_svc):
+        # Pre-existing contract for the fallback path is unchanged.
+        response = {"replies": _INSERT_OK["replies"]}
+        mock_svc.return_value = _mock_docs_service(response)
+        assert insert_comment("abc123", "hi", 5, 9) == "c_new"
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_partial_failure_state_is_error(self, mock_svc):
+        response = dict(
+            _INSERT_OK, commentUpdateState="ALL_FAILED_UNKNOWN_REASON",
+        )
+        mock_svc.return_value = _mock_docs_service(response)
+        with pytest.raises(PreviewUnavailableError, match="ALL_FAILED"):
+            insert_comment("abc123", "hi", 5, 9, assignee_email=ME)
+
+
+# --- add_comment_reply / update / delete API wrappers ---------------------
+
+_SAVED_EMPTY = {"commentUpdateState": "ALL_SAVED", "replies": [{}]}
+
+
+def _reply_ok(post_id="p_new", content="text", assignee=None):
+    post = _post(post_id, content, assignee=assignee)
+    return {
+        "commentUpdateState": "ALL_SAVED",
+        "replies": [{"addCommentReply": {"post": post}}],
+    }
+
+
+class TestAddCommentReply:
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_comment_thread_request_and_verification(self, mock_svc, mock_read):
+        service = _mock_docs_service(_reply_ok("p_new", "hello"))
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("p_new", "hello")])]
+        )
+        post = add_comment_reply("abc123", "c1", content="hello")
+        assert post["postId"] == "p_new"
+        body = _batch_body(service)
+        assert body == {"requests": [
+            {"addCommentReply": {"commentId": "c1", "post": {"content": "hello"}}}
+        ]}
+        assert "writeControl" not in body
+        mock_read.assert_called_once_with("abc123")
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_suggestion_thread_uses_suggestion_id(self, mock_svc, mock_read):
+        service = _mock_docs_service(_reply_ok("p_new"))
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(
+            suggestions=[_suggestion_thread("suggest.s1", replies=[_post("p_new")])]
+        )
+        add_comment_reply("abc123", "suggest.s1", content="text", suggestion=True)
+        assert _batch_body(service)["requests"] == [
+            {"addCommentReply": {
+                "suggestionId": "suggest.s1", "post": {"content": "text"},
+            }}
+        ]
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_reassign_sends_assignee_email_in_same_post(self, mock_svc, mock_read):
+        service = _mock_docs_service(_reply_ok("p_new", "t", assignee=OTHER))
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(comments=[_comment_thread(
+            "c1", assignee=ME, replies=[_post("p_new", "t", assignee=OTHER)],
+        )])
+        add_comment_reply("abc123", "c1", content="t", assignee_email=OTHER)
+        assert _batch_body(service)["requests"][0]["addCommentReply"]["post"] == {
+            "content": "t", "assigneeEmail": OTHER,
+        }
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_read_back_missing_post_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_reply_ok("p_new"))
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        with pytest.raises(GdocError, match="not on commentId c1"):
+            add_comment_reply("abc123", "c1", content="x")
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_read_back_missing_thread_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_reply_ok("p_new"))
+        mock_read.return_value = _doc()
+        with pytest.raises(GdocError, match="inspect the thread"):
+            add_comment_reply("abc123", "suggest.s1", content="x", suggestion=True)
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_200_without_post_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+        with pytest.raises(GdocError, match="no post"):
+            add_comment_reply("abc123", "c1", content="x")
+        mock_read.assert_not_called()
+
+    @pytest.mark.parametrize("state", ["", "ALL_FAILED_UNKNOWN_REASON",
+                                       "NO_UPDATES_REQUESTED"])
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_not_all_saved_is_error(self, mock_svc, mock_read, state):
+        response = _reply_ok("p_new")
+        if state:
+            response["commentUpdateState"] = state
+        else:
+            del response["commentUpdateState"]
+        mock_svc.return_value = _mock_docs_service(response)
+        with pytest.raises(GdocError, match="not saved"):
+            add_comment_reply("abc123", "c1", content="x")
+        mock_read.assert_not_called()
+
+    @pytest.mark.parametrize("message", [
+        'Invalid JSON payload received. Unknown name "add_comment_reply"',
+        "Invalid requests[0]: No request set.",
+        "Cannot find field.",
+    ])
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_preview_unavailable_is_named(self, mock_svc, message):
+        mock_svc.return_value = _mock_docs_service(
+            batch_error=_http_error(400, message)
+        )
+        with pytest.raises(GdocError, match="not enrolled") as ei:
+            add_comment_reply("abc123", "c1", content="x")
+        assert not isinstance(ei.value, PreviewUnavailableError)
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_author_rule_400_keeps_google_message(self, mock_svc):
+        msg = "The comment thread is not assigned to anyone."
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(400, msg))
+        with pytest.raises(GdocError, match=msg) as ei:
+            add_comment_reply("abc123", "c1", content="x", assignee_email=OTHER)
+        assert ei.value.exit_code == 1
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_403_keeps_google_message(self, mock_svc):
+        msg = "The caller does not have permission"
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(403, msg))
+        with pytest.raises(GdocError, match=msg):
+            add_comment_reply("abc123", "c1", content="x")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_404_names_thread_or_document(self, mock_svc):
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(404))
+        with pytest.raises(GdocError, match="thread/post"):
+            add_comment_reply("abc123", "c1", content="x")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_401_is_auth_error(self, mock_svc):
+        from gdoc.util import AuthError
+
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(401))
+        with pytest.raises(AuthError):
+            add_comment_reply("abc123", "c1", content="x")
+
+
+class TestUpdateCommentPost:
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_request_and_read_back(self, mock_svc, mock_read):
+        service = _mock_docs_service(_SAVED_EMPTY)
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1", "new text")])]
+        )
+        update_comment_post("abc123", "c1", "r1", "new text")
+        body = _batch_body(service)
+        assert body == {"requests": [{"updateCommentPost": {
+            "commentId": "c1", "postId": "r1", "content": "new text",
+        }}]}
+        assert "writeControl" not in body
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_suggestion_namespace(self, mock_svc, mock_read):
+        service = _mock_docs_service(_SAVED_EMPTY)
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(suggestions=[
+            _suggestion_thread("suggest.s1", replies=[_post("r1", "new")])
+        ])
+        update_comment_post("abc123", "suggest.s1", "r1", "new", suggestion=True)
+        request = _batch_body(service)["requests"][0]["updateCommentPost"]
+        assert "suggestionId" in request
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_read_back_with_old_text_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1", "old text")])]
+        )
+        with pytest.raises(GdocError, match="does not show the new text"):
+            update_comment_post("abc123", "c1", "r1", "new text")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_not_author_400_keeps_message(self, mock_svc):
+        msg = "Only the author of a post can edit it."
+        mock_svc.return_value = _mock_docs_service(batch_error=_http_error(400, msg))
+        with pytest.raises(GdocError, match=msg):
+            update_comment_post("abc123", "c1", "r1", "x")
+
+
+class TestDeleteCommentReply:
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_request_and_read_back(self, mock_svc, mock_read):
+        service = _mock_docs_service(_SAVED_EMPTY)
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        delete_comment_reply("abc123", "c1", "r1")
+        assert _batch_body(service) == {"requests": [{"deleteCommentReply": {
+            "commentId": "c1", "postId": "r1",
+        }}]}
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_suggestion_namespace(self, mock_svc, mock_read):
+        service = _mock_docs_service(_SAVED_EMPTY)
+        mock_svc.return_value = service
+        mock_read.return_value = _doc(suggestions=[_suggestion_thread("suggest.s1")])
+        delete_comment_reply("abc123", "suggest.s1", "r1", suggestion=True)
+        assert _batch_body(service)["requests"][0]["deleteCommentReply"] == {
+            "suggestionId": "suggest.s1", "postId": "r1",
+        }
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_post_still_present_is_error(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1")])]
+        )
+        with pytest.raises(GdocError, match="still on the thread"):
+            delete_comment_reply("abc123", "c1", "r1")
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_thread_gone_after_delete_counts_as_deleted(self, mock_svc, mock_read):
+        mock_svc.return_value = _mock_docs_service(_SAVED_EMPTY)
+        mock_read.return_value = _doc()
+        delete_comment_reply("abc123", "c1", "r1")  # no raise
+
+
+# --- cmd_comment --assign -------------------------------------------------
+
+
+_TABS_DOC = {
+    "revisionId": "rev1",
+    "tabs": [{
+        "tabProperties": {"tabId": "t.0", "title": "Tab 1"},
+        "documentTab": {"body": {"content": [{
+            "startIndex": 1, "endIndex": 20,
+            "paragraph": {"elements": [{
+                "startIndex": 1, "endIndex": 20,
+                "textRun": {"content": "the quick brown fox\n"},
+            }]},
+        }]}},
+    }],
+}
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.notify.pre_flight", return_value=None)
+@patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+class TestCmdCommentAssign:
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.insert_comment", return_value="c_assigned")
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_assign_passes_assignee_and_never_uses_drive(
+        self, _get, mock_insert, mock_create, _ver, _pf, mock_update, capsys,
+    ):
+        args = _make_args("comment", text="please", quote="quick brown", assign=ME)
+        assert cmd_comment(args) == 0
+        assert mock_insert.call_args.kwargs["assignee_email"] == ME
+        assert mock_insert.call_args.kwargs["revision_id"] == "rev1"
+        assert mock_insert.call_args.kwargs["tab_id"] == "t.0"
+        mock_create.assert_not_called()
+        out = capsys.readouterr().out
+        assert f"OK comment #c_assigned (anchored, assigned to {ME})" in out
+        assert mock_update.call_args.kwargs["comment_state_patch"] == {
+            "add_comment_id": "c_assigned",
+        }
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.insert_comment", return_value="c_assigned")
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_assign_json_and_plain(
+        self, _get, _insert, _create, _ver, _pf, _update, capsys,
+    ):
+        cmd_comment(
+            _make_args("comment", text="p", quote="quick", assign=ME, json=True)
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert data == {
+            "ok": True, "id": "c_assigned", "status": "created",
+            "anchored": True, "assignee": ME,
+        }
+        cmd_comment(
+            _make_args("comment", text="p", quote="quick", assign=ME, plain=True)
+        )
+        assert capsys.readouterr().out == (
+            f"id\tc_assigned\nanchored\ttrue\nassignee\t{ME}\n"
+        )
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_assign_requires_quote(
+        self, mock_get, mock_create, _ver, _pf, _update, capsys,
+    ):
+        with pytest.raises(GdocError, match="requires --quote") as ei:
+            cmd_comment(_make_args("comment", text="p", quote=None, assign=ME))
+        assert ei.value.exit_code == 3
+        mock_get.assert_not_called()
+        mock_create.assert_not_called()
+        assert capsys.readouterr().out == ""
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.insert_comment")
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_assign_quote_not_found_is_usage_error(
+        self, _get, mock_insert, mock_create, _ver, _pf, _update,
+    ):
+        with pytest.raises(GdocError, match="Quote text not found") as ei:
+            cmd_comment(_make_args("comment", text="p", quote="zzz", assign=ME))
+        assert ei.value.exit_code == 3
+        mock_insert.assert_not_called()
+        mock_create.assert_not_called()
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch(
+        "gdoc.api.docs.insert_comment",
+        side_effect=PreviewUnavailableError("insertComment not available"),
+    )
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_assign_preview_unavailable_is_hard_error(
+        self, _get, _insert, mock_create, _ver, _pf, _update,
+    ):
+        with pytest.raises(GdocError, match="cannot create an assigned comment") as ei:
+            cmd_comment(_make_args("comment", text="p", quote="quick", assign=ME))
+        assert ei.value.exit_code == 1
+        mock_create.assert_not_called()
+
+    @patch("gdoc.api.comments.create_comment", return_value={"id": "c_drive"})
+    @patch(
+        "gdoc.api.docs.insert_comment",
+        side_effect=PreviewUnavailableError("insertComment not available"),
+    )
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_without_assign_fallback_is_unchanged(
+        self, _get, mock_insert, mock_create, _ver, _pf, _update, capsys,
+    ):
+        args = _make_args("comment", text="p", quote="quick", assign=None)
+        assert cmd_comment(args) == 0
+        assert "assignee_email" not in mock_insert.call_args.kwargs
+        mock_create.assert_called_once_with("abc123", "p", quote="quick")
+        assert "OK comment #c_drive" in capsys.readouterr().out
+
+    @patch("gdoc.api.comments.create_comment")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_assign_validates_text_before_any_read(
+        self, mock_get, mock_create, _ver, _pf, _update,
+    ):
+        with pytest.raises(GdocError, match="must not be empty") as ei:
+            cmd_comment(_make_args("comment", text="  ", quote="quick", assign=ME))
+        assert ei.value.exit_code == 3
+        too_long = "é" * 1025  # 2050 UTF-8 bytes, 1025 characters
+        with pytest.raises(GdocError, match="2050 UTF-8 bytes") as ei:
+            cmd_comment(_make_args("comment", text=too_long, quote="quick", assign=ME))
+        assert ei.value.exit_code == 3
+        mock_get.assert_not_called()
+
+
+class TestTryAnchoredCommentAssignee:
+    @patch("gdoc.api.docs.insert_comment", return_value="c1")
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_TABS_DOC)
+    def test_no_assignee_keeps_legacy_call_signature(self, _get, mock_insert):
+        _try_anchored_comment("abc123", "t", "quick")
+        assert mock_insert.call_args.kwargs == {"tab_id": "t.0", "revision_id": "rev1"}
+
+
+# --- cmd_reply native routing ---------------------------------------------
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.notify.pre_flight", return_value=None)
+@patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+class TestCmdReplyNative:
+    @patch("gdoc.api.comments.create_reply")
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.add_comment_reply", return_value=_post("p9", "hi"))
+    def test_suggestion_reply_routes_natively_without_preread(
+        self, mock_add, mock_read, mock_drive, _ver, _pf, mock_update, capsys,
+    ):
+        args = _make_args("reply", comment_id="suggest.s1", text="hi", suggestion=True,
+                          reassign=None)
+        assert cmd_reply(args) == 0
+        mock_add.assert_called_once_with(
+            "abc123", "suggest.s1", content="hi", suggestion=True, assignee_email=None,
+        )
+        mock_read.assert_not_called()  # no precondition for a plain reply
+        mock_drive.assert_not_called()
+        assert "OK reply on suggestion #suggest.s1" in capsys.readouterr().out
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs["comment_state_patch"] is None
+        assert kwargs["command_version"] == 7
+
+    @patch("gdoc.api.docs.add_comment_reply", return_value=_post("p9", "hi"))
+    def test_suggestion_reply_json_and_plain(
+        self, _add, _ver, _pf, _update, capsys,
+    ):
+        cmd_reply(_make_args("reply", comment_id="suggest.s1", text="hi",
+                             suggestion=True, reassign=None, json=True))
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True, "suggestionId": "suggest.s1", "postId": "p9",
+            "status": "created",
+        }
+        cmd_reply(_make_args("reply", comment_id="suggest.s1", text="hi",
+                             suggestion=True, reassign=None, plain=True))
+        assert capsys.readouterr().out == "suggestionId\tsuggest.s1\npostId\tp9\n"
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch(
+        "gdoc.api.docs.add_comment_reply",
+        return_value=_post("p9", "hi", assignee=OTHER),
+    )
+    def test_reassign_preflights_assignee_then_writes(
+        self, mock_add, mock_read, _ver, _pf, mock_update, capsys,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1", assignee=ME)])
+        args = _make_args("reply", comment_id="c1", text="over to you",
+                          suggestion=False, reassign=OTHER, json=True)
+        assert cmd_reply(args) == 0
+        mock_read.assert_called_once_with("abc123")
+        mock_add.assert_called_once_with(
+            "abc123", "c1", content="over to you", suggestion=False,
+            assignee_email=OTHER,
+        )
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True, "commentId": "c1", "postId": "p9", "status": "created",
+            "assignee": OTHER,
+        }
+        assert mock_update.call_args.kwargs["comment_state_patch"] == {
+            "add_comment_id": "c1",
+        }
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_reassign_unassigned_parent_fails_before_write(
+        self, mock_add, mock_read, _ver, _pf, mock_update, capsys,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        args = _make_args("reply", comment_id="c1", text="t", suggestion=False,
+                          reassign=OTHER)
+        with pytest.raises(GdocError, match="has no assignee") as ei:
+            cmd_reply(args)
+        assert ei.value.exit_code == 3
+        mock_add.assert_not_called()
+        mock_update.assert_not_called()
+        assert capsys.readouterr().out == ""
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_reassign_thread_missing_fails_before_write(
+        self, mock_add, mock_read, _ver, _pf, _update,
+    ):
+        mock_read.return_value = _doc()
+        args = _make_args("reply", comment_id="c1", text="t", suggestion=False,
+                          reassign=OTHER)
+        with pytest.raises(GdocError, match="comment thread not found") as ei:
+            cmd_reply(args)
+        assert ei.value.exit_code == 3
+        mock_add.assert_not_called()
+
+    @patch("gdoc.api.docs.get_document_threads")
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_reassign_runs_preflight_even_with_quiet(
+        self, mock_add, mock_read, _ver, mock_pf, _update,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        args = _make_args("reply", comment_id="c1", text="t", suggestion=False,
+                          reassign=OTHER, quiet=True)
+        with pytest.raises(GdocError):
+            cmd_reply(args)
+        mock_pf.assert_called_once_with("abc123", quiet=True)
+        mock_read.assert_called_once()
+
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_suggestion_and_reassign_conflict(self, mock_add, _ver, _pf, _update):
+        args = _make_args("reply", comment_id="suggest.s1", text="t",
+                          suggestion=True, reassign=OTHER)
+        with pytest.raises(GdocError, match="comment threads only") as ei:
+            cmd_reply(args)
+        assert ei.value.exit_code == 3
+        mock_add.assert_not_called()
+
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_suggestion_flag_rejects_comment_looking_id(
+        self, mock_add, _ver, _pf, _update,
+    ):
+        args = _make_args("reply", comment_id="AAACabc", text="t",
+                          suggestion=True, reassign=None)
+        with pytest.raises(GdocError, match="does not look like a suggestion") as ei:
+            cmd_reply(args)
+        assert ei.value.exit_code == 3
+        mock_add.assert_not_called()
+
+    @patch("gdoc.api.comments.create_reply")
+    def test_drive_path_rejects_suggestion_id(self, mock_drive, _ver, _pf, _update):
+        args = _make_args("reply", comment_id="suggest.s1", text="t",
+                          suggestion=False, reassign=None)
+        with pytest.raises(GdocError, match="suggestion thread ID") as ei:
+            cmd_reply(args)
+        assert ei.value.exit_code == 3
+        mock_drive.assert_not_called()
+
+    @patch("gdoc.api.docs.add_comment_reply")
+    def test_native_reply_validates_text(self, mock_add, _ver, _pf, _update):
+        args = _make_args("reply", comment_id="suggest.s1", text="",
+                          suggestion=True, reassign=None)
+        with pytest.raises(GdocError, match="must not be empty") as ei:
+            cmd_reply(args)
+        assert ei.value.exit_code == 3
+        mock_add.assert_not_called()
+
+    @patch("gdoc.api.comments.get_drive_service")
+    @patch("gdoc.api.comments.create_reply", return_value={"id": "r1"})
+    def test_plain_reply_still_uses_drive(
+        self, mock_drive, _svc, _ver, _pf, mock_update, capsys,
+    ):
+        args = _make_args("reply", comment_id="c1", text="thanks",
+                          suggestion=False, reassign=None, json=True)
+        assert cmd_reply(args) == 0
+        mock_drive.assert_called_once_with("abc123", "c1", content="thanks")
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True, "commentId": "c1", "replyId": "r1", "status": "created",
+        }
+        assert mock_update.call_args.kwargs["comment_state_patch"] == {
+            "add_comment_id": "c1",
+        }
+
+
+# --- edit-comment / edit-suggestion-reply ---------------------------------
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.notify.pre_flight", return_value=None)
+@patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+@patch("gdoc.api.docs.update_comment_post")
+@patch("gdoc.api.docs.get_document_threads")
+class TestEditPost:
+    def test_edit_comment_reply(
+        self, mock_read, mock_update_post, _ver, _pf, mock_state, capsys,
+    ):
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1", "old")])]
+        )
+        args = _make_args("edit-comment", thread_id="c1", post_id="r1", text="new")
+        assert cmd_edit_comment(args) == 0
+        mock_update_post.assert_called_once_with(
+            "abc123", "c1", "r1", "new", suggestion=False,
+        )
+        assert "OK updated post r1 on #c1" in capsys.readouterr().out
+        kwargs = mock_state.call_args.kwargs
+        assert kwargs["command"] == "edit-comment"
+        assert kwargs["comment_state_patch"] == {"add_comment_id": "c1"}
+
+    def test_edit_comment_head_post_is_allowed(
+        self, mock_read, mock_update_post, _ver, _pf, _state, capsys,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        args = _make_args("edit-comment", thread_id="c1", post_id="c1", text="new",
+                          json=True)
+        assert cmd_edit_comment(args) == 0
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True, "commentId": "c1", "postId": "c1", "status": "updated",
+        }
+
+    def test_edit_suggestion_reply(
+        self, mock_read, mock_update_post, _ver, _pf, mock_state, capsys,
+    ):
+        mock_read.return_value = _doc(suggestions=[
+            _suggestion_thread("suggest.s1", replies=[_post("r1", "old")])
+        ])
+        args = _make_args("edit-suggestion-reply", thread_id="suggest.s1",
+                          post_id="r1", text="new", plain=True)
+        assert cmd_edit_suggestion_reply(args) == 0
+        mock_update_post.assert_called_once_with(
+            "abc123", "suggest.s1", "r1", "new", suggestion=True,
+        )
+        assert capsys.readouterr().out == (
+            "suggestionId\tsuggest.s1\npostId\tr1\nstatus\tupdated\n"
+        )
+        assert mock_state.call_args.kwargs["comment_state_patch"] is None
+
+    def test_edit_suggestion_head_post_refused(
+        self, mock_read, mock_update_post, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(suggestions=[_suggestion_thread("suggest.s1")])
+        args = _make_args("edit-suggestion-reply", thread_id="suggest.s1",
+                          post_id="p_head", text="new")
+        with pytest.raises(GdocError, match="head post of a suggestion") as ei:
+            cmd_edit_suggestion_reply(args)
+        assert ei.value.exit_code == 3
+        mock_update_post.assert_not_called()
+
+    def test_edit_post_not_found(
+        self, mock_read, mock_update_post, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        args = _make_args("edit-comment", thread_id="c1", post_id="zz", text="new")
+        with pytest.raises(GdocError, match="post zz not found") as ei:
+            cmd_edit_comment(args)
+        assert ei.value.exit_code == 3
+        mock_update_post.assert_not_called()
+
+    def test_edit_other_users_post_refused(
+        self, mock_read, mock_update_post, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1", me=False)])]
+        )
+        args = _make_args("edit-comment", thread_id="c1", post_id="r1", text="new")
+        with pytest.raises(GdocError, match="another user") as ei:
+            cmd_edit_comment(args)
+        assert ei.value.exit_code == 3
+        mock_update_post.assert_not_called()
+
+    def test_edit_validates_text_before_read(
+        self, mock_read, mock_update_post, _ver, _pf, _state,
+    ):
+        args = _make_args("edit-comment", thread_id="c1", post_id="r1", text="")
+        with pytest.raises(GdocError, match="must not be empty"):
+            cmd_edit_comment(args)
+        mock_read.assert_not_called()
+
+    def test_edit_comment_rejects_suggestion_id(
+        self, mock_read, mock_update_post, _ver, _pf, _state,
+    ):
+        args = _make_args(
+            "edit-comment", thread_id="suggest.s1", post_id="r1", text="x",
+        )
+        with pytest.raises(GdocError, match="suggestion thread ID") as ei:
+            cmd_edit_comment(args)
+        assert ei.value.exit_code == 3
+        mock_read.assert_not_called()
+
+
+# --- delete-reply / delete-suggestion-reply -------------------------------
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.notify.pre_flight", return_value=None)
+@patch("gdoc.api.drive.get_file_version", return_value={"version": 7})
+@patch("gdoc.api.docs.delete_comment_reply")
+@patch("gdoc.api.docs.get_document_threads")
+class TestDeletePost:
+    def test_delete_reply_force(
+        self, mock_read, mock_delete, _ver, _pf, mock_state, capsys,
+    ):
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1")])]
+        )
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=True)
+        assert cmd_delete_reply(args) == 0
+        mock_delete.assert_called_once_with("abc123", "c1", "r1", suggestion=False)
+        assert "OK deleted reply r1 from #c1" in capsys.readouterr().out
+        # The thread survives, so its ID stays known; nothing is removed.
+        assert mock_state.call_args.kwargs["comment_state_patch"] == {
+            "add_comment_id": "c1",
+        }
+
+    def test_delete_suggestion_reply_json(
+        self, mock_read, mock_delete, _ver, _pf, mock_state, capsys,
+    ):
+        mock_read.return_value = _doc(suggestions=[
+            _suggestion_thread("suggest.s1", replies=[_post("r1")])
+        ])
+        args = _make_args("delete-suggestion-reply", thread_id="suggest.s1",
+                          post_id="r1", force=True, json=True)
+        assert cmd_delete_suggestion_reply(args) == 0
+        mock_delete.assert_called_once_with(
+            "abc123", "suggest.s1", "r1", suggestion=True,
+        )
+        assert json.loads(capsys.readouterr().out) == {
+            "ok": True, "suggestionId": "suggest.s1", "postId": "r1",
+            "status": "deleted",
+        }
+        assert mock_state.call_args.kwargs["comment_state_patch"] is None
+
+    @patch("sys.stdin")
+    def test_delete_without_force_non_interactive(
+        self, mock_stdin, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        mock_stdin.isatty.return_value = False
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=False)
+        with pytest.raises(GdocError, match="without --force") as ei:
+            cmd_delete_reply(args)
+        assert ei.value.exit_code == 3
+        mock_read.assert_not_called()
+        mock_delete.assert_not_called()
+
+    def test_delete_head_post_refused(
+        self, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        args = _make_args("delete-reply", thread_id="c1", post_id="c1", force=True)
+        with pytest.raises(GdocError, match="delete-comment") as ei:
+            cmd_delete_reply(args)
+        assert ei.value.exit_code == 3
+        mock_delete.assert_not_called()
+
+    def test_delete_suggestion_head_post_refused(
+        self, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(suggestions=[_suggestion_thread("suggest.s1")])
+        args = _make_args("delete-suggestion-reply", thread_id="suggest.s1",
+                          post_id="p_head", force=True)
+        with pytest.raises(GdocError, match="head post") as ei:
+            cmd_delete_suggestion_reply(args)
+        assert ei.value.exit_code == 3
+        mock_delete.assert_not_called()
+
+    @pytest.mark.parametrize("post", [
+        _post("r1", assignee=OTHER), _post("r1", action="RESOLVE"),
+    ])
+    def test_delete_action_or_assignment_reply_refused(
+        self, mock_read, mock_delete, _ver, _pf, _state, post,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1", replies=[post])])
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=True)
+        with pytest.raises(GdocError, match="action or an assignment") as ei:
+            cmd_delete_reply(args)
+        assert ei.value.exit_code == 3
+        mock_delete.assert_not_called()
+
+    def test_delete_other_users_reply_refused(
+        self, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(
+            comments=[_comment_thread("c1", replies=[_post("r1", me=False)])]
+        )
+        args = _make_args("delete-reply", thread_id="c1", post_id="r1", force=True)
+        with pytest.raises(GdocError, match="another user"):
+            cmd_delete_reply(args)
+        mock_delete.assert_not_called()
+
+    def test_delete_post_not_found(
+        self, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        mock_read.return_value = _doc(comments=[_comment_thread("c1")])
+        args = _make_args("delete-reply", thread_id="c1", post_id="zz", force=True)
+        with pytest.raises(GdocError, match="not found") as ei:
+            cmd_delete_reply(args)
+        assert ei.value.exit_code == 3
+        mock_delete.assert_not_called()
+
+    def test_delete_reply_rejects_suggestion_id(
+        self, mock_read, mock_delete, _ver, _pf, _state,
+    ):
+        args = _make_args("delete-reply", thread_id="suggest.s1", post_id="r1",
+                          force=True)
+        with pytest.raises(GdocError, match="suggestion thread ID"):
+            cmd_delete_reply(args)
+        mock_read.assert_not_called()
+
+
+# --- parser and MCP exposure ---------------------------------------------
+
+
+class TestParserAndMcp:
+    def test_parser_flags(self):
+        from gdoc.cli import build_parser
+
+        parser = build_parser()
+        a = parser.parse_args(["comment", "d", "t", "--quote", "q", "--assign", ME])
+        assert a.assign == ME and a.quote == "q"
+        a = parser.parse_args(["reply", "d", "suggest.s1", "t", "--suggestion"])
+        assert a.suggestion is True and a.reassign is None
+        a = parser.parse_args(["reply", "d", "c1", "t", "--reassign", OTHER])
+        assert a.reassign == OTHER and a.suggestion is False
+        a = parser.parse_args(["edit-comment", "d", "c1", "p1", "new"])
+        assert (a.thread_id, a.post_id, a.text) == ("c1", "p1", "new")
+        assert a.func is cmd_edit_comment
+        a = parser.parse_args(["edit-suggestion-reply", "d", "s", "p", "n"])
+        assert a.func is cmd_edit_suggestion_reply
+        a = parser.parse_args(["delete-reply", "d", "c1", "p1", "--force"])
+        assert a.force is True and a.func is cmd_delete_reply
+        a = parser.parse_args(["delete-suggestion-reply", "d", "s", "p"])
+        assert a.force is False and a.func is cmd_delete_suggestion_reply
+
+    def test_reply_text_still_required(self):
+        from gdoc.cli import build_parser
+
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["reply", "d", "c1", "--reassign", OTHER])
+
+    def test_mcp_exposes_new_commands_as_writes(self):
+        from gdoc.mcp import EXPOSED_COMMANDS, build_tools
+
+        for cmd in ("edit-comment", "edit-suggestion-reply", "delete-reply",
+                    "delete-suggestion-reply"):
+            assert EXPOSED_COMMANDS[cmd] is False
+        names = set(build_tools())
+        assert {"gdoc_edit_comment", "gdoc_delete_suggestion_reply"} <= names
+        assert "gdoc_delete_reply" not in build_tools(read_only=True)
+
+    def test_mcp_delete_reply_requires_force(self):
+        from gdoc.mcp import build_tools, call_command
+
+        tools = build_tools()
+        for name in ("gdoc_delete_reply", "gdoc_delete_suggestion_reply"):
+            assert "force" in tools[name]["inputSchema"]["required"]
+        with pytest.raises(ValueError, match="force: true"):
+            call_command(
+                "delete-reply", {"doc": "d", "thread_id": "c1", "post_id": "p"},
+            )


### PR DESCRIPTION
## Summary

Third Docs API Developer Preview PR, after anchored comments (#40). Adds only the comment operations the Drive API cannot express, on Google's **native comment threads**. Independent of `gdoc suggest` (#53) and suggestion management (#54) — branched from `origin/main` @ 31b4309, no stacking.

```
gdoc comment DOC TEXT --quote TEXT --assign EMAIL        # assigned anchored comment
gdoc reply DOC SUGGESTION_ID TEXT --suggestion           # reply on a suggestion thread
gdoc reply DOC COMMENT_ID TEXT --reassign EMAIL          # hand an assigned thread on
gdoc edit-comment DOC COMMENT_ID POST_ID TEXT
gdoc edit-suggestion-reply DOC SUGGESTION_ID POST_ID TEXT
gdoc delete-reply DOC COMMENT_ID POST_ID [--force]
gdoc delete-suggestion-reply DOC SUGGESTION_ID POST_ID [--force]
```

**Drive v3 stays the default read and mutation path for ordinary comments** (`comments`, `comment`, `reply`, `resolve`, `reopen`, `delete-comment`, `comment-info`, the awareness system). Native threads are used only when a command needs assignment, a suggestion-thread reply, post editing, or single-reply deletion.

### Contract

- **No fallback for native operations.** `--assign` needs `--quote` (insertComment needs a range) and never degrades to an unassigned Drive comment: quote not found → exit 3, preview unavailable / no batchUpdate access → exit 1 naming the reason, nothing created. Plain `comment --quote` fallback behavior is byte-for-byte unchanged (`insert_comment` is called with the same arguments as before when no assignee is given).
- **Reassign is reply-only and preflighted.** `reply --reassign` reads the native thread (`documents.get` with `commentsViewMode=COMMENTS_VIEW_MODE_INCLUDED`) and refuses (exit 3, no write) unless **`headPost.assigneeEmail`** is set — Google returns 400 for `Post.assigneeEmail` on an unassigned parent. A reply carrying `assigneeEmail` records an event, not current state, and does not satisfy the check; an unrecognized/missing field fails closed. `--suggestion --reassign` is refused.
- **Explicit ID namespaces, opaque IDs.** The flag/command, not the ID, chooses `commentId` vs `suggestionId`; nothing inspects the ID's shape (an earlier `suggest.` prefix heuristic was removed on audit).
- **Success is verified, never assumed.** Every native write requires HTTP 2xx **and** `commentUpdateState == ALL_SAVED` (missing state is a failure), then re-reads the thread: a reply must appear with its `postId`, an assignment (`--assign`/`--reassign`) must appear as `assigneeEmail` on the thread, an edit must show the new text, a deleted post must be gone or carry `deleted: true` (tombstone). Editing or deleting an already-deleted post is refused before writing. If the verification read itself fails after `ALL_SAVED` (preview rejected, 5xx, expired auth), the error says the write *may have succeeded* and to inspect before retrying — it never repeats the pre-write "No change was made" text. Likewise a 5xx or transport failure from the `batchUpdate` itself is reported as an uncertain outcome (the request may have been applied) and never triggers the Drive fallback. The native read itself requires Google to echo `commentsViewMode`, so a silently dropped preview parameter can't read as "no threads". Otherwise it fails with "inspect the thread" — no silent success. `insert_comment --assign` also requires the state to be present (the unassigned path keeps its existing tolerance because it can still fall back).
- **Mutation-ambiguous outcomes are reported as such.** An assigned insert that returns 2xx without `ALL_SAVED`, or `ALL_SAVED` without a thread ID, fails with "a comment may have been created; inspect the document's comments before retrying" — never "not created", never a Drive fallback.
- **Pre-write refusals (exit 3)** for what Google would 400 anyway, with a clearer message: a suggestion's generated head post can't be edited; a head post isn't a reply (`delete-reply` points to `delete-comment`); replies carrying a resolve/reopen action or an assignment can't be deleted; another user's post (`author.me == false`) can't be edited/deleted. Post text must be non-empty and ≤ 2048 UTF-8 bytes.
- **Errors keep Google's message.** Author/assignee rule 400s and 403s surface as `Docs API rejected the request (NNN): <message>` (exit 1), distinct from preview-unavailable (`Unknown name` / `Cannot find field` / `No request set` → message naming Developer Preview enrollment). 401 → `AuthError` (exit 2).
- **No `writeControl` on post operations.** They carry no document ranges, so a concurrent text edit must not fail a reply on a stale revision; `insertComment` keeps `requiredRevisionId`.
- **State / awareness.** Comment-thread operations record `command_version` and `add_comment_id` (the thread survives `delete-reply`, so nothing is removed); suggestion-thread operations record `command_version` only — `suggest.*` IDs are never returned by Drive and must not enter `known_comment_ids`. `last_read_version` is never advanced (partial write). `--quiet` skips only Drive pre-flight; the native precondition reads and read-backs always run.
- **MCP.** The four new commands are exposed as writes; `delete-reply` / `delete-suggestion-reply` (and `delete-comment`) declare `force` as `required` with `const: true`, and the runtime still rejects omitted/false. Tool descriptions state the `comment`/`reply` cross-parameter rules. `reply`'s argparse schema is unchanged apart from the two new optional flags (TEXT stays required).

### Files

- `gdoc/api/docs.py` — `insert_comment(..., assignee_email=)`; `get_document_threads` (raw `documents.get` through the service's authorized transport, since the public Discovery document doesn't list `commentsViewMode`); `find_thread` / `find_post` / `thread_assignee` / `post_is_action` helpers; `add_comment_reply`, `update_comment_post`, `delete_comment_reply` sharing `_run_thread_request` (ALL_SAVED gate, error taxonomy).
- `gdoc/cli.py` — `comment --assign`, `reply --suggestion|--reassign` (`_native_reply`), `edit-comment` / `edit-suggestion-reply` (`_cmd_edit_post`), `delete-reply` / `delete-suggestion-reply` (`_cmd_delete_post`), `_check_thread_namespace`, `_validate_post_text`.
- `gdoc/mcp.py` — exposure + `_FORCE_REQUIRED`.
- `tests/test_comment_posts.py` — 167 tests. README (Comments table + "Native thread operations" section), CHANGELOG (`Unreleased`), `gdoc.md`.

Overlap note for whoever merges second: #54 adds its own `get_document_threads` / `_preview_parse_error` / `_documents_get_raw` with the same semantics (independently implemented here to avoid stacking) and also touches the MCP force check; the duplicate can be dropped at merge. Version bump deferred for the same reason (#53 and #54 both target 0.21.x); CHANGELOG entry is under `[Unreleased]`. `uv.lock` is synced to the existing 0.20.1 (it recorded 0.19.0 on main).

## Tests

```
uv run pytest tests/test_comment_posts.py -v      # 167 passed
uv run pytest tests/ -v                           # 1584 passed
uv lock --check                                   # OK (lock synced to 0.20.1; was stale on main)
uv run ruff check gdoc/ tests/                    # 198 findings, all pre-existing (main @ 31b4309 has 201 with ruff 0.15.0; 3 I001 fixed in touched blocks)
bash scripts/check-no-stubs.sh                    # OK
```

Tests mock exact `batchUpdate` bodies (including `"writeControl" not in body`), every `commentUpdateState` variant, preview-unavailable 400 variants vs author-rule 400/403 with Google's message preserved, read-back failures (reply missing, old text still shown, deleted post still present), all pre-write refusals, `--quiet` still running the precondition read, state patches per namespace, terse/plain/json output, parser flags (TEXT still required), MCP exposure and force requirement, and the unchanged `insert_comment` call signature / Drive fallback without `--assign`.

## Live evidence (registered project)

Registered OAuth-client project **1009200210134** (`mac-air-2020`, enrolled per `02-access-tests.md`), Workspace account, scratch document created for this PR (two tabs, emoji before the target, inline formatting, one suggestion created in `SUGGEST` mode on tab 2 to have a suggestion thread). All commands run through the built CLI at this commit; emails and personal identifiers redacted.

| Step | Command | Result |
|---|---|---|
| Native read shape | `documents.get … commentsViewMode` | `comments[]{commentId, anchorId, headPost{postId==commentId, content, author{me,user}, commentAction, assigneeEmail?}, replies[], status, plainTextQuote}`, `suggestions[]{suggestionId, headPost{postId≠suggestionId, suggestionAction}, replies[], status, summaryText}` |
| Assigned comment | `comment DOC "…" --quote "assigned target sentence" --assign <me> --json` | `{"ok": true, "id": "AAACGGw72qw", "status": "created", "anchored": true, "assignee": "<me>"}`; read-back shows `headPost.assigneeEmail` |
| Plain anchored | `comment DOC "…" --quote "unassigned anchor text" --json` | `anchored: true`, no assignee (unchanged path) |
| Reassign (assigned thread) | `reply DOC AAACGGw72qw "…" --reassign <me> --json` | `{"commentId": "AAACGGw72qw", "postId": "AAACGGyG5CU", "status": "created", "assignee": "<me>"}`; reply post carries `assigneeEmail` |
| Reassign (unassigned thread) | `reply DOC AAACGGyG5CE "…" --reassign <me>` | exit 3, `has no assignee … --reassign can only move an existing assignment`, no write |
| Drive reply on same thread | `reply DOC AAACGGw72qw "…"` | Drive `replyId AAACGGyG5CY` — identical to the native `postId` in the read-back; `comment-info` lists both replies. **Drive reply IDs == native post IDs** |
| Suggestion reply | `reply DOC suggest.lpqjyvt6f5dc "…" --suggestion --json` | `{"suggestionId": "suggest.lpqjyvt6f5dc", "postId": "AAACGGyG5Cg", "status": "created"}` |
| Edit reply / head | `edit-comment DOC AAACGGw72qw AAACGGyG5CY "…" --json`; `edit-comment DOC AAACGGw72qw AAACGGw72qw "…"` | `status: updated` both (Google allows editing a comment thread's head post you wrote); read-back shows new text |
| Edit suggestion reply | `edit-suggestion-reply DOC suggest.… AAACGGyG5Cg "…" --plain` | `status\tupdated` |
| Edit suggestion head | `edit-suggestion-reply DOC suggest.… AAACGGyG5CM "…"` | exit 3, refused before write |
| Delete assignment reply | `delete-reply DOC AAACGGw72qw AAACGGyG5CU --force` | exit 3, refused before write (action/assignment) |
| Delete head as reply | `delete-reply DOC AAACGGw72qw AAACGGw72qw --force` | exit 3, points to `delete-comment` |
| Delete without `--force`, non-tty | `delete-reply … </dev/null` | exit 3 `Refusing … without --force` |
| Delete reply | `delete-reply DOC AAACGGw72qw AAACGGyG5CY --force --json` | `status: deleted`; read-back confirms gone |
| Delete suggestion reply | `delete-suggestion-reply DOC suggest.… AAACGGyG5Cg --force`, then again | `OK deleted`, then exit 3 `not found` |
| Re-test @ 3123e76 | `comment … --assign` (new thread `AAACGGuesUk`), `reply --reassign` (`replyId`/`postId AAACGGuesUs`), `reply --suggestion` (`AAACGGuesU0`), `comment --assign` without `--quote` (no `--quiet`) | assignment confirmed on read-back for both; exit 3 raised before any Drive pre-flight call |
| Re-test @ d4a18a9 | `reply --reassign` on head-assigned thread (`AAACGGuesU8`); `reply --reassign` on unassigned head → exit 3 `no assignee on its head post`; `reply --suggestion` → `delete-suggestion-reply --force` → repeat → exit 3 `not found`; `edit-comment` then `delete-reply --force` on a fresh reply | all as designed; the native read returned no `deleted` tombstones in this project (deleted posts are absent), so the tombstone branch is covered by unit tests |
| Drive regression smoke | `comment` (unanchored), `reply`, `resolve`, `reopen`, `comments`, `comment --quote <missing text>` | all unchanged; quote-not-found still falls back with `anchored: false` |

No fallback performed a direct edit; the only text mutation on the scratch document was the deliberate `SUGGEST`-mode replaceAllText used to create the suggestion fixture (response: `createdSuggestionIds`, `ALL_SAVED`).

### Not live-tested

- **Unregistered project `856825977485`**: not re-probed in this session (the control client's credentials live in a keyring the session did not access). The rejection shape this PR handles (`400 Unknown name "comments_view_mode"` / `No request set`) is the one recorded on 25 Aug in `02-access-tests.md`; no write of any kind was attempted there.
- Another user's post (author-rule 400 from Google) — single-account session; covered by unit tests with Google's message preserved, and by the `author.me == false` pre-write refusal.
- Commenter-role account; reassigning to a non-collaborator.

### Review

Design contract reviewed pre-implementation by an independent read-only pass (findings folded in: strict `ALL_SAVED` for assigned inserts, `suggest.` namespace guard, preserved 403 messages, MCP force generalization, `postId` in native reply output, no `nargs="?"` change to `reply`); a second independent whole-diff pass ran before opening this PR; its 14 findings and their resolution are recorded in the first PR comment (fixed in `3123e76`, two rejected with reasons). An independent Codex audit of `6deced6` (8 findings) is resolved in `d4a18a9`; see the second PR comment. A final-HEAD closure audit found one P2 (post-write verification failures could say "No change was made"), fixed in `bcf2978`; see the third PR comment. CodeRabbit's 7 comments on `d4a18a9` are resolved in `b72fc6f` (all threads confirmed by CodeRabbit). A second closure audit (5xx/transport failures on native writes) is resolved in `33a6777`; lint follow-up `a7739c1`. A third closure audit is resolved in `e7116bd` + `aa3c90f` (one claim rejected with live evidence; see the PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
