### PR TITLE
feat: ?tab= URL deep links + per-tab write-conflict baselines (0.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to `gdoc` are documented here. This project follows
     conflict on the second write (the first write bumped the doc version but
     the tab-scoped write left the baseline behind). A tab write now advances
     that tab's own baseline, so repeated edits to one tab just work.
+- **HTML-escaped `&amp;tab=` in a pasted URL is honored.** A doc URL copied
+  out of rendered HTML keeps the escaped separator; the tab id used to go
+  unseen, silently downgrading `edit`/`write` to the whole-doc path.
 - **`insert --tab X` accepts a `cat --tab X` baseline.** The tab-populate
   flow the collapse-guard error recommends no longer demands a whole-doc
   read: `insert` runs the same per-tab conflict check as `write --tab`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `gdoc` are documented here. This project follows
 
 ## [0.22.0] — 2026-08-28
 
+
 ### Added
 - **Document URLs honor their `?tab=` deep link.** Google's editor appends
   `?tab=<id>` when you open a tab, so a pasted tab URL now acts exactly like
@@ -14,6 +15,7 @@ All notable changes to `gdoc` are documented here. This project follows
   command, wired in via this release's merge) — previously the tab was silently dropped
   and the command operated on the first tab (or whole doc). An explicit
   `--tab`/`--all-tabs` still overrides the URL.
+
 
 ### Fixed
 - **Per-tab write-conflict baselines.** The write guard now tracks a read
@@ -57,6 +59,7 @@ All notable changes to `gdoc` are documented here. This project follows
   the same rule as `cat --tab X`: on a multi-tab doc it stamps only that
   tab's baseline, not the whole-doc one.
 
+
 ### Changed
 - State files gain a `tab_read_versions` map and a
   `global_read_covers_doc` provenance marker. Older state files load
@@ -81,6 +84,7 @@ All notable changes to `gdoc` are documented here. This project follows
 - **`gdoc insert` no longer requires `--tab`** when the document URL already
   carries a `?tab=`.
 
+
 ### Notes
 - Combining a URL tab with a whole-document flag errors (exit 3) and names the
   URL as the source: `cat --comments`/`--revision`,
@@ -96,6 +100,7 @@ All notable changes to `gdoc` are documented here. This project follows
   error now points this out).
 - Spreadsheet `#gid=` deep links are still unparsed — select a worksheet with
   `--tab`/`--range`.
+
 
 ### Docs
 - Corrected the README Tabs section: the Drive export returns **all** tabs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,102 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] — 2026-08-28
+
+### Added
+- **Document URLs honor their `?tab=` deep link.** Google's editor appends
+  `?tab=<id>` when you open a tab, so a pasted tab URL now acts exactly like
+  `--tab <id>` for `cat`, `edit` (incl. `--cell`), `write`, `insert`, `toc`,
+  `structure`, `insert-image`, and `suggest` (0.21.0's suggested-edit
+  command, wired in via this release's merge) — previously the tab was silently dropped
+  and the command operated on the first tab (or whole doc). An explicit
+  `--tab`/`--all-tabs` still overrides the URL.
+
+### Fixed
+- **Per-tab write-conflict baselines.** The write guard now tracks a read
+  baseline *per tab*, not just per document — a follow-up to the `?tab=` URL
+  support above. Two defects on multi-tab docs are fixed:
+  - **Cross-tab false negative.** `write --tab B` after only `cat --tab A`
+    used to be satisfied by A's read and would replace tab B unseen. It now
+    errors `no read baseline for tab 'B'` until you read B (or the whole
+    doc). `info` still advances the whole-doc guard's baseline (status
+    quo) but never authorizes tab-scoped writes — it shows no content,
+    and an `info` that moves the baseline also voids any earlier read's
+    content provenance for the tab guard.
+  - **Same-tab false positive.** `write --tab X` twice in a row used to
+    conflict on the second write (the first write bumped the doc version but
+    the tab-scoped write left the baseline behind). A tab write now advances
+    that tab's own baseline, so repeated edits to one tab just work.
+- **`insert --tab X` accepts a `cat --tab X` baseline.** The tab-populate
+  flow the collapse-guard error recommends no longer demands a whole-doc
+  read: `insert` runs the same per-tab conflict check as `write --tab`.
+- **`structure --fields` no longer counts as a read.** A masked response
+  may omit tab ids, sibling tabs, or the content itself, so it can't prove
+  the document (or a tab) was actually seen; it now records the
+  interaction without advancing any read baseline.
+- **Metadata-only version bumps heal per-tab baselines.** `mv`/`rename`
+  used to leave `tab_read_versions` behind their own version bump, so the
+  next `write --tab` false-conflicted. Entries current at pre-flight are
+  now carried forward under the same attributability guard as the global
+  baseline.
+- **Replacing a document's only tab counts as a whole-doc write** (the
+  single-tab rule `cat --tab` already follows), so a following
+  whole-document `write`/`push` doesn't conflict with the CLI's own edit.
+- **Blank `--tab` values are rejected** (exit 3) instead of silently
+  reading as "no tab" and mutating the default target.
+
+  A plain `cat`/`pull` still covers every tab (its Drive export is the whole
+  document), so the common read-then-write flow is unchanged. On a single-tab
+  document a `cat --tab X` reads the whole document too, so a following
+  whole-document `write`/`push` is not blocked. An edit to a *different* tab
+  still trips the check — Google's version number is per-document — which is
+  conservative by design; `--force` overrides. `structure --tab X` follows
+  the same rule as `cat --tab X`: on a multi-tab doc it stamps only that
+  tab's baseline, not the whole-doc one.
+
+### Changed
+- State files gain a `tab_read_versions` map and a
+  `global_read_covers_doc` provenance marker. Older state files load
+  unchanged, but their **whole-doc read baseline is not trusted for
+  tab-scoped writes** — a pre-0.22 `cat --tab A` stored its version in the
+  global baseline, which would wrongly authorize `write --tab B`. The
+  first `write --tab` after upgrading may therefore ask for a fresh
+  `gdoc cat`. Downgrading is safe but lossy in the same direction: a
+  pre-0.22 binary rewriting state drops both new fields, so re-upgrading
+  fail-closes (re-read before the next tab write) rather than risking an
+  overwrite.
+- **Multi-tab `cat --tab X` / `structure --tab X` no longer establish a
+  whole-doc baseline.** A scripted `cat --tab X` followed by
+  `write`/`push --force-collapse-tabs` now errors `no read baseline`
+  where it previously succeeded — reading one tab shouldn't authorize
+  flattening the others. Read the whole doc (plain `cat`) first.
+- **`?tab=t.0` is treated as no tab.** The editor auto-appends `t.0` for the
+  first tab, so it's ambient UI noise; honoring it would push the common
+  pasted-URL case onto the lower-fidelity Docs-API renderer. It now stays on
+  the high-fidelity Drive export path. Escape hatch: pass `--tab t.0`
+  explicitly to force the literal first-tab read.
+- **`gdoc insert` no longer requires `--tab`** when the document URL already
+  carries a `?tab=`.
+
+### Notes
+- Combining a URL tab with a whole-document flag errors (exit 3) and names the
+  URL as the source: `cat --comments`/`--revision`,
+  `write --force-collapse-tabs`.
+- `pull`/`push`/`export`/`diff`/`comments`/`images` ignore a URL tab (they
+  cover the whole document) but print a one-line stderr `NOTE:` when
+  discarding a non-`t.0` tab (suppressed under `--quiet`).
+- **`t.0` caveat:** tab ids are assigned at creation and survive
+  reordering, so after tabs are dragged around, id `t.0` may no longer be
+  the first-*positioned* tab — yet the editor still emits `?tab=t.0` when
+  viewing it, and the ambient-noise rule still drops it. If you mean that
+  tab specifically, pass `--tab t.0` explicitly (the multi-tab collapse
+  error now points this out).
+- Spreadsheet `#gid=` deep links are still unparsed — select a worksheet with
+  `--tab`/`--range`.
+
+### Docs
+- Corrected the README Tabs section: the Drive export returns **all** tabs
+  (each under a `# **Tab title**` heading), not just the first.
 ## [0.21.0] — 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ gdoc write DOC draft.md    # OK written
 
 Use `--force` to skip conflict detection. Use `--quiet` to skip pre-flight checks entirely (saves 2 API calls).
 
+**Tabs get their own baseline.** For a tab-scoped write (`write --tab X`, or a pasted `?tab=` URL), the baseline is tracked per tab: `gdoc cat --tab X` establishes a baseline for tab X alone, while a whole-document `gdoc cat DOC` covers every tab (the Drive export is the full document). On a single-tab document, reading the one tab covers the whole document, so a following whole-document write isn't blocked. So reading tab A does **not** let you overwrite tab B unseen — `write --tab B` then errors `no read baseline for tab 'B'` — and writing the same tab twice in a row won't false-conflict against your own edit. Because Google's version number is per-document, an edit to *another* tab still trips the check for tab X (conservative by design); `--force` overrides.
+
 ## Spreadsheets
 
 `cat`, `tabs`, and `info` detect Google Sheets automatically — point them at a
@@ -470,7 +472,7 @@ HTML output has no extra dependencies. Richer artifacts (docx, PDF, …) are del
 
 ## Tabs
 
-Google Docs supports multiple tabs per document. The default `cat` command uses Drive export which only returns the first tab. Use `--tab` or `--all-tabs` to read tab content via the Docs API:
+Google Docs supports multiple tabs per document. The default `cat` (Drive export) returns the **whole document** — every tab, each introduced by a `# **Tab title**` heading — as one markdown stream. Use `--tab` to isolate a single tab or `--all-tabs` for every tab with `=== Tab: … ===` separators, read via the Docs API:
 
 ```bash
 # List tabs in a document
@@ -490,6 +492,21 @@ gdoc cat --all-tabs DOC
 ```
 
 `--tab` and `--all-tabs` are mutually exclusive with `--comments`. They work with `--json` and `--plain`.
+
+### Tabs in the URL
+
+Google's editor deep-links to a tab with a `?tab=<id>` query param (e.g. `.../edit?tab=t.abc123`). `gdoc` honors it: a pasted tab URL acts exactly as if you'd passed `--tab <id>`, so `cat`, `edit`, `write`, `insert`, `toc`, `structure`, `insert-image`, and `suggest` all operate on that tab.
+
+```bash
+# Reads the "Notes" tab — same as `gdoc cat --tab t.abc123 DOC`
+gdoc cat 'https://docs.google.com/document/d/DOC/edit?tab=t.abc123'
+```
+
+One special case: the editor auto-appends `?tab=t.0` to the address bar for the **first** tab, so it's ambient UI noise rather than an intentional selection. `gdoc` therefore treats `?tab=t.0` as if no tab were given — the common pasted URL stays on the high-fidelity Drive export path. To force the Docs-API read of the literal first tab, pass `--tab t.0` explicitly. Caveat: tab ids are assigned at creation and survive reordering, so after tabs are dragged around, `t.0` may no longer be the first-positioned tab — the rule still drops it, so pass `--tab t.0` when you mean that tab specifically.
+
+Precedence: an explicit `--tab` (or `cat --all-tabs`) always overrides the URL. Combining a URL tab with a whole-document flag is an error (`cat --comments`/`--revision`, `write --force-collapse-tabs`) — the message names the URL so you know to drop `?tab=`. Whole-document commands that can't target a tab (`pull`, `push`, `export`, `diff`, `comments`, `images`) ignore a URL tab but print a one-line `NOTE:` to stderr when they do (silent for `t.0`, and under `--quiet`).
+
+> **Spreadsheets:** Sheets deep-links use `#gid=<n>`, which `gdoc` does not yet parse — select a worksheet with `--tab`/`--range` instead.
 
 ## Byte truncation
 

--- a/docs/per-tab-read-baselines-plan.md
+++ b/docs/per-tab-read-baselines-plan.md
@@ -1,8 +1,8 @@
 # Per-tab read baselines for write-conflict detection
 
-Status: **shipped in 0.20.0** (planned 2026-07-04/05 as 0.14.0, JP + Claude; renumbered
-after merging main, which had reused 0.13-0.19). Builds on the URL `?tab=` support in
-the same release. Kept as a design record — see CHANGELOG 0.20.0 for what shipped.
+Status: **shipped in 0.22.0** (planned 2026-07-04/05 as 0.14.0, JP + Claude; renumbered
+after merging main, which had reused 0.13-0.21). Builds on the URL `?tab=` support in
+the same release. Kept as a design record — see CHANGELOG 0.22.0 for what shipped.
 
 > **Premise correction (2026-07-05, verified live):** the Drive markdown export includes
 > **all tabs**, not just the first — confirmed empirically against a real 7-tab doc (unique
@@ -135,7 +135,7 @@ anything — same as today's quiet behavior for `last_read_version`.
 
 4. **Docs**: README "Working with tabs" — fix the stale "export only returns the first
    tab" claim, and add a short "Conflict detection and tabs" paragraph (per-tab baselines,
-   the lenient rule, the `--force` escape, the sibling-edit caveat). CHANGELOG 0.20.0.
+   the lenient rule, the `--force` escape, the sibling-edit caveat). CHANGELOG 0.22.0.
    Bump version; sync `uv.lock`.
 
 ## Tests

--- a/docs/per-tab-read-baselines-plan.md
+++ b/docs/per-tab-read-baselines-plan.md
@@ -1,0 +1,169 @@
+# Per-tab read baselines for write-conflict detection
+
+Status: **shipped in 0.20.0** (planned 2026-07-04/05 as 0.14.0, JP + Claude; renumbered
+after merging main, which had reused 0.13-0.19). Builds on the URL `?tab=` support in
+the same release. Kept as a design record — see CHANGELOG 0.20.0 for what shipped.
+
+> **Premise correction (2026-07-05, verified live):** the Drive markdown export includes
+> **all tabs**, not just the first — confirmed empirically against a real 7-tab doc (unique
+> tokens from every tab present in the export; tab titles inserted as headings). README's
+> "Drive export only returns the first tab" (Working-with-tabs section) is stale and needs
+> fixing separately. This changed the check rule below from *strict* to *lenient*:
+> plain `cat`/`pull` are genuine full-document reads, so the global baseline they advance
+> legitimately covers every tab.
+
+## Problem
+
+The write-conflict guard tracks one `last_read_version` per **document**, but tab-scoped
+reads and writes are per-**tab**. On multi-tab docs this produces both false negatives and
+false positives:
+
+1. **False negative — replace a tab you've never seen.** `write --tab B` checks the
+   doc-global baseline, which is satisfied by any prior read — including `cat --tab A` or
+   a pasted `?tab=A` URL, which showed you nothing of tab B. "Read tab A → `write --tab B`"
+   replaces all of tab B with no warning. Pre-existing; PR #4 widened the on-ramp (pasted
+   URLs now route into tab reads).
+
+2. **False positive — can't write the same tab twice.** `cat --tab X` (baseline → v100) →
+   `write --tab X` (doc → v101; tab writes deliberately don't advance the baseline,
+   state.py) → second `write --tab X` → "doc changed since last read", exit 3. The agent's
+   own write strands it; the workaround is re-`cat` or `--force`, and habituating agents to
+   `--force` defeats the guard.
+
+3. **R2 from PR #4's review** — a tab-scoped `cat` advances the whole-doc baseline. Less
+   severe than first assessed: whole-doc `write`/`push` on multi-tab docs are already
+   blocked by the collapse guard (`count_document_tabs > 1` → exit 3) unless
+   `--force-collapse-tabs`, so the baseline was never the last line of defense for sibling
+   tabs. Fixing 1–2 fixes R2 as a byproduct.
+
+A naive R2 fix (tab reads stop advancing the baseline) is **not** viable: it would break
+the core tab workflow (`cat --tab X` → `write --tab X` would hit "no read baseline").
+Per-tab state is the minimal correct fix.
+
+## Spec
+
+### State schema (`gdoc/state.py`)
+
+```python
+@dataclass
+class DocState:
+    ...
+    tab_read_versions: dict[str, int] = field(default_factory=dict)
+    # tab_id -> doc version at last read of that tab's full content
+```
+
+- Keys are **resolved tab IDs** (`resolve_tab(...)["id"]`), never user-typed titles, so
+  `--tab "Notes"` and `?tab=t.abc` share an entry and renames don't fragment state.
+- Values are the doc-global Drive `version` (already int-coerced at the API boundary,
+  `api/drive.py`), so int comparison is safe.
+- Compat: old state files load with an empty dict (`default_factory`); old gdoc versions
+  ignore the new key (`load_state` filters to known fields). No migration step.
+
+### Who advances what
+
+| Action | `last_read_version` | `tab_read_versions` |
+|---|---|---|
+| `cat` (plain, Drive export — includes ALL tabs) / `pull` | advance (correct: full read) | — |
+| `cat --tab X` / `cat '<url>?tab=X'` | **no longer advanced** | `[X] = current` |
+| `cat --all-tabs` | advance | — (subsumed by global under the lenient rule) |
+| `cat --revision`, `pull --revision`, `toc`, `info` | unchanged (status quo) | — |
+| `write` / `push` (full doc, success) | `= post-write version` (status quo) | — |
+| `write --tab X` (success, full-tab replace) | — | `[X] = post-write version` |
+| `insert --tab X` | — | — (append ≠ read; the rest of the tab is unseen) |
+| `edit` (whole doc or `--tab`) | unchanged | — |
+
+Quiet reads (`--quiet`) skip pre-flight and have no version in hand; they don't stamp
+anything — same as today's quiet behavior for `last_read_version`.
+
+### Conflict check rules
+
+- **Whole-doc `write`/`push`:** unchanged — check `last_read_version` (plus the existing
+  `_doc_matches` in-sync rescue and the collapse guard).
+- **`write --tab X`:** check the **effective tab baseline** (lenient rule):
+  - Resolve X → `tab_id` first. Effective baseline =
+    `max(last_read_version, tab_read_versions.get(tab_id))` (None-aware; versions are
+    monotonic ints).
+  - The global component is legitimate because plain `cat`/`pull` genuinely read every
+    tab (see premise correction). The false-negative fix comes from tab reads no longer
+    advancing the global baseline: after `cat --tab A`, tab B has no baseline at all.
+  - No effective baseline → exit 3: `no read baseline for tab 'X'. Run 'gdoc cat --tab X'
+    (or 'gdoc cat DOC' for the whole doc) first, or use --force to overwrite.`
+  - Baseline set but `current_version != baseline` → exit 3: `tab 'X' may have changed
+    since last read (doc moved v{base} -> v{cur}). Run 'gdoc cat --tab X' first, or use
+    --force to overwrite.` ("may" is honest — the version is doc-global; see Limits.)
+  - `--force` bypasses, as today.
+
+### Known limits (shipped as-is)
+
+- **Sibling-edit false positives remain.** Drive versions are doc-global, so an edit to
+  tab B still conflicts a `write --tab X` whose baseline predates it. Same conservatism as
+  today — no regression, and the post-write self-advancement removes the most common case
+  (our own sequential writes). If real-world friction shows up, layer 2 is a per-tab
+  content hash stamped at read time and re-checked (one extra Docs fetch) only on the
+  conflict path. Deferred deliberately.
+- **`edit`/`insert` strand baselines.** Any version-bumping mutation that isn't a full-tab
+  replace leaves other baselines behind; the next tab write may false-conflict. Same class
+  of conservatism as today (`edit` → `push` already behaves this way, rescued only by
+  `_doc_matches`).
+- **Truncated reads still count.** `cat --max-bytes` advances baselines despite showing a
+  prefix. Pre-existing looseness; out of scope.
+- `writeControl.requiredRevisionId` (already sent by `insert_markdown_into_tab`) continues
+  to guard the fetch→write race at the API level, independent of this state model.
+
+## Implementation
+
+1. **`gdoc/state.py`**
+   - Add the field. Extend `update_state_after_command` with `read_tab_id: str | None`
+     and `written_tab_id: str | None`. When `read_tab_id` is set, the command must NOT be
+     treated as a whole-doc read (`is_read` stays False for it — introduce e.g.
+     `command="cat-tab"` or gate on the param; pick one, don't do both).
+
+2. **`gdoc/cli.py` — read side (`cmd_cat`)**
+   - Tab path (`resolve_tab` already called here): pass `match["id"]` as `read_tab_id`;
+     stop advancing `last_read_version` for this path.
+   - `--all-tabs` path: unchanged (whole-doc semantics; global baseline covers all tabs).
+
+3. **`gdoc/cli.py` — write side (`cmd_write` tab branch)**
+   - Resolve before checking: fetch the doc once (`get_document_with_tabs`), `resolve_tab`
+     in the CLI, then run the new `_check_tab_write_conflict(doc_id, tab_id, tab_label,
+     quiet, force)` (both quiet and pre-flight branches, mirroring
+     `_check_write_conflict`; banner/pre-flight still runs first).
+   - Extend `insert_markdown_into_tab` to accept an optional pre-fetched `doc` dict so the
+     resolution fetch isn't duplicated (today it fetches internally; keep that as the
+     default for other callers).
+   - On success: `update_state_after_command(..., written_tab_id=tab_id)`.
+
+4. **Docs**: README "Working with tabs" — fix the stale "export only returns the first
+   tab" claim, and add a short "Conflict detection and tabs" paragraph (per-tab baselines,
+   the lenient rule, the `--force` escape, the sibling-edit caveat). CHANGELOG 0.20.0.
+   Bump version; sync `uv.lock`.
+
+## Tests
+
+Mock at the `gdoc.api` boundary per suite convention.
+
+- `test_state.py` (or new `test_state_tabs.py`): tab read stamps `tab_read_versions` and
+  leaves `last_read_version` alone; tab write advances its own entry; old-format state
+  file loads with empty dict.
+- `test_write.py`:
+  - `cat --tab A` only → `write --tab B` → exit 3 "no read baseline for tab 'B'" (false-negative fix).
+  - plain `cat` → `write --tab B` → succeeds (lenient rule: export is a full read).
+  - `cat --tab X` → `write --tab X` → `write --tab X` again → **both succeed** (false-positive fix).
+  - sibling version bump between tab read and tab write → exit 3 with the "may have changed" message; `--force` bypasses.
+  - `--quiet` variants of the above (state-file-driven branch).
+  - URL-tab variants (`write '<url>?tab=X'`) behave identically to `--tab`.
+- `test_cat_tabs.py`: tab read no longer advances `last_read_version` (regression lock for R2).
+- Whole-doc `write`/`push` tests unchanged — assert no behavioral drift (existing suite covers).
+
+## Verification
+
+1. `uv run pytest tests/ -q` and `uv run ruff check gdoc/ tests/`.
+2. Live smoke on a scratch 2-tab doc: cat tab B → write tab B twice (both succeed);
+   write tab A without reading anything (exit 3); plain cat then write tab A (succeeds —
+   lenient); `--force` path.
+
+## Related follow-ups surfaced by the 2026-07-05 live verification (separate work)
+
+Designs for tab-scoped `comments`, the `images`/`toc` first-tab-only bug fixes, `diff`
+export-slicing, and the stale README export claim live in
+`docs/tab-scoped-commands-plan.md`.

--- a/docs/per-tab-read-baselines-plan.md
+++ b/docs/per-tab-read-baselines-plan.md
@@ -64,7 +64,7 @@ class DocState:
 | Action | `last_read_version` | `tab_read_versions` |
 |---|---|---|
 | `cat` (plain, Drive export — includes ALL tabs) / `pull` | advance (correct: full read) | — |
-| `cat --tab X` / `cat '<url>?tab=X'` | **no longer advanced** | `[X] = current` |
+| `cat --tab X` / `cat '<url>?tab=X'` | **no longer advanced** — except on a single-tab doc, where the one tab IS the whole doc (advance) | `[X] = current` |
 | `cat --all-tabs` | advance | — (subsumed by global under the lenient rule) |
 | `cat --revision`, `pull --revision`, `toc`, `info` | unchanged (status quo) | — |
 | `write` / `push` (full doc, success) | `= post-write version` (status quo) | — |
@@ -120,7 +120,11 @@ anything — same as today's quiet behavior for `last_read_version`.
 
 2. **`gdoc/cli.py` — read side (`cmd_cat`)**
    - Tab path (`resolve_tab` already called here): pass `match["id"]` as `read_tab_id`;
-     stop advancing `last_read_version` for this path.
+     stop advancing `last_read_version` for this path. **Exception:** when the doc has
+     exactly one tab, reading that tab is a whole-doc read — take the normal whole-doc
+     path (advance `last_read_version`) instead, or a subsequent whole-doc write
+     false-conflicts against a read that did cover everything. `write --tab X` applies
+     the mirror-image rule (`full_doc_write=(len(all_tabs) == 1)`).
    - `--all-tabs` path: unchanged (whole-doc semantics; global baseline covers all tabs).
 
 3. **`gdoc/cli.py` — write side (`cmd_write` tab branch)**

--- a/docs/tab-scoped-commands-plan.md
+++ b/docs/tab-scoped-commands-plan.md
@@ -1,8 +1,8 @@
 # Tab-scoped commands: `comments`, `images`, `toc`, `diff`
 
 Status: **PROPOSAL — none of this is implemented.** (Discussed 2026-07-04/05,
-JP + Claude. "PR #4" below = the `?tab=` URL support that shipped in 0.20.0;
-as of 0.20.0, `diff`/`comments`/`images` print a discard NOTE.) Companion to
+JP + Claude. "PR #4" below = the `?tab=` URL support that shipped in 0.22.0;
+as of 0.22.0, `diff`/`comments`/`images` print a discard NOTE.) Companion to
 `per-tab-read-baselines-plan.md`; follows PR #4 (URL `?tab=` support). This is the "R3"
 workstream: the commands PR #4 left silently discarding `?tab=`, now given real tab
 behavior instead of a discard NOTE.
@@ -82,7 +82,7 @@ uniqueness).
   and `matched_tabs: [...]`; top-level `omitted_other_tabs: N`.
 - **Terse output sketch:**
 
-  ```
+  ```text
   # tab: Budget (t.abc123)
   #AAABxyz [open] someone@example.com 2026-06-30
     "Can we cut this?"

--- a/docs/tab-scoped-commands-plan.md
+++ b/docs/tab-scoped-commands-plan.md
@@ -13,8 +13,8 @@ All designs below were validated live on 2026-07-05 against a real 7-tab work do
 comments (read-only probes). Key findings, which several designs depend on:
 
 - **The Drive markdown export includes ALL tabs**, each preceded by a `# **{tab title}**`
-  heading line, in Docs-API tab order. (README's "export only returns the first tab" is
-  stale — fix it as part of this work.)
+  heading line, in Docs-API tab order. (README's "export only returns the first tab" was
+  stale; corrected in 0.22.0, so this is no longer a follow-up for this workstream.)
 - **`get_tab_text` emits plain text**, not markdown (0 bold/link/heading markers on a doc
   full of them). Per-tab *markdown* only exists inside the whole-doc export.
 - **`gdoc images` returns wrong answers today**: `list_inline_objects` uses
@@ -142,7 +142,12 @@ Resolve X → current title via the Docs API tab list. Scan the export **in tab 
 find each tab's `# **{title}**` heading line sequentially (each search starting after the
 previous boundary); tab X's slice runs from its heading to the next tab's heading (or
 EOF). Ordered scanning is what contains the main threat — a user-authored heading
-identical to a *later* tab's title.
+identical to a *later* tab's title. It does not *eliminate* it: a `# **B**` a user wrote
+inside tab A is found before the real tab-B heading and truncates A's slice early, in
+order, so the out-of-order check below can't see it. On the current side the oracle
+catches this; on a revision there is no oracle, which is the residual risk the rejection
+rules must be sized against — treat any tab whose slice comes back shorter than its
+neighbours' heading spacing suggests as ambiguous, and refuse.
 
 ### Failure semantics — the opposite of comments: fail LOUD, never open
 
@@ -188,5 +193,5 @@ mismatch); mode wiring tests for FILE / `--rev` / `--since`; `?tab=t.0` stays wh
 2. `comments` bucketing (validated, pure-function core),
 3. `diff` slicing (heuristic, loud-fail, benefits from the others' tab plumbing).
 
-Each is independently shippable; README's stale export claim gets fixed with whichever
-lands first.
+Each is independently shippable. (README's stale export claim was the one cross-cutting
+follow-up here; it was corrected in 0.22.0 and needs no further work.)

--- a/docs/tab-scoped-commands-plan.md
+++ b/docs/tab-scoped-commands-plan.md
@@ -1,0 +1,192 @@
+# Tab-scoped commands: `comments`, `images`, `toc`, `diff`
+
+Status: **PROPOSAL — none of this is implemented.** (Discussed 2026-07-04/05,
+JP + Claude. "PR #4" below = the `?tab=` URL support that shipped in 0.20.0;
+as of 0.20.0, `diff`/`comments`/`images` print a discard NOTE.) Companion to
+`per-tab-read-baselines-plan.md`; follows PR #4 (URL `?tab=` support). This is the "R3"
+workstream: the commands PR #4 left silently discarding `?tab=`, now given real tab
+behavior instead of a discard NOTE.
+
+## Evidence base
+
+All designs below were validated live on 2026-07-05 against a real 7-tab work doc with 33
+comments (read-only probes). Key findings, which several designs depend on:
+
+- **The Drive markdown export includes ALL tabs**, each preceded by a `# **{tab title}**`
+  heading line, in Docs-API tab order. (README's "export only returns the first tab" is
+  stale — fix it as part of this work.)
+- **`get_tab_text` emits plain text**, not markdown (0 bold/link/heading markers on a doc
+  full of them). Per-tab *markdown* only exists inside the whole-doc export.
+- **`gdoc images` returns wrong answers today**: `list_inline_objects` uses
+  `get_document` (no `includeTabsContent`), which returns only the first tab's body.
+  Verified: 0 objects reported on a doc with 2 (in a later tab). `toc`'s whole-doc path
+  has the same mechanism (`get_document_headings` → `get_document`, docs.py:744).
+- **Comment-anchor bucketing distribution** (33 real comments vs 7 tabs, exact raw
+  matching): 42% matched exactly one tab (all spot-checked correct), 24% matched multiple
+  tabs, 21% anchors under 4 chars, 12% stale (text edited/deleted). The multi-tab matches
+  were systematic — draft tabs duplicating the canonical tab — so ambiguity is a routine
+  case, not an edge case. A normalization layer (typography fold + whitespace collapse)
+  changed **nothing**: quote and tab text share a representation. Table cells are fully
+  present in `get_tab_text` (163/163).
+
+## Shared conventions (from PR #4)
+
+- URL `?tab=` acts as `--tab`; explicit flags win; `?tab=t.0` is ambient noise (= no tab).
+- Whole-doc behavior stays the default; a tab only ever *restricts*.
+- Tab identity: resolve via `resolve_tab` (title-first-then-ID); operate on resolved IDs.
+- These commands honoring the tab **supersedes** the discard-NOTE idea for them.
+
+---
+
+## 1. `comments` — tab-scoped listing via anchor-text bucketing
+
+Comments come from the Drive API, which is file-generic and carries **no tab
+information**. The only positional breadcrumb is `quotedFileContent` — a plain-text
+snapshot of the anchored passage at comment-creation time. Tab scoping is therefore a
+heuristic: match each quote against each tab's `get_tab_text`.
+
+### Core principle: partition, never filter
+
+A filter ("show comments matching tab X") silently drops everything unmatchable — and
+anchors go stale precisely when the doc is being actively edited, i.e. exactly when
+comments are being triaged. Instead, every comment lands in one epistemic bucket, and a
+tab-scoped view omits **only comments positively matched to a different tab**. Uncertainty
+fails open: shown, labeled.
+
+Buckets, relative to requested tab X:
+
+1. **Quote found only in tab X** → show, anchored.
+2. **Quote found in X and other tabs** → show, tagged `[also matches: <titles>]`.
+   (Routine, not rare — 24% in the live data, driven by draft-tab duplication.)
+3. **Quote found only in other tab(s)** → omit; count in a footer:
+   `(N comments on other tabs not shown; use 'gdoc comments DOC' for all)`.
+4. **Unplaceable** — no quote, quote < 4 chars, or quote found in no tab → show under
+   `[UNPLACED — may be on any tab]` with the reason, reusing annotate.py's note vocabulary
+   (`anchor too short`, `anchor deleted`). 33% of the live data; the footer/labels keep
+   "tab X has N comments" from ever being silently wrong.
+
+Matching is **raw substring** (`quote in tab_text`) with the <4-char guard. No
+normalization layer — verified unnecessary (plain-vs-plain text already agrees on smart
+quotes, NBSP, emoji). Within-tab multiplicity is irrelevant: a quote appearing 3× inside
+tab X is still unambiguously X's (unlike annotate.py's line-pinning, which needs
+uniqueness).
+
+### Shape
+
+- **Engine:** pure function `bucket_comments_by_tab(tabs, comments)` in a new module (or
+  alongside annotate.py) — no API calls inside; unit-testable with fixture dicts.
+- **CLI:** `gdoc comments '<url>?tab=X'` and `gdoc comments DOC --tab X`. No tab → today's
+  whole-doc listing, byte-identical (no extra API call). With a tab → one extra Docs API
+  fetch for tab texts.
+- **JSON:** each included comment gains `placement: "matched" | "multi_tab" | "unplaced"`
+  and `matched_tabs: [...]`; top-level `omitted_other_tabs: N`.
+- **Terse output sketch:**
+
+  ```
+  # tab: Budget (t.abc123)
+  #AAABxyz [open] someone@example.com 2026-06-30
+    "Can we cut this?"
+    on "Our approach to..."
+  #AAABdef [open] other@example.com 2026-07-01 [also matches: Drafts]
+    ...
+        [UNPLACED — may be on any tab]
+  #AAABghi [open] ... [anchor deleted]
+    ...
+  (5 comments on other tabs not shown)
+  ```
+
+### Tests
+
+Pure-function tests for all four buckets, the <4-char guard, within-tab multiplicity
+(still bucket 1), multi-tab quotes, no-quote comments; CLI tests for URL-tab and `--tab`
+paths, footer counts, JSON placement fields, `--all` orthogonality, and the no-tab path
+being unchanged.
+
+~250 LOC incl. tests; ~half a day.
+
+---
+
+## 2. `images` (and `toc`'s whole-doc default) — mechanical fix + scoping
+
+No heuristics needed: objects and headings are structurally located per tab.
+
+- **Bug fix (default, whole doc):** `list_inline_objects` walks **all tabs**; each result
+  row gains the containing tab (id + title). `get_document_headings`'s whole-doc path
+  likewise walks all tabs (group headings by tab in `toc` output). This changes existing
+  output on multi-tab docs — that's the point; today's output is wrong (missing content).
+- **Scoping (feature):** `images '<url>?tab=X'` / `--tab X` walks only tab X's body.
+  `toc`'s `--tab`/URL path already works (PR #4).
+- **Plumbing:** `get_document_tabs`/`flatten_tabs` currently keep only id/title/body per
+  tab; retain the per-tab `inlineObjects`/`positionedObjects` maps (the
+  `includeTabsContent=true` response provides them per `documentTab`).
+
+Tests: multi-tab fixture with objects in a non-first tab (the live bug); per-tab
+filtering; positioned + inline objects; toc grouping. ~Half a day for both commands.
+
+---
+
+## 3. `diff` — tab scoping by slicing exports at tab-title headings
+
+Historical content only exists as whole-doc revision exports (there is **no** per-tab
+revision API), so the only route to tab-scoped revision diffs is slicing the export. The
+same mechanism serves all three modes, and beats `get_tab_text` for the current side too
+(markdown vs. markdown against pulled files, instead of plain text vs. markdown):
+
+- `diff '<url>?tab=X' FILE` → slice the current export; diff tab X's slice vs. FILE.
+- `diff '<url>?tab=X' --rev A..B` (and `--since`) → slice both revision exports; diff the
+  two X-slices.
+
+### Slicing algorithm
+
+Resolve X → current title via the Docs API tab list. Scan the export **in tab order**:
+find each tab's `# **{title}**` heading line sequentially (each search starting after the
+previous boundary); tab X's slice runs from its heading to the next tab's heading (or
+EOF). Ordered scanning is what contains the main threat — a user-authored heading
+identical to a *later* tab's title.
+
+### Failure semantics — the opposite of comments: fail LOUD, never open
+
+A comments listing that includes too much is safe; a diff computed on the wrong slice is a
+silent wrong answer. Exit 3 (never a fallback diff) when:
+
+- two tabs share a title ("tab title ambiguous; rename or diff the whole doc");
+- a tab's heading isn't found in a revision export (tab renamed since, or didn't exist at
+  that revision — name the revision in the error);
+- boundaries come back out of order / overlapping;
+- **oracle check fails** (current doc only): normalized slice text should roughly agree
+  with normalized `get_tab_text` — we have both in hand. Mismatch means the slicer
+  misfired (or Google changed the heading format); refuse rather than emit a
+  plausible-looking wrong diff. Revisions have no oracle; the current-side check is the
+  canary for format drift.
+
+Ship revision slicing in v1 (not a "not supported" stub): the boundary format verified
+clean on real data, and loud-fail bounds the worst case at an error message.
+
+Tests: slicer unit tests (fixture exports: clean case, duplicate-title error, missing-tab
+error, user heading colliding with a later tab title, out-of-order detection, oracle
+mismatch); mode wiring tests for FILE / `--rev` / `--since`; `?tab=t.0` stays whole-doc.
+~A day incl. tests.
+
+---
+
+## Future unlocks (file, don't build)
+
+- **High-fidelity `cat --tab`:** the same slicer would give per-tab *markdown* (links,
+  bold, tables) instead of `get_tab_text`'s plain-text subset — the exact limitation
+  PR #4's `t.0` rationale worked around. Natural sequel once the slicer proves itself in
+  `diff`.
+- **`cat --comments --tab X`:** annotate tab content with bucket-1/2 comments (turns
+  PR #4's `cat --comments <tab-url>` error into real behavior). Second customer for
+  `bucket_comments_by_tab`.
+- **Heuristic upgrade for annotate.py:** whole-doc `cat --comments` could use tab
+  bucketing to shrink its `anchor ambiguous` pile (9/33 in live data) by resolving
+  cross-tab duplicates to per-tab line matches.
+
+## Sequencing within this workstream
+
+1. `images`/`toc` fixes (mechanical, wrong answers today, no design risk),
+2. `comments` bucketing (validated, pure-function core),
+3. `diff` slicing (heuristic, loud-fail, benefits from the others' tab plumbing).
+
+Each is independently shippable; README's stale export claim gets fixed with whichever
+lands first.

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/gdoc/api/docs.py
+++ b/gdoc/api/docs.py
@@ -1414,6 +1414,7 @@ def insert_markdown_into_tab(
     markdown: str,
     position: str = "start",
     replace: bool = False,
+    doc: dict | None = None,
 ) -> dict:
     """Insert (or replace) markdown content in a tab via Docs API.
 
@@ -1428,13 +1429,19 @@ def insert_markdown_into_tab(
         position: "start" or "end". Ignored when replace=True.
         replace: If True, delete the tab body first then insert at the
             body start.
+        doc: Optional pre-fetched get_document_with_tabs() response. When a
+            caller (e.g. `write --tab`) already fetched the doc to resolve the
+            tab for its conflict check, pass it here to avoid a second fetch.
+            Its revisionId still pins writeControl, so a concurrent edit
+            between the fetch and this write is still rejected.
 
     Returns:
         Dict with "tab_id", "tab_title", "insert_index".
     """
     from gdoc.mdparse import parse_markdown, to_docs_requests, utf16_len
 
-    doc = get_document_with_tabs(doc_id)
+    if doc is None:
+        doc = get_document_with_tabs(doc_id)
     revision_id = doc.get("revisionId", "")
     tabs = flatten_tabs(doc.get("tabs", []))
     tab_match = resolve_tab(tabs, tab_name)

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -9,6 +9,12 @@ from gdoc import __version__
 from gdoc.revdiff import DEFAULT_CONTEXT, DEFAULT_MIN_COMMON
 from gdoc.util import SPREADSHEET_MIME, AuthError, GdocError
 
+# Google's editor auto-appends ``?tab=t.0`` (the first tab) to every doc URL,
+# so a URL tab of ``t.0`` is treated as ambient noise, not an intentional
+# selection. This sentinel is the load-bearing heuristic of URL-tab handling;
+# name it once so the call sites can't drift.
+_FIRST_TAB_ID = "t.0"
+
 
 class GdocArgumentParser(argparse.ArgumentParser):
     """Custom parser that exits with code 3 on usage errors (not 2)."""
@@ -33,13 +39,69 @@ def _truncate_bytes(text: str, max_bytes: int) -> str:
 
 def _resolve_doc_id(raw: str) -> str:
     """Extract doc ID, wrapping ValueError as GdocError(exit_code=3)."""
-    from gdoc.util import extract_doc_id
+    return _resolve_doc_ref(raw)[0]
+
+
+def _resolve_doc_ref(raw: str) -> tuple[str, str | None]:
+    """Extract (doc ID, URL tab ID), wrapping ValueError as GdocError(3)."""
+    from gdoc.util import extract_doc_ref
 
     try:
-        return extract_doc_id(raw)
+        return extract_doc_ref(raw)
     except ValueError as e:
         raise GdocError(str(e), exit_code=3)
 
+
+def _effective_tab(
+    url_tab: str | None,
+    flag_tab: str | None,
+    all_tabs: bool = False,
+) -> tuple[str | None, bool]:
+    """Merge a URL's ?tab= value with an explicit --tab flag.
+
+    Rules:
+    - An explicit --tab flag (or --all-tabs) always wins over the URL.
+    - A URL tab of ``t.0`` is treated as absent — Google's editor
+      auto-appends it, so it is ambient UI noise, not an intentional
+      selection. Escape hatch: pass ``--tab t.0`` explicitly.
+
+    Returns (effective_tab, from_url) where from_url is True when the
+    returned tab originated from the URL (used to tailor error wording).
+    """
+    if flag_tab is not None:
+        # A blank --tab would win precedence here but read as "no tab" at
+        # every truthiness check downstream — a silent wrong-target. Reject.
+        # Return the stripped value: resolve_tab matches titles verbatim,
+        # so stray whitespace would pass this guard then "tab not found".
+        flag_tab = flag_tab.strip()
+        if not flag_tab:
+            raise GdocError(
+                "--tab requires a non-empty tab title or id", exit_code=3,
+            )
+        return flag_tab, False
+    if all_tabs:
+        return None, False
+    if url_tab is not None and url_tab != _FIRST_TAB_ID:
+        return url_tab, True
+    return None, False
+
+
+def _note_discarded_url_tab(
+    url_tab: str | None, command: str, quiet: bool = False
+) -> None:
+    """Print a stderr NOTE when a whole-document command drops a URL's tab.
+
+    Silent for the ambient ``t.0`` (Google auto-appends it), when no tab was
+    present, and under ``--quiet`` (the established switch for suppressing
+    stderr chatter). ``command`` names the operation for the message.
+    """
+    if quiet or not url_tab or url_tab == _FIRST_TAB_ID:
+        return
+    print(
+        f"NOTE: ignoring tab {url_tab!r} from the URL; {command} operates "
+        "on the whole document",
+        file=sys.stderr,
+    )
 
 
 def _file_mime(doc_id: str, change_info) -> str:
@@ -259,16 +321,24 @@ def cmd_revisions(args) -> int:
 
 def cmd_cat(args) -> int:
     """Handler for `gdoc cat`."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
 
     quiet = getattr(args, "quiet", False)
-    tab = getattr(args, "tab", None)
     all_tabs = getattr(args, "all_tabs", False)
+    tab, tab_from_url = _effective_tab(
+        url_tab, getattr(args, "tab", None), all_tabs
+    )
 
     if getattr(args, "comments", False) and getattr(args, "plain", False):
         raise GdocError("--comments and --plain are mutually exclusive", exit_code=3)
 
     if (tab or all_tabs) and getattr(args, "comments", False):
+        if tab_from_url:
+            raise GdocError(
+                f"the URL targets tab {tab!r}, but --comments reads the whole "
+                "document; drop ?tab= from the URL to view comments",
+                exit_code=3,
+            )
         raise GdocError(
             "--tab/--all-tabs and --comments are mutually exclusive",
             exit_code=3,
@@ -279,6 +349,12 @@ def cmd_cat(args) -> int:
 
     revision = getattr(args, "revision", None)
     if revision and (tab or all_tabs or getattr(args, "comments", False)):
+        if tab_from_url:
+            raise GdocError(
+                f"the URL targets tab {tab!r}, but --revision reads the whole "
+                "document; drop ?tab= from the URL to view a revision",
+                exit_code=3,
+            )
         raise GdocError(
             "--revision cannot be combined with "
             "--tab/--all-tabs/--comments",
@@ -327,28 +403,24 @@ def cmd_cat(args) -> int:
         return 0
 
     if tab or all_tabs:
-        from gdoc.api.docs import get_document_tabs, get_tab_text
+        from gdoc.api.docs import get_document_tabs, get_tab_text, resolve_tab
 
         tabs = get_document_tabs(doc_id)
+        read_tab_id = None
 
         # Default view renders markdown (headings survive round-trips);
         # --plain returns the verbatim text gdoc edit matches against.
         want_md = not getattr(args, "plain", False)
 
         if tab:
-            # Match by title (case-insensitive) first, then by ID
-            match = None
-            for t in tabs:
-                if t["title"].lower() == tab.lower():
-                    match = t
-                    break
-            if match is None:
-                for t in tabs:
-                    if t["id"] == tab:
-                        match = t
-                        break
-            if match is None:
-                raise GdocError(f"tab not found: {tab}", exit_code=3)
+            match = resolve_tab(tabs, tab)
+            # On a multi-tab doc a `--tab` read covers only that tab, so it
+            # stamps just that tab's baseline. On a single-tab doc the one tab
+            # IS the whole document, so the read advances the whole-doc
+            # baseline (read_tab_id stays None) — otherwise a following
+            # whole-doc write/push would be spuriously blocked for no baseline.
+            if len(tabs) > 1:
+                read_tab_id = match["id"]
             content = get_tab_text(match, markdown=want_md)
             if no_images:
                 from gdoc.mdimport import strip_images
@@ -380,8 +452,13 @@ def cmd_cat(args) -> int:
             else:
                 print(content, end="")
 
+        # A single-tab read stamps only that tab's baseline; --all-tabs is a
+        # whole-doc read (read_tab_id stays None) and advances the global one.
         from gdoc.state import update_state_after_command
-        update_state_after_command(doc_id, change_info, command="cat", quiet=quiet)
+        update_state_after_command(
+            doc_id, change_info, command="cat", quiet=quiet,
+            read_tab_id=read_tab_id,
+        )
         return 0
 
     if getattr(args, "comments", False):
@@ -515,9 +592,9 @@ def cmd_tabs(args) -> int:
 
 def cmd_toc(args) -> int:
     """Handler for `gdoc toc`."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
-    tab = getattr(args, "tab", None)
+    tab, _ = _effective_tab(url_tab, getattr(args, "tab", None))
     max_depth = getattr(args, "max_depth", 0)
     no_links = getattr(args, "no_links", False)
 
@@ -677,10 +754,21 @@ def cmd_insert(args) -> int:
     """Handler for `gdoc insert`."""
     import os
 
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
     force = getattr(args, "force", False)
-    tab_name = args.tab
+    tab_name, _ = _effective_tab(url_tab, getattr(args, "tab", None))
+    if not tab_name:
+        if url_tab == _FIRST_TAB_ID:
+            raise GdocError(
+                "the URL's ?tab=t.0 is the first tab, which is ignored as an "
+                "ambient default; pass --tab NAME to target a specific tab "
+                "(or --tab t.0 for the first tab explicitly)",
+                exit_code=3,
+            )
+        raise GdocError(
+            "--tab is required (or pass a URL with ?tab=)", exit_code=3,
+        )
     position = getattr(args, "position", "start")
     file_path = args.file
 
@@ -698,12 +786,32 @@ def cmd_insert(args) -> int:
     if not content.strip():
         raise GdocError("input file has no content to insert", exit_code=3)
 
-    change_info, _ = _check_write_conflict(doc_id, quiet, force)
+    # Per-tab conflict check: `cat --tab X` establishes the baseline for
+    # `insert --tab X` (the whole-doc check would demand a full-doc read —
+    # the exact flow the collapse-guard error recommends). Pre-flight runs
+    # before the document fetch so usage errors keep their exit code.
+    from gdoc.api.docs import (
+        flatten_tabs,
+        get_document_with_tabs,
+        insert_markdown_into_tab,
+        resolve_tab,
+    )
 
-    from gdoc.api.docs import insert_markdown_into_tab
+    change_info = None
+    if not quiet:
+        from gdoc.notify import pre_flight
+
+        change_info = pre_flight(doc_id, quiet=False)
+        _require_doc(doc_id, change_info)
+
+    doc = get_document_with_tabs(doc_id)
+    tab_match = resolve_tab(flatten_tabs(doc.get("tabs", [])), tab_name)
+    tab_id = tab_match["id"]
+
+    _check_tab_write_conflict(doc_id, tab_id, tab_name, force)
 
     result = insert_markdown_into_tab(
-        doc_id, tab_name, content, position=position, replace=False,
+        doc_id, tab_name, content, position=position, replace=False, doc=doc,
     )
 
     from gdoc.api.drive import get_file_version
@@ -1110,14 +1218,16 @@ def _resolve_replacement_text(args, cell) -> tuple[str | None, str | None]:
 
 def _prepare_text_replacement(
     args, doc_id: str, old_text: str | None,
-    *, suggest: bool = False,
+    *, suggest: bool = False, url_tab: str | None = None,
 ) -> _ReplacementPlan:
     """Pre-flight, read the document, and locate the ranges to replace.
 
     `edit` reads the default view (legacy `body`, or the named tab).
     `suggest` always reads every tab with SUGGESTIONS_INLINE — the only
     view whose indexes match what a suggest-mode batchUpdate addresses —
-    and targets an explicit tab (the first when --tab is absent).
+    and targets an explicit tab (the first when no tab is named). The
+    target tab comes from `--tab` or the doc URL's `?tab=` via
+    `_effective_tab` (`--tab` wins; a URL `t.0` counts as absent).
     """
     quiet = getattr(args, "quiet", False)
     replace_all = getattr(args, "all", False)
@@ -1140,7 +1250,7 @@ def _prepare_text_replacement(
     # Get document structure + revision ID
     from gdoc.api.docs import find_text_in_document, get_document
 
-    tab_name = getattr(args, "tab", None)
+    tab_name, _ = _effective_tab(url_tab, getattr(args, "tab", None))
     tab_id = None
 
     if suggest:
@@ -1220,13 +1330,13 @@ def _prepare_text_replacement(
 
 def cmd_edit(args) -> int:
     """Handler for `gdoc edit`."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     cell = getattr(args, "cell", None)
 
     # Resolve text from args or files (fail fast before API calls)
     old_text, new_text = _resolve_replacement_text(args, cell)
 
-    plan = _prepare_text_replacement(args, doc_id, old_text)
+    plan = _prepare_text_replacement(args, doc_id, old_text, url_tab=url_tab)
     matches = plan.matches
 
     # Check if replacement contains tables — not supported with --all
@@ -1285,7 +1395,7 @@ def cmd_suggest(args) -> int:
     is unavailable or unverifiable the command fails and nothing is
     edited directly.
     """
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
 
     old_text, new_text = _resolve_replacement_text(args, None)
 
@@ -1305,7 +1415,7 @@ def cmd_suggest(args) -> int:
     read_identity = _token_identity(account_cache_key()[0])
 
     plan = _prepare_text_replacement(
-        args, doc_id, old_text, suggest=True,
+        args, doc_id, old_text, suggest=True, url_tab=url_tab,
     )
 
     # Never touch an existing review thread by accident: Google may merge a
@@ -1512,16 +1622,114 @@ def _check_write_conflict(
     return None, False
 
 
+def _max_opt(a, b):
+    """max of two Optional[int]s, treating None as absent."""
+    vals = [v for v in (a, b) if v is not None]
+    return max(vals) if vals else None
+
+
+def _tab_read_version(state, tab_id: str):
+    """This tab's stamped read baseline from state, or None."""
+    return state.tab_read_versions.get(tab_id) if state else None
+
+
+def _global_read_baseline(state):
+    """Global last_read_version, gated on whole-doc provenance.
+
+    Pre-0.22 state files stored a `cat --tab A` version in
+    last_read_version, so without the 0.22+ provenance marker the global
+    baseline is ambiguous and must not authorize a tab-scoped write —
+    return None and let the guard fail closed (fresh `cat` required).
+    """
+    if state is None or not state.global_read_covers_doc:
+        return None
+    return state.last_read_version
+
+
+def _raise_on_tab_conflict(tab_label: str, baseline, current_version) -> None:
+    """Raise GdocError(exit_code=3) if a tab write can't be safely made."""
+    if baseline is None:
+        raise GdocError(
+            f"no read baseline for tab {tab_label!r}. "
+            f"Run 'gdoc cat DOC --tab {tab_label}' (or 'gdoc cat DOC' for "
+            "the whole doc) first, or use --force to overwrite.",
+            exit_code=3,
+        )
+    if current_version is not None and current_version != baseline:
+        # "may" is honest: Drive versions are doc-global, so a sibling tab's
+        # edit also trips this. Conservative, and no worse than pre-per-tab.
+        raise GdocError(
+            f"tab {tab_label!r} may have changed since last read "
+            f"(doc moved v{baseline} -> v{current_version}). "
+            f"Run 'gdoc cat DOC --tab {tab_label}' first, or use --force to "
+            "overwrite.",
+            exit_code=3,
+        )
+
+
+def _check_tab_write_conflict(
+    doc_id: str, tab_id: str, tab_label: str, force: bool,
+) -> None:
+    """Conflict detection for a tab-scoped write (per-tab baseline).
+
+    Mirrors _check_write_conflict but checks the effective *tab* baseline —
+    lenient rule: max(whole-doc last_read_version, this tab's read version).
+    A plain `cat`/`pull` exports the whole doc (every tab), so the global
+    baseline legitimately covers tab X; a `cat --tab X` or an earlier
+    `write --tab X` stamps X's own entry. (`info` advances the whole-doc
+    guard's last_read_version but is excluded from the provenance marker,
+    so it never authorizes a tab-scoped write — it shows no content.)
+    Tab writes never get the content-match rescue — a tab body is never
+    the whole-doc export — so no in_sync escape.
+
+    Call this AFTER fetching the document to write into: the current
+    version is re-derived here, post-fetch, because comparing against the
+    caller's pre-flight snapshot would miss an edit landing between
+    pre-flight and the fetch — the batchUpdate's requiredRevisionId pin
+    only guards edits after the fetch. (The caller still runs
+    pre_flight/_require_doc first so usage errors surface cheaply, at the
+    right exit code, before the expensive document fetch.)
+    Raises GdocError(exit_code=3) on a real conflict.
+    """
+    if force:
+        return
+    from gdoc.state import load_state
+
+    state = load_state(doc_id)
+    baseline = _max_opt(
+        _global_read_baseline(state),
+        _tab_read_version(state, tab_id),
+    )
+
+    # With no baseline the write is rejected regardless of the current
+    # version, so skip the get_file_version network call.
+    current_version = None
+    if baseline is not None:
+        from gdoc.api.drive import get_file_version
+
+        current_version = get_file_version(doc_id).get("version")
+    _raise_on_tab_conflict(tab_label, baseline, current_version)
+
+
 def cmd_write(args) -> int:
     """Handler for `gdoc write`."""
     import os
 
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
     force = getattr(args, "force", False)
-    tab_name = getattr(args, "tab", None)
+    tab_name, tab_from_url = _effective_tab(url_tab, getattr(args, "tab", None))
     force_collapse = getattr(args, "force_collapse_tabs", False)
     file_path = args.file
+
+    # A URL that targets a tab and --force-collapse-tabs (collapse every tab
+    # into a single whole-doc write) express opposite intents.
+    if tab_from_url and force_collapse:
+        raise GdocError(
+            f"the URL targets tab {tab_name!r}, but --force-collapse-tabs "
+            "rewrites the whole document; drop ?tab= from the URL or the flag",
+            exit_code=3,
+        )
 
     # Read local file first (fail fast on missing file)
     if not os.path.isfile(file_path):
@@ -1537,62 +1745,106 @@ def cmd_write(args) -> int:
     from gdoc.frontmatter import parse_frontmatter
     _, content = parse_frontmatter(content)
 
-    # Conflict detection. Content comparison only applies to full-doc
-    # writes — a tab write's body never equals the whole-doc export.
+    from gdoc.format import format_json, get_output_mode
+    from gdoc.state import update_state_after_command
+    mode = get_output_mode(args)
+
+    if tab_name:
+        # Per-tab write. Pre-flight first — usage errors (spreadsheet, 404)
+        # must exit 3 before the expensive whole-document fetch — then
+        # resolve the tab (the conflict check needs its id) and hand the
+        # fetched doc to the write so the document isn't fetched twice.
+        from gdoc.api.docs import (
+            flatten_tabs,
+            get_document_with_tabs,
+            insert_markdown_into_tab,
+            resolve_tab,
+        )
+        from gdoc.api.drive import get_file_version
+
+        change_info = None
+        if not quiet:
+            from gdoc.notify import pre_flight
+
+            change_info = pre_flight(doc_id, quiet=False)
+            _require_doc(doc_id, change_info)
+
+        doc = get_document_with_tabs(doc_id)
+        all_tabs = flatten_tabs(doc.get("tabs", []))
+        tab_match = resolve_tab(all_tabs, tab_name)
+        tab_id = tab_match["id"]
+
+        _check_tab_write_conflict(doc_id, tab_id, tab_name, force)
+
+        result = insert_markdown_into_tab(
+            doc_id, tab_name, content, replace=True, doc=doc,
+        )
+        # Note: this version is fetched AFTER the batchUpdate — unlike the
+        # whole-doc path, whose files.update returns its own version
+        # atomically. A concurrent edit landing in that sub-second window
+        # would be folded into the stamped tab baseline — and on a
+        # single-tab doc, via full_doc_write below, into the whole-doc
+        # baseline too, exposing a later `push` to the same window.
+        # Accepted risk until the Docs API exposes the post-write version.
+        command_version = get_file_version(doc_id).get("version")
+        _print_tab_write_result(
+            mode, doc_id, result, command_version, verb="wrote",
+        )
+
+        update_state_after_command(
+            doc_id, change_info, command="write",
+            quiet=quiet, command_version=command_version,
+            # Replacing the only tab IS a whole-doc write (same single-tab
+            # rule as `cat --tab`): advance the global baseline too, so a
+            # following whole-doc write doesn't conflict with our own.
+            full_doc_write=(len(all_tabs) == 1),
+            written_tab_id=tab_id,
+        )
+        return 0
+
+    # Whole-doc write. Content comparison rescues an in-sync write (our own
+    # earlier write, or a cosmetic version bump) from a false conflict.
     change_info, in_sync = _check_write_conflict(
-        doc_id, quiet, force, body=None if tab_name else content,
+        doc_id, quiet, force, body=content,
     )
     if in_sync:
         return _finish_noop_write(doc_id, change_info, args, quiet, command="write")
 
-    from gdoc.format import format_json, get_output_mode
-    mode = get_output_mode(args)
+    # Refuse destructive multi-tab collapse unless the user opts in.
+    if not force_collapse:
+        from gdoc.api.docs import count_document_tabs
+        tab_count = count_document_tabs(doc_id)
+        if tab_count > 1:
+            # If the URL carried the ambient ?tab=t.0 we dropped, say so —
+            # the user may have meant the first tab, not a collapse.
+            t0_hint = (
+                " (the URL's ?tab=t.0 was ignored as an ambient default; "
+                "pass --tab t.0 to write only the first tab)"
+                if url_tab == _FIRST_TAB_ID else ""
+            )
+            raise GdocError(
+                f"write would collapse {tab_count} tabs into 1. "
+                "Use `gdoc write --tab NAME FILE` for per-tab "
+                "writes, `gdoc insert --tab NAME FILE` to populate "
+                f"a tab, or pass --force-collapse-tabs to confirm.{t0_hint}",
+                exit_code=3,
+            )
 
-    if tab_name:
-        from gdoc.api.docs import insert_markdown_into_tab
-        result = insert_markdown_into_tab(
-            doc_id, tab_name, content, replace=True,
-        )
+    from gdoc.api.drive import update_doc_content
+    command_version = update_doc_content(doc_id, content)
 
-        from gdoc.api.drive import get_file_version
-        version_data = get_file_version(doc_id)
-        command_version = version_data.get("version")
-
-        _print_tab_write_result(
-            mode, doc_id, result, command_version, verb="wrote",
-        )
+    if mode == "json":
+        print(format_json(written=True, version=command_version))
+    elif mode == "plain":
+        print(f"id\t{doc_id}")
+        print("status\tupdated")
     else:
-        # Refuse destructive multi-tab collapse unless the user opts in.
-        if not force_collapse:
-            from gdoc.api.docs import count_document_tabs
-            tab_count = count_document_tabs(doc_id)
-            if tab_count > 1:
-                raise GdocError(
-                    f"write would collapse {tab_count} tabs into 1. "
-                    "Use `gdoc write --tab NAME FILE` for per-tab "
-                    "writes, `gdoc insert --tab NAME FILE` to populate "
-                    "a tab, or pass --force-collapse-tabs to confirm.",
-                    exit_code=3,
-                )
-
-        from gdoc.api.drive import update_doc_content
-        command_version = update_doc_content(doc_id, content)
-
-        if mode == "json":
-            print(format_json(written=True, version=command_version))
-        elif mode == "plain":
-            print(f"id\t{doc_id}")
-            print("status\tupdated")
-        else:
-            print("OK written")
-
-    # Update state
-    from gdoc.state import update_state_after_command
+        print("OK written")
 
     update_state_after_command(
         doc_id, change_info, command="write",
         quiet=quiet, command_version=command_version,
-        full_doc_write=not tab_name,
+        full_doc_write=True,
     )
 
     return 0
@@ -1600,8 +1852,9 @@ def cmd_write(args) -> int:
 
 def cmd_pull(args) -> int:
     """Handler for `gdoc pull`."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
+    _note_discarded_url_tab(url_tab, "pull", quiet)
     file_path = args.file
     revision = getattr(args, "revision", None)
 
@@ -1725,7 +1978,8 @@ def cmd_push(args) -> int:
             exit_code=3,
         )
 
-    doc_id = _resolve_doc_id(metadata["gdoc"])
+    doc_id, url_tab = _resolve_doc_ref(metadata["gdoc"])
+    _note_discarded_url_tab(url_tab, "push", quiet)
 
     # Conflict detection (reuse shared helper)
     change_info, in_sync = _check_write_conflict(doc_id, quiet, force, body=body)
@@ -2105,7 +2359,10 @@ def cmd_diff(args) -> int:
     import difflib
     import os
 
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
+    # A whole-doc diff against a tab-scoped expectation is a plausible-
+    # looking wrong answer — say the tab was dropped.
+    _note_discarded_url_tab(url_tab, "diff", getattr(args, "quiet", False))
     file_path = getattr(args, "file", None)
     rev = getattr(args, "rev", None)
     since = getattr(args, "since", None)
@@ -2198,8 +2455,9 @@ def cmd_diff(args) -> int:
 
 def cmd_comments(args) -> int:
     """Handler for `gdoc comments`."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
+    _note_discarded_url_tab(url_tab, "comments", quiet)
 
     # Pre-flight awareness check
     from gdoc.notify import pre_flight
@@ -2562,8 +2820,9 @@ def cmd_comment_info(args) -> int:
 
 def cmd_images(args) -> int:
     """Handler for `gdoc images`."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
+    _note_discarded_url_tab(url_tab, "images", quiet)
     image_id = getattr(args, "image_id", None)
     download_dir = getattr(args, "download", None)
 
@@ -2670,8 +2929,10 @@ _EXT_TO_FORMAT = {
 
 def cmd_export(args) -> int:
     """Handler for `gdoc export`: render a doc to PDF/DOCX/HTML/etc."""
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
+    # Exports always render the whole document, all tabs included.
+    _note_discarded_url_tab(url_tab, "export", quiet)
     fmt = getattr(args, "format", None)
     out = getattr(args, "out", None)
 
@@ -2887,7 +3148,7 @@ def cmd_insert_image(args) -> int:
     """Handler for `gdoc insert-image`: add an image to an existing doc."""
     import math
 
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
     for name in ("width", "height"):
         val = getattr(args, name, None)
@@ -2909,7 +3170,8 @@ def cmd_insert_image(args) -> int:
 
     doc = get_document_with_tabs(doc_id)
     revision_id = doc.get("revisionId", "")
-    tab = _resolve_image_target_tab(doc, getattr(args, "tab", None))
+    tab_name, _ = _effective_tab(url_tab, getattr(args, "tab", None))
+    tab = _resolve_image_target_tab(doc, tab_name)
     tab_id = tab["id"] if tab else None
     body = tab["body"] if tab else doc.get("body", {})
 
@@ -3031,9 +3293,9 @@ def cmd_structure(args) -> int:
     """Handler for `gdoc structure`: raw document JSON for native edits."""
     import json
 
-    doc_id = _resolve_doc_id(args.doc)
+    doc_id, url_tab = _resolve_doc_ref(args.doc)
     quiet = getattr(args, "quiet", False)
-    tab_name = getattr(args, "tab", None)
+    tab_name, _ = _effective_tab(url_tab, getattr(args, "tab", None))
     fields = getattr(args, "fields", None)
     svm = getattr(args, "suggestions_view_mode", None)
     svm = svm.upper() if svm else None
@@ -3053,8 +3315,9 @@ def cmd_structure(args) -> int:
     if svm and "suggestionsViewMode" not in doc:
         doc = {**doc, "suggestionsViewMode": svm}
 
+    read_tab_id = None
     if tab_name:
-        from gdoc.api.docs import resolve_raw_tab
+        from gdoc.api.docs import flatten_tabs, resolve_raw_tab
 
         tab = resolve_raw_tab(doc.get("tabs", []), tab_name)
         if tab is None:
@@ -3063,6 +3326,16 @@ def cmd_structure(args) -> int:
                 "(with --fields, the mask must keep tabProperties)",
                 exit_code=3,
             )
+        # Same rule as `cat --tab`: on a multi-tab doc a tab-scoped read
+        # stamps only that tab's baseline; on a single-tab doc the one tab
+        # IS the whole document, so the read stays a full one. Only when
+        # the response is unmasked — a --fields response may omit tabIds,
+        # sibling tabs, or the content itself, so it can't prove coverage
+        # (the fields is None gate below keeps it from stamping anything).
+        # A missing tabId degrades to "" (fail-closed: not None, so the
+        # read never claims whole-doc provenance) — matching cmd_cat.
+        if fields is None and len(flatten_tabs(doc.get("tabs", []))) > 1:
+            read_tab_id = tab.get("tabProperties", {}).get("tabId", "")
         out = {
             "documentId": doc.get("documentId", doc_id),
             "title": doc.get("title", ""),
@@ -3086,8 +3359,13 @@ def cmd_structure(args) -> int:
 
     from gdoc.state import update_state_after_command
 
+    # A --fields-masked response can't prove a full read (it may have no
+    # body at all), so it records the interaction without advancing any
+    # read baseline — same mechanism as cat-revision.
     update_state_after_command(
-        doc_id, change_info, command="structure", quiet=quiet,
+        doc_id, change_info,
+        command="structure" if fields is None else "structure-partial",
+        quiet=quiet, read_tab_id=read_tab_id,
     )
     return 0
 
@@ -3835,7 +4113,9 @@ def build_parser() -> GdocArgumentParser:
         "cat", parents=[output_parent],
         help="Export doc as markdown (spreadsheets print as a table)",
     )
-    cat_p.add_argument("doc", help="Document ID or URL")
+    cat_p.add_argument(
+        "doc", help="Document ID or URL (a ?tab= in the URL selects that tab)"
+    )
     cat_p.add_argument(
         "--comments", action="store_true", help="Include comment annotations"
     )
@@ -3845,7 +4125,7 @@ def build_parser() -> GdocArgumentParser:
     )
     cat_tab_group = cat_p.add_mutually_exclusive_group()
     cat_tab_group.add_argument(
-        "--tab", help="Read a specific tab by title or ID"
+        "--tab", help="Read a specific tab by title or ID (or pass a URL with ?tab=)"
     )
     cat_tab_group.add_argument(
         "--all-tabs", action="store_true", help="Read all tabs"
@@ -3943,8 +4223,12 @@ def build_parser() -> GdocArgumentParser:
         "toc", parents=[output_parent],
         help="Extract table of contents with deep links",
     )
-    toc_p.add_argument("doc", help="Document ID or URL")
-    toc_p.add_argument("--tab", help="Read a specific tab by title or ID")
+    toc_p.add_argument(
+        "doc", help="Document ID or URL (a ?tab= in the URL selects that tab)"
+    )
+    toc_p.add_argument(
+        "--tab", help="Read a specific tab by title or ID (or pass a URL with ?tab=)"
+    )
     toc_p.add_argument(
         "--max-depth", type=int, default=0,
         help="Only show headings up to level N (0 = all)",
@@ -3978,7 +4262,9 @@ def build_parser() -> GdocArgumentParser:
                "Replacement text supports markdown formatting "
                "(bold, italic, headings, bullets, links).",
     )
-    edit_p.add_argument("doc", help="Document ID or URL")
+    edit_p.add_argument(
+        "doc", help="Document ID or URL (a ?tab= in the URL selects that tab)"
+    )
     edit_p.add_argument("old_text", nargs="?", default=None, help="Text to find")
     edit_p.add_argument("new_text", nargs="?", default=None, help="Replacement text")
     edit_p.add_argument("--old-file", help="Read old text from file")
@@ -4013,7 +4299,8 @@ def build_parser() -> GdocArgumentParser:
         "--quiet", action="store_true", help="Skip pre-flight checks"
     )
     edit_p.add_argument(
-        "--tab", help="Target a specific tab by title or ID"
+        "--tab",
+        help="Target a specific tab by title or ID (or pass a URL with ?tab=)",
     )
     edit_p.set_defaults(func=cmd_edit)
 
@@ -4128,11 +4415,14 @@ def build_parser() -> GdocArgumentParser:
             "automatically."
         ),
     )
-    write_p.add_argument("doc", help="Document ID or URL")
+    write_p.add_argument(
+        "doc", help="Document ID or URL (a ?tab= in the URL selects that tab)"
+    )
     write_p.add_argument("file", help="Local markdown file")
     write_p.add_argument(
         "--tab",
-        help="Replace only this tab (by title or ID); leaves siblings alone",
+        help="Replace only this tab (by title or ID, or a URL with ?tab=); "
+             "leaves siblings alone",
     )
     write_p.add_argument(
         "--force-collapse-tabs", action="store_true",
@@ -4156,11 +4446,13 @@ def build_parser() -> GdocArgumentParser:
             "before upload."
         ),
     )
-    insert_p.add_argument("doc", help="Document ID or URL")
+    insert_p.add_argument(
+        "doc", help="Document ID or URL (a ?tab= in the URL supplies the tab)"
+    )
     insert_p.add_argument("file", help="Local markdown file")
     insert_p.add_argument(
-        "--tab", required=True,
-        help="Target tab by title or ID",
+        "--tab",
+        help="Target tab by title or ID (or pass a URL with ?tab=)",
     )
     insert_p.add_argument(
         "--position", choices=["start", "end"], default="start",
@@ -4351,7 +4643,9 @@ def build_parser() -> GdocArgumentParser:
     ii_p.add_argument("doc", help="Document ID or URL")
     ii_p.add_argument("image", help="Local image path or public image URL")
     ii_p.add_argument(
-        "--tab", help="Tab title or ID (required for multi-tab docs)",
+        "--tab",
+        help="Tab title or ID (required for multi-tab docs; "
+        "or pass a URL with ?tab=)",
     )
     ii_where = ii_p.add_mutually_exclusive_group(required=True)
     ii_where.add_argument(
@@ -4414,7 +4708,7 @@ def build_parser() -> GdocArgumentParser:
     structure_p.add_argument(
         "--tab",
         help="Narrow to one tab by title or ID (returns that tab's raw "
-        "subtree plus documentId/revisionId)",
+        "subtree plus documentId/revisionId; or pass a URL with ?tab=)",
     )
     structure_p.add_argument(
         "--fields",

--- a/gdoc/state.py
+++ b/gdoc/state.py
@@ -18,6 +18,19 @@ class DocState:
     last_comment_check: str = ""                 # ISO timestamp for comments.list
     known_comment_ids: list[str] = field(default_factory=list)
     known_resolved_ids: list[str] = field(default_factory=list)
+    # Resolved tab id -> doc version at the last full read/write of that tab.
+    # The write-conflict baseline for a tab-scoped write is per-tab (see
+    # update_state_after_command). Old state files load with an empty dict.
+    tab_read_versions: dict[str, int] = field(default_factory=dict)
+    # Provenance for last_read_version: True when it was written by gdoc
+    # >= 0.22, whose tab-scoped reads no longer touch the global baseline.
+    # Pre-0.22 `cat --tab A` stored its version in last_read_version, so a
+    # legacy global baseline is ambiguous and must not authorize a
+    # tab-scoped write — legacy files load as False and the tab guard
+    # fails closed (fresh `cat` required). A downgrade round-trip strips
+    # the field (old binaries drop unknown keys on save), re-entering the
+    # same fail-closed state.
+    global_read_covers_doc: bool = False
 
 
 def _state_path(doc_id: str) -> Path:
@@ -64,6 +77,8 @@ def update_state_after_command(
     comment_state_patch: dict | None = None,
     full_doc_write: bool = False,
     metadata_only_write: bool = False,
+    read_tab_id: str | None = None,
+    written_tab_id: str | None = None,
 ) -> None:
     """Update per-doc state after a successful command.
 
@@ -82,6 +97,12 @@ def update_state_after_command(
             current at pre-flight, it is carried forward past our own
             version bump so the next content write doesn't see a phantom
             conflict.
+        read_tab_id: Set for a tab-scoped read (`cat --tab X`). Stamps that
+            tab's read baseline in tab_read_versions instead of advancing the
+            whole-doc last_read_version — a single-tab read is not a full read.
+        written_tab_id: Set for a tab-scoped write (`write --tab X`). Stamps
+            that tab's baseline to the post-write version so the writer's own
+            output doesn't false-conflict a later write to the same tab.
     """
     from datetime import datetime, timezone
 
@@ -89,19 +110,42 @@ def update_state_after_command(
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     state.last_seen = now
 
-    is_read = command in ("cat", "info", "pull", "export", "structure")
+    # A tab-scoped read is NOT a whole-doc read: it stamps only that tab's
+    # baseline, never the doc-global last_read_version.
+    is_read = (
+        command in ("cat", "info", "pull", "export", "structure")
+        and read_tab_id is None
+    )
 
     if quiet:
         # Decision #14: --quiet state update rules
         if command == "info" and command_version is not None:
             state.last_version = command_version
+            # See the non-quiet info branch below: a version bump seen
+            # only through `info` voids content provenance.
+            if command_version != state.last_read_version:
+                state.global_read_covers_doc = False
             state.last_read_version = command_version
     elif change_info is not None:
         # Normal (non-quiet) run: update from pre-flight data
         if change_info.current_version is not None:
             state.last_version = change_info.current_version
             if is_read:
+                # `info` shows metadata only: it keeps the whole-doc
+                # guard's status quo (advancing last_read_version) but
+                # never *grants* whole-doc content provenance — and when
+                # it moves the baseline past the last genuine read, it
+                # must also VOID any existing provenance: the versions
+                # in between were never seen, so leaving the marker True
+                # would launder an unseen edit into the tab guard.
+                if command == "info":
+                    if change_info.current_version != state.last_read_version:
+                        state.global_read_covers_doc = False
+                else:
+                    state.global_read_covers_doc = True
                 state.last_read_version = change_info.current_version
+            if read_tab_id is not None:
+                state.tab_read_versions[read_tab_id] = change_info.current_version
 
         # Advance last_comment_check to pre-request timestamp (Decision #12)
         if change_info.preflight_timestamp:
@@ -124,6 +168,7 @@ def update_state_after_command(
         # the rest of the doc may hold changes the writer never saw.
         if full_doc_write:
             state.last_read_version = command_version
+            state.global_read_covers_doc = True
         elif (
             metadata_only_write
             and change_info is not None
@@ -141,6 +186,26 @@ def update_state_after_command(
             # spurious conflict later is recoverable, marking unseen
             # content as read is not.
             state.last_read_version = command_version
+        # Metadata-only bumps also heal per-tab baselines, under the same
+        # attributability condition (post-op version exactly one past
+        # pre-flight). Deliberately independent of the global branch's
+        # has_conflict guard: after a tab-only read the global baseline is
+        # unset, which reads as a conflict there, yet each per-tab entry
+        # proves its own currency by matching the pre-flight version.
+        if (
+            metadata_only_write
+            and change_info is not None
+            and change_info.current_version is not None
+            and command_version == change_info.current_version + 1
+        ):
+            for tid, ver in state.tab_read_versions.items():
+                if ver == change_info.current_version:
+                    state.tab_read_versions[tid] = command_version
+        # A tab-scoped write is a full read+replace of that one tab: stamp its
+        # per-tab baseline so a second write to the same tab doesn't conflict
+        # against the version our own write just produced.
+        if written_tab_id is not None:
+            state.tab_read_versions[written_tab_id] = command_version
 
     # Apply comment mutation patch (both quiet and non-quiet)
     # Per CONTEXT.md Decision #10

--- a/gdoc/state.py
+++ b/gdoc/state.py
@@ -161,6 +161,15 @@ def update_state_after_command(
     # (the pre-flight version is from BEFORE the mutation; this is from AFTER)
     if command_version is not None and command not in ("cat", "info"):
         state.last_version = command_version
+        # The post-op version is exactly one past pre-flight, so the bump is
+        # attributable solely to our own metadata change. Shared by the global
+        # and per-tab healing rules below so the two cannot drift apart.
+        attributable_bump = (
+            metadata_only_write
+            and change_info is not None
+            and change_info.current_version is not None
+            and command_version == change_info.current_version + 1
+        )
         # A successful full-content write doubles as a read: the doc now
         # contains exactly what we sent, so advance the conflict baseline.
         # Without this, a later push false-conflicts against our own write.
@@ -169,13 +178,7 @@ def update_state_after_command(
         if full_doc_write:
             state.last_read_version = command_version
             state.global_read_covers_doc = True
-        elif (
-            metadata_only_write
-            and change_info is not None
-            and change_info.current_version is not None
-            and not change_info.has_conflict
-            and command_version == change_info.current_version + 1
-        ):
+        elif attributable_bump and not change_info.has_conflict:
             # Content is untouched, the baseline was current going in,
             # and the post-op version is exactly one past the pre-flight
             # read — the bump is attributable solely to our own metadata
@@ -192,12 +195,7 @@ def update_state_after_command(
         # has_conflict guard: after a tab-only read the global baseline is
         # unset, which reads as a conflict there, yet each per-tab entry
         # proves its own currency by matching the pre-flight version.
-        if (
-            metadata_only_write
-            and change_info is not None
-            and change_info.current_version is not None
-            and command_version == change_info.current_version + 1
-        ):
+        if attributable_bump:
             for tid, ver in state.tab_read_versions.items():
                 if ver == change_info.current_version:
                     state.tab_read_versions[tid] = command_version

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -204,8 +204,11 @@ _PATTERNS = [
 _BARE_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 # Tab ids look like `t.0`, `t.abc123` — the dot distinguishes them from
-# doc-id charsets, so it must be included in the capture class.
-_TAB_PARAM = re.compile(r"[?&]tab=([A-Za-z0-9._-]+)")
+# doc-id charsets, so it must be included in the capture class. `&amp;` is
+# accepted alongside `?`/`&` because a URL copied out of rendered HTML keeps
+# the escaped separator: failing to match there would silently downgrade a
+# tab-scoped `edit`/`write` to the whole-doc path.
+_TAB_PARAM = re.compile(r"(?:[?&]|&amp;)tab=([A-Za-z0-9._-]+)")
 
 
 def confirm_destructive(message: str, force: bool = False) -> None:

--- a/gdoc/util.py
+++ b/gdoc/util.py
@@ -203,6 +203,10 @@ _PATTERNS = [
 
 _BARE_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
 
+# Tab ids look like `t.0`, `t.abc123` — the dot distinguishes them from
+# doc-id charsets, so it must be included in the capture class.
+_TAB_PARAM = re.compile(r"[?&]tab=([A-Za-z0-9._-]+)")
+
 
 def confirm_destructive(message: str, force: bool = False) -> None:
     """Prompt for confirmation on destructive ops. Raises GdocError on decline."""
@@ -255,6 +259,34 @@ def build_doc_url(doc_id: str, tab_id: str | None = None) -> str:
     return url
 
 
+def extract_doc_ref(input_str: str) -> tuple[str, str | None]:
+    """Extract (document ID, tab ID) from a URL or bare ID string.
+
+    The tab ID is the value of a `?tab=`/`&tab=` query param, if present
+    (Google's editor deep-links to a tab that way). A bare ID or a URL
+    without the param yields a ``None`` tab.
+
+    Raises ValueError if no valid ID can be extracted.
+    """
+    input_str = input_str.strip()
+
+    if not input_str:
+        raise ValueError("Cannot extract document ID from empty string")
+
+    tab_match = _TAB_PARAM.search(input_str)
+    tab_id = tab_match.group(1) if tab_match else None
+
+    for pattern in _PATTERNS:
+        match = pattern.search(input_str)
+        if match:
+            return match.group(1), tab_id
+
+    if _BARE_ID.match(input_str):
+        return input_str, None
+
+    raise ValueError(f"Cannot extract document ID from: {input_str}")
+
+
 def extract_doc_id(input_str: str) -> str:
     """Extract document ID from a URL or bare ID string.
 
@@ -265,17 +297,4 @@ def extract_doc_id(input_str: str) -> str:
 
     Raises ValueError if no valid ID can be extracted.
     """
-    input_str = input_str.strip()
-
-    if not input_str:
-        raise ValueError("Cannot extract document ID from empty string")
-
-    for pattern in _PATTERNS:
-        match = pattern.search(input_str)
-        if match:
-            return match.group(1)
-
-    if _BARE_ID.match(input_str):
-        return input_str
-
-    raise ValueError(f"Cannot extract document ID from: {input_str}")
+    return extract_doc_ref(input_str)[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.21.0"
+version = "0.22.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,3 +31,29 @@ def doc_mime(monkeypatch):
         "gdoc.api.drive.get_file_version",
         lambda doc_id: {"mimeType": DOC_MIME, "version": 1, "modifiedTime": ""},
     )
+
+
+def doc_with_tabs(*pairs):
+    """A get_document_with_tabs() response for the given (id, title) pairs.
+
+    Shared by the insert/write/baseline test modules: the payload encodes
+    the API contract (tabProperties.tabId, documentTab.body), so its shape
+    lives in one place.
+    """
+    return {
+        "revisionId": "rev1",
+        "tabs": [
+            {
+                "tabProperties": {"tabId": tid, "title": title, "index": i},
+                "documentTab": {"body": {"content": []}},
+            }
+            for i, (tid, title) in enumerate(pairs)
+        ],
+    }
+
+
+def whole_doc_read_state(version=11):
+    """State proving a whole-doc read at `version` (0.22 provenance)."""
+    from gdoc.state import DocState
+
+    return DocState(last_read_version=version, global_read_covers_doc=True)

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -722,9 +722,9 @@ class TestZeroWidthReplace:
 
 
 class TestInsertMarkdownIntoTab:
-    def _tabs_doc(self, body_content=None):
+    def _tabs_doc(self, body_content=None, revision_id="rev-xyz"):
         return {
-            "revisionId": "rev-xyz",
+            "revisionId": revision_id,
             "tabs": [{
                 "tabProperties": {
                     "tabId": "t.todo", "title": "TODO", "index": 0,
@@ -830,3 +830,33 @@ class TestInsertMarkdownIntoTab:
 
         with pytest.raises(GdocError, match="tab not found"):
             insert_markdown_into_tab("doc1", "Not A Real Tab", "hi")
+
+    @patch("gdoc.api.docs.get_docs_service")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    def test_prefetched_doc_skips_fetch_and_pins_its_revision(
+        self, mock_get, mock_svc,
+    ):
+        """`write --tab`'s fast path passes a pre-fetched doc. The function
+        must NOT fetch again, must resolve the tab from the passed doc, and
+        must pin writeControl to the passed doc's revisionId — that revision
+        is what rejects a concurrent edit between the caller's fetch and this
+        write."""
+        from gdoc.api.docs import insert_markdown_into_tab
+
+        prefetched = self._tabs_doc(
+            body_content=[
+                {"startIndex": 1, "endIndex": 30, "paragraph": {}},
+            ],
+            revision_id="rev-prefetched",
+        )
+        captured = _capture_batch_updates(mock_svc)
+
+        result = insert_markdown_into_tab(
+            "doc1", "TODO", "new content", replace=True, doc=prefetched,
+        )
+
+        mock_get.assert_not_called()
+        assert result["tab_id"] == "t.todo"
+        assert captured[0]["writeControl"] == {
+            "requiredRevisionId": "rev-prefetched",
+        }

--- a/tests/test_cat_tabs.py
+++ b/tests/test_cat_tabs.py
@@ -232,6 +232,107 @@ class TestCatTabMutualExclusivity:
             cmd_cat(args)
 
 
+_URL = "https://docs.google.com/document/d/abc123/edit"
+
+
+class TestCatUrlTab:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_tab_text", return_value="tab body\n")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_url_tab_routes_to_docs_api(
+        self, _svc, mock_tabs, mock_text, _pf, _update, capsys,
+    ):
+        """A non-t.0 ?tab= in the URL is honored like --tab."""
+        mock_tabs.return_value = [_tab("t.second", "Second")]
+        args = _make_args(doc=f"{_URL}?tab=t.second")
+        with patch("gdoc.api.drive.export_doc") as mock_export:
+            rc = cmd_cat(args)
+            mock_export.assert_not_called()
+        assert rc == 0
+        assert capsys.readouterr().out == "tab body\n"
+        mock_tabs.assert_called_once_with("abc123")
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_url_tab_t0_stays_on_drive_export(self, _pf, _update, capsys):
+        """?tab=t.0 is ambient noise: stay on the high-fidelity Drive path."""
+        args = _make_args(doc=f"{_URL}?tab=t.0")
+        with patch(
+            "gdoc.api.drive.export_doc", return_value="whole doc\n"
+        ) as mock_export, patch("gdoc.api.docs.get_document_tabs") as mock_tabs:
+            rc = cmd_cat(args)
+            mock_export.assert_called_once()
+            mock_tabs.assert_not_called()
+        assert rc == 0
+        assert capsys.readouterr().out == "whole doc\n"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_tab_text", return_value="flag body\n")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_flag_overrides_url_tab(
+        self, _svc, mock_tabs, mock_text, _pf, _update, capsys,
+    ):
+        """An explicit --tab wins over a differing URL tab."""
+        mock_tabs.return_value = [_tab("t.second", "Second"), _tab("t.flag", "Flag")]
+        args = _make_args(doc=f"{_URL}?tab=t.second", tab="Flag")
+        rc = cmd_cat(args)
+        assert rc == 0
+        called_tab = mock_text.call_args[0][0]
+        assert called_tab["id"] == "t.flag"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_tab_text")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_all_tabs_overrides_url_tab(
+        self, _svc, mock_tabs, mock_text, _pf, _update, capsys,
+    ):
+        """--all-tabs wins over a URL tab (no conflict error)."""
+        mock_tabs.return_value = [_tab("t1", "First"), _tab("t.second", "Second")]
+        mock_text.side_effect = ["a\n", "b\n"]
+        args = _make_args(doc=f"{_URL}?tab=t.second", all_tabs=True)
+        rc = cmd_cat(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "=== Tab: First ===" in out
+        assert "=== Tab: Second ===" in out
+
+    def test_url_tab_and_comments_conflict_mentions_url(self):
+        args = _make_args(doc=f"{_URL}?tab=t.second", comments=True, quiet=True)
+        with pytest.raises(GdocError, match="URL targets tab") as exc:
+            cmd_cat(args)
+        assert exc.value.exit_code == 3
+
+    def test_url_tab_and_revision_conflict_mentions_url(self):
+        args = _make_args(doc=f"{_URL}?tab=t.second", revision="latest", quiet=True)
+        with pytest.raises(GdocError, match="URL targets tab") as exc:
+            cmd_cat(args)
+        assert exc.value.exit_code == 3
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_tab_text", return_value="first tab\n")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_flag_t0_forces_first_tab(
+        self, _svc, mock_tabs, mock_text, _pf, _update, capsys,
+    ):
+        """Explicit --tab t.0 is the escape hatch: read the literal first tab
+        via the Docs API rather than treating t.0 as ambient noise."""
+        mock_tabs.return_value = [_tab("t.0", "First"), _tab("t.second", "Second")]
+        args = _make_args(tab="t.0")
+        with patch("gdoc.api.drive.export_doc") as mock_export:
+            rc = cmd_cat(args)
+        assert rc == 0
+        assert mock_text.call_args[0][0]["id"] == "t.0"
+        mock_export.assert_not_called()
+
+
 class TestCatTabAwareness:
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight")
@@ -243,14 +344,36 @@ class TestCatTabAwareness:
     ):
         change_info = ChangeInfo(current_version=7)
         mock_pf.return_value = change_info
-        mock_tabs.return_value = [_tab("t1", "Tab 1")]
+        # Multi-tab doc: a --tab read covers only that tab.
+        mock_tabs.return_value = [_tab("t1", "Tab 1"), _tab("t2", "Tab 2")]
         args = _make_args(tab="Tab 1")
         rc = cmd_cat(args)
         assert rc == 0
         mock_pf.assert_called_once_with("abc123", quiet=False)
+        # A tab read stamps that tab's baseline, not the whole-doc one.
         mock_update.assert_called_once_with(
             "abc123", change_info, command="cat", quiet=False,
+            read_tab_id="t1",
         )
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight")
+    @patch("gdoc.api.docs.get_tab_text", return_value="text\n")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_single_tab_read_advances_global_baseline(
+        self, _svc, mock_tabs, _text, mock_pf, mock_update,
+    ):
+        """On a single-tab doc, `cat --tab X` reads the whole document, so it
+        advances the whole-doc baseline (read_tab_id None) rather than stamping
+        a per-tab one — otherwise a following whole-doc write/push would be
+        spuriously blocked."""
+        change_info = ChangeInfo(current_version=7)
+        mock_pf.return_value = change_info
+        mock_tabs.return_value = [_tab("t.only", "Only")]
+        rc = cmd_cat(_make_args(tab="Only"))
+        assert rc == 0
+        assert mock_update.call_args.kwargs.get("read_tab_id") is None
 
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.notify.pre_flight")
@@ -268,3 +391,34 @@ class TestCatTabAwareness:
         assert rc == 0
         mock_pf.assert_called_once()
         mock_update.assert_called_once()
+        # --all-tabs is a whole-doc read: no per-tab stamp.
+        assert mock_update.call_args.kwargs.get("read_tab_id") is None
+
+
+class TestCatTabBaselinePersistence:
+    """R2 regression lock, against real (tmp) state: on a multi-tab doc a
+    single-tab read stamps only that tab's baseline and never advances the
+    whole-doc one (which would let a sibling tab be overwritten unseen)."""
+
+    def test_tab_read_does_not_advance_global_baseline(self, tmp_path):
+        from gdoc.state import DocState, load_state, save_state
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("abc123", DocState(last_read_version=50, last_version=50))
+            change_info = ChangeInfo(
+                current_version=100,
+                mime_type="application/vnd.google-apps.document",
+            )
+            with patch("gdoc.notify.pre_flight", return_value=change_info), \
+                 patch("gdoc.api.docs.get_document_tabs",
+                       return_value=[
+                           _tab("t.notes", "Notes", "body\n"),
+                           _tab("t.other", "Other", "other\n"),
+                       ]), \
+                 patch("gdoc.api.docs.get_tab_text", return_value="body\n"), \
+                 patch("gdoc.api.docs.get_docs_service"):
+                rc = cmd_cat(_make_args(tab="Notes"))
+            assert rc == 0
+            state = load_state("abc123")
+            assert state.last_read_version == 50  # global untouched
+            assert state.tab_read_versions == {"t.notes": 100}

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -699,6 +699,45 @@ class TestEditTab:
         with pytest.raises(GdocError, match="Document not found"):
             cmd_edit(args)
 
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_mock_tabs_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_url_tab_passes_tab_id(
+        self, _pf, mock_get_tabs, mock_replace, _ver, _update,
+    ):
+        """A non-t.0 ?tab= in the URL drives the tab-scoped edit path."""
+        args = _make_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t1",
+            tab=None,
+        )
+        rc = cmd_edit(args)
+        assert rc == 0
+        mock_get_tabs.assert_called_once()
+        assert mock_replace.call_args[1]["tab_id"] == "t1"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_version_data())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.find_text_in_document", return_value=_single_match())
+    @patch("gdoc.api.docs.get_document", return_value=_mock_doc())
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_url_tab_t0_uses_whole_doc(
+        self, _pf, mock_get_tabs, mock_doc, _find, mock_replace, _ver, _update,
+    ):
+        """?tab=t.0 is ambient noise: whole-doc path, tab_id=None."""
+        args = _make_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.0",
+            tab=None,
+        )
+        rc = cmd_edit(args)
+        assert rc == 0
+        mock_doc.assert_called_once()
+        mock_get_tabs.assert_not_called()
+        assert mock_replace.call_args[1]["tab_id"] is None
+
 
 class TestEditStdin:
     @patch("gdoc.state.update_state_after_command")

--- a/tests/test_edit_cell.py
+++ b/tests/test_edit_cell.py
@@ -181,3 +181,59 @@ class TestCmdEditCell:
         with pytest.raises(GdocError, match="needs replacement text") as exc:
             cmd_edit(_args(cell="Label A"))
         assert exc.value.exit_code == 3
+
+
+def _two_tab_doc():
+    # Second tab's grid sits at different offsets than GRID so a wrong-tab
+    # resolution produces a visibly wrong range.
+    grid2 = {"content": [_table([
+        [("Label A\n", 105), ("Value A\n", 120)],
+    ])]}
+    return {
+        "revisionId": "rev123",
+        "tabs": [
+            {
+                "tabProperties": {"tabId": "t.first", "title": "First", "index": 0},
+                "documentTab": {"body": GRID},
+            },
+            {
+                "tabProperties": {"tabId": "t.second", "title": "Second", "index": 1},
+                "documentTab": {"body": grid2},
+            },
+        ],
+    }
+
+
+class TestCmdEditCellUrlTab:
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_ver())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_two_tab_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_url_tab_cell_edit_targets_selected_tab(
+        self, _pf, _doc_, mock_replace, _v, _u,
+    ):
+        # The composition the URL feature advertises: cell indices resolve
+        # from the URL-selected tab's body, and the write carries its id.
+        rc = cmd_edit(_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            cell="Label A", old_text="new value",
+        ))
+        assert rc == 0
+        call = mock_replace.call_args
+        assert call.args[1] == [{"startIndex": 120, "endIndex": 127}]
+        assert call.kwargs["tab_id"] == "t.second"
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_ver())
+    @patch("gdoc.api.docs.replace_formatted", return_value=1)
+    @patch("gdoc.api.docs.get_document_with_tabs", return_value=_two_tab_doc())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_tab_flag_cell_edit_same_composition(
+        self, _pf, _doc_, mock_replace, _v, _u,
+    ):
+        rc = cmd_edit(_args(cell="Label A", old_text="x", tab="Second"))
+        assert rc == 0
+        call = mock_replace.call_args
+        assert call.args[1] == [{"startIndex": 120, "endIndex": 127}]
+        assert call.kwargs["tab_id"] == "t.second"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -10,6 +10,7 @@ from googleapiclient.errors import HttpError
 
 from gdoc.api.drive import export_doc_bytes
 from gdoc.cli import cmd_export
+from gdoc.notify import ChangeInfo
 from gdoc.util import GdocError
 
 PDF_MIME = "application/pdf"
@@ -187,3 +188,39 @@ class TestCmdExport:
         args = _make_args(out=str(tmp_path / "r.pdf"))
         cmd_export(args)
         assert mock_update.call_args.kwargs["command"] == "export"
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.drive.export_doc_bytes", return_value=b"# Hi\n")
+class TestExportUrlTabNote:
+    # Exports render the whole document, so a URL's tab deep link is
+    # discarded with the same stderr NOTE convention as pull/push.
+    @patch(
+        "gdoc.notify.pre_flight",
+        return_value=ChangeInfo(current_version=42),
+    )
+    def test_notes_discarded_url_tab(self, _pf, _export, _update, capsys):
+        args = _make_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            format="md",
+            quiet=False,
+        )
+        rc = cmd_export(args)
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "NOTE" in err
+        assert "t.second" in err
+
+    @patch(
+        "gdoc.notify.pre_flight",
+        return_value=ChangeInfo(current_version=42),
+    )
+    def test_t0_url_tab_is_silent(self, _pf, _export, _update, capsys):
+        args = _make_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.0",
+            format="md",
+            quiet=False,
+        )
+        rc = cmd_export(args)
+        assert rc == 0
+        assert "NOTE" not in capsys.readouterr().err

--- a/tests/test_image_edit.py
+++ b/tests/test_image_edit.py
@@ -315,6 +315,30 @@ class TestCmdInsertImage:
         assert rc == 0
         assert mock_insert.call_args.kwargs["tab_id"] == "t2"
 
+    def test_url_tab_satisfies_multi_tab_requirement(
+        self, mock_get, mock_insert, _ver, _update,
+    ):
+        mock_get.return_value = _TWO_TAB_DOC
+        args = _make_args(
+            "insert-image", after="Architecture",
+            doc="https://docs.google.com/document/d/doc123/edit?tab=t2",
+        )
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        assert mock_insert.call_args.kwargs["tab_id"] == "t2"
+
+    def test_tab_flag_overrides_url_tab(
+        self, mock_get, mock_insert, _ver, _update,
+    ):
+        mock_get.return_value = _TWO_TAB_DOC
+        args = _make_args(
+            "insert-image", after="Intro", tab="t1",
+            doc="https://docs.google.com/document/d/doc123/edit?tab=t2",
+        )
+        rc = cmd_insert_image(args)
+        assert rc == 0
+        assert mock_insert.call_args.kwargs["tab_id"] == "t1"
+
     def test_index_used_directly(self, mock_get, mock_insert, _ver, _update):
         args = _make_args("insert-image", index=5)
         cmd_insert_image(args)

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -9,6 +9,8 @@ import pytest
 from gdoc.cli import cmd_insert
 from gdoc.notify import ChangeInfo
 from gdoc.util import GdocError
+from tests.conftest import doc_with_tabs as _tabs_doc
+from tests.conftest import whole_doc_read_state as _read_state
 
 
 def _make_args(**overrides):
@@ -38,27 +40,6 @@ def _insert_result(tab_id="t.todo", tab_title="TODO", insert_index=1):
 
 def _preflight_ok():
     return ChangeInfo(current_version=10, last_read_version=10)
-
-
-def _tabs_doc(*pairs):
-    """A get_document_with_tabs() response for the given (id, title) pairs."""
-    return {
-        "revisionId": "rev1",
-        "tabs": [
-            {
-                "tabProperties": {"tabId": tid, "title": title, "index": i},
-                "documentTab": {"body": {"content": []}},
-            }
-            for i, (tid, title) in enumerate(pairs)
-        ],
-    }
-
-
-def _read_state(version=11):
-    """State proving a whole-doc read at `version` (0.20 provenance)."""
-    from gdoc.state import DocState
-
-    return DocState(last_read_version=version, global_read_covers_doc=True)
 
 
 class TestInsertBasic:

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -40,13 +40,40 @@ def _preflight_ok():
     return ChangeInfo(current_version=10, last_read_version=10)
 
 
+def _tabs_doc(*pairs):
+    """A get_document_with_tabs() response for the given (id, title) pairs."""
+    return {
+        "revisionId": "rev1",
+        "tabs": [
+            {
+                "tabProperties": {"tabId": tid, "title": title, "index": i},
+                "documentTab": {"body": {"content": []}},
+            }
+            for i, (tid, title) in enumerate(pairs)
+        ],
+    }
+
+
+def _read_state(version=11):
+    """State proving a whole-doc read at `version` (0.20 provenance)."""
+    from gdoc.state import DocState
+
+    return DocState(last_read_version=version, global_read_covers_doc=True)
+
+
 class TestInsertBasic:
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
     @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
     def test_terse_output(
-        self, _pf, mock_insert, _ver, _update, tmp_path, capsys,
+        self, _pf, mock_insert, _ver, _update, mock_doc, _state,
+        tmp_path, capsys,
     ):
         f = tmp_path / "content.md"
         f.write_text("# Hello")
@@ -57,15 +84,21 @@ class TestInsertBasic:
         assert 'OK inserted into "TODO"' in out
         mock_insert.assert_called_once_with(
             "abc123", "TODO", "# Hello",
-            position="start", replace=False,
+            position="start", replace=False, doc=mock_doc.return_value,
         )
 
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
     @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
     def test_json_output(
-        self, _pf, _mock_insert, _ver, _update, tmp_path, capsys,
+        self, _pf, _mock_insert, _ver, _update, _doc, _state,
+        tmp_path, capsys,
     ):
         f = tmp_path / "content.md"
         f.write_text("hi")
@@ -79,12 +112,17 @@ class TestInsertBasic:
         assert data["tab_title"] == "TODO"
         assert data["version"] == 11
 
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
     @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
     def test_position_end_is_forwarded(
-        self, _pf, mock_insert, _ver, _update, tmp_path,
+        self, _pf, mock_insert, _ver, _update, mock_doc, _state, tmp_path,
     ):
         f = tmp_path / "content.md"
         f.write_text("tail")
@@ -92,17 +130,22 @@ class TestInsertBasic:
         cmd_insert(args)
         mock_insert.assert_called_once_with(
             "abc123", "TODO", "tail",
-            position="end", replace=False,
+            position="end", replace=False, doc=mock_doc.return_value,
         )
 
 
 class TestInsertFrontmatterStrip:
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
     @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
     def test_frontmatter_stripped(
-        self, _pf, mock_insert, _ver, _update, tmp_path,
+        self, _pf, mock_insert, _ver, _update, _doc, _state, tmp_path,
     ):
         f = tmp_path / "content.md"
         f.write_text(
@@ -133,29 +176,114 @@ class TestInsertFileErrors:
         assert exc.value.exit_code == 3
 
 
+class TestInsertUrlTab:
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.second", "Second"), ("t.x", "X")),
+    )
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_url_tab_satisfies_requirement(
+        self, _pf, mock_insert, _ver, _update, mock_doc, _state, tmp_path,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("# Hello")
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            tab=None,
+        )
+        rc = cmd_insert(args)
+        assert rc == 0
+        mock_insert.assert_called_once_with(
+            "abc123", "t.second", "# Hello",
+            position="start", replace=False, doc=mock_doc.return_value,
+        )
+
+    def test_no_tab_anywhere_errors(self, tmp_path):
+        f = tmp_path / "content.md"
+        f.write_text("# Hello")
+        args = _make_args(file=str(f), doc="abc123", tab=None)
+        with pytest.raises(GdocError, match="--tab is required") as exc:
+            cmd_insert(args)
+        assert exc.value.exit_code == 3
+
+    def test_url_t0_errors_with_ambient_hint(self, tmp_path):
+        # ?tab=t.0 collapses to "no tab", but the error names t.0 as the
+        # ignored ambient default rather than telling the user to pass a URL
+        # ?tab= (which they already did).
+        f = tmp_path / "content.md"
+        f.write_text("# Hello")
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.0",
+            tab=None,
+        )
+        with pytest.raises(GdocError, match="ambient default") as exc:
+            cmd_insert(args)
+        assert exc.value.exit_code == 3
+
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.e", "Explicit"), ("t.second", "Second")),
+    )
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
+    @patch("gdoc.notify.pre_flight", return_value=_preflight_ok())
+    def test_flag_overrides_url_tab(
+        self, _pf, mock_insert, _ver, _update, _doc, _state, tmp_path,
+    ):
+        f = tmp_path / "content.md"
+        f.write_text("# Hello")
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            tab="Explicit",
+        )
+        cmd_insert(args)
+        assert mock_insert.call_args.args[1] == "Explicit"
+
+
 class TestInsertConflict:
+    @patch("gdoc.state.load_state", return_value=_read_state(version=5))
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab")
     @patch("gdoc.notify.pre_flight")
     def test_blocks_on_conflict(
-        self, mock_pf, mock_insert, _ver, tmp_path,
+        self, mock_pf, mock_insert, _ver, _doc, _state, tmp_path,
     ):
+        # Per-tab check: the effective baseline (5) trails the current
+        # version (10), so the insert conflicts.
         f = tmp_path / "content.md"
         f.write_text("hi")
         mock_pf.return_value = ChangeInfo(
             current_version=10, last_read_version=5,
         )
         args = _make_args(file=str(f))
-        with pytest.raises(GdocError, match="doc changed"):
+        with pytest.raises(GdocError, match="may have changed"):
             cmd_insert(args)
         mock_insert.assert_not_called()
 
+    @patch("gdoc.state.load_state", return_value=_read_state(version=5))
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab", return_value=_insert_result())
     @patch("gdoc.notify.pre_flight")
     def test_force_bypasses_conflict(
-        self, mock_pf, mock_insert, _ver, _update, tmp_path,
+        self, mock_pf, mock_insert, _ver, _update, _doc, _state, tmp_path,
     ):
         f = tmp_path / "content.md"
         f.write_text("hi")
@@ -164,5 +292,34 @@ class TestInsertConflict:
         )
         args = _make_args(file=str(f), force=True)
         rc = cmd_insert(args)
+        assert rc == 0
+        mock_insert.assert_called_once()
+
+    @patch(
+        "gdoc.api.docs.get_document_with_tabs",
+        return_value=_tabs_doc(("t.todo", "TODO"), ("t.b", "B")),
+    )
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_tab_read_satisfies_insert(
+        self, mock_pf, mock_insert, _doc, tmp_path,
+    ):
+        # The regression the per-tab check fixes: `cat --tab X` (which
+        # stamps only tab_read_versions) must satisfy `insert --tab X` —
+        # the whole-doc baseline stays None.
+        from gdoc.state import DocState
+
+        f = tmp_path / "content.md"
+        f.write_text("hi")
+        mock_pf.return_value = ChangeInfo(current_version=11)
+        state = DocState(tab_read_versions={"t.todo": 11})
+        with patch("gdoc.state.load_state", return_value=state), \
+             patch("gdoc.state.update_state_after_command"), \
+             patch(
+                 "gdoc.api.drive.get_file_version",
+                 return_value={"version": 11},
+             ):
+            mock_insert.return_value = _insert_result()
+            rc = cmd_insert(_make_args(file=str(f)))
         assert rc == 0
         mock_insert.assert_called_once()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -116,9 +116,24 @@ def test_html_diff_format_is_not_offered():
     assert "color" in props["format"]["enum"]
 
 
-def test_required_options_are_marked_required():
+def test_insert_tab_is_optional_via_url():
     schema = mcp.build_tools(allow={"insert"})["gdoc_insert"]["inputSchema"]
-    # `insert --tab` is required=True in the CLI parser.
+    # `insert --tab` is no longer parser-required: a `doc` URL carrying
+    # `?tab=` satisfies it (cmd_insert errors at runtime when neither is
+    # given).
+    assert "tab" not in schema.get("required", [])
+    assert "doc" in schema["required"]
+
+
+def test_parser_required_flag_is_marked_required():
+    # No exposed command carries required=True on an option anymore, so pin
+    # the action.required derivation branch with a synthetic parser.
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("doc")
+    parser.add_argument("--tab", required=True)
+    schema = mcp._schema_for("insert", parser)
     assert "tab" in schema["required"]
 
 

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -263,3 +263,72 @@ class TestPullPlain:
         assert rc == 0
         out = capsys.readouterr().out
         assert f"path\t{f}" in out
+
+
+class TestPullUrlTab:
+    """pull ignores a URL tab but notes the discard on stderr."""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_drive_service")
+    @patch(
+        "gdoc.api.drive.get_file_info",
+        return_value={"name": "My Doc", "version": 42},
+    )
+    @patch("gdoc.api.drive.export_doc", return_value="# Hello\n")
+    @patch("gdoc.notify.pre_flight", return_value=ChangeInfo(current_version=42))
+    def test_non_t0_url_tab_notes_discard(
+        self, _pf, _export, _info, _drv, _update, tmp_path, capsys,
+    ):
+        f = tmp_path / "out.md"
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+        )
+        rc = cmd_pull(args)
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "NOTE" in err
+        assert "t.second" in err
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_drive_service")
+    @patch(
+        "gdoc.api.drive.get_file_info",
+        return_value={"name": "My Doc", "version": 42},
+    )
+    @patch("gdoc.api.drive.export_doc", return_value="# Hello\n")
+    @patch("gdoc.notify.pre_flight", return_value=ChangeInfo(current_version=42))
+    def test_t0_url_tab_is_silent(
+        self, _pf, _export, _info, _drv, _update, tmp_path, capsys,
+    ):
+        f = tmp_path / "out.md"
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.0",
+        )
+        rc = cmd_pull(args)
+        assert rc == 0
+        assert "NOTE" not in capsys.readouterr().err
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_drive_service")
+    @patch(
+        "gdoc.api.drive.get_file_info",
+        return_value={"name": "My Doc", "version": 42},
+    )
+    @patch("gdoc.api.drive.export_doc", return_value="# Hello\n")
+    @patch("gdoc.notify.pre_flight", return_value=ChangeInfo(current_version=42))
+    def test_quiet_suppresses_note(
+        self, _pf, _export, _info, _drv, _update, tmp_path, capsys,
+    ):
+        # --quiet is the established "be silent on stderr" switch; the
+        # tab-discard NOTE honors it like other stderr chatter.
+        f = tmp_path / "out.md"
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            quiet=True,
+        )
+        rc = cmd_pull(args)
+        assert rc == 0
+        assert "NOTE" not in capsys.readouterr().err

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -409,3 +409,49 @@ class TestPushCollapseSafety:
         # With the opt-in flag, no count lookup happens at all.
         mock_count.assert_not_called()
         mock_update.assert_called_once()
+
+
+class TestPushUrlTab:
+    """push ignores a URL tab in frontmatter but notes the discard."""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_drive_service")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.notify.pre_flight")
+    def test_non_t0_url_tab_notes_discard(
+        self, mock_pf, _update_doc, _drv, _update, tmp_path, capsys,
+    ):
+        f = tmp_path / "test.md"
+        f.write_text(
+            "---\n"
+            "gdoc: https://docs.google.com/document/d/abc123/edit?tab=t.second\n"
+            "title: My Doc\n"
+            "---\n# Hello\n"
+        )
+        mock_pf.return_value = ChangeInfo(current_version=10, last_read_version=10)
+        args = _make_args(file=str(f))
+        rc = cmd_push(args)
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "NOTE" in err
+        assert "t.second" in err
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_drive_service")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.notify.pre_flight")
+    def test_t0_url_tab_is_silent(
+        self, mock_pf, _update_doc, _drv, _update, tmp_path, capsys,
+    ):
+        f = tmp_path / "test.md"
+        f.write_text(
+            "---\n"
+            "gdoc: https://docs.google.com/document/d/abc123/edit?tab=t.0\n"
+            "title: My Doc\n"
+            "---\n# Hello\n"
+        )
+        mock_pf.return_value = ChangeInfo(current_version=10, last_read_version=10)
+        args = _make_args(file=str(f))
+        rc = cmd_push(args)
+        assert rc == 0
+        assert "NOTE" not in capsys.readouterr().err

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -18,6 +18,7 @@ class TestDocState:
         assert s.last_comment_check == ""
         assert s.known_comment_ids == []
         assert s.known_resolved_ids == []
+        assert s.tab_read_versions == {}
 
     def test_custom_values(self):
         s = DocState(
@@ -264,6 +265,65 @@ class TestUpdateStateAfterCommand:
             state = load_state("doc1")
             assert state.last_version == 11
             assert state.last_read_version == 5
+
+    def test_tab_read_stamps_tab_version_not_global(self, tmp_path):
+        """cat --tab X stamps that tab's baseline, never last_read_version."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            info = self._make_change_info(current_version=100)
+            update_state_after_command(
+                "doc1", info, command="cat", quiet=False, read_tab_id="t.x",
+            )
+            state = load_state("doc1")
+            assert state.tab_read_versions == {"t.x": 100}
+            assert state.last_read_version is None  # NOT a whole-doc read
+            assert state.last_version == 100  # we did observe the version
+
+    def test_tab_read_preserves_prior_global_baseline(self, tmp_path):
+        """A tab read must not disturb a global baseline set by an earlier
+        whole-doc cat."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(last_read_version=50))
+            info = self._make_change_info(current_version=100)
+            update_state_after_command(
+                "doc1", info, command="cat", quiet=False, read_tab_id="t.x",
+            )
+            state = load_state("doc1")
+            assert state.last_read_version == 50  # untouched
+            assert state.tab_read_versions == {"t.x": 100}
+
+    def test_tab_write_stamps_tab_version(self, tmp_path):
+        """write --tab X advances that tab's baseline to the post-write
+        version so a second write to the same tab doesn't false-conflict."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(last_read_version=5))
+            update_state_after_command(
+                "doc1", None, command="write", quiet=True,
+                command_version=11, full_doc_write=False, written_tab_id="t.x",
+            )
+            state = load_state("doc1")
+            assert state.tab_read_versions == {"t.x": 11}
+            assert state.last_read_version == 5  # global still untouched
+
+    def test_quiet_tab_read_stamps_nothing(self, tmp_path):
+        """A --quiet tab read has no version in hand, so it stamps nothing."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "doc1", None, command="cat", quiet=True, read_tab_id="t.x",
+            )
+            state = load_state("doc1")
+            assert state.tab_read_versions == {}
+
+    def test_old_state_file_loads_with_empty_tab_versions(self, tmp_path):
+        """A state file written before per-tab baselines loads cleanly."""
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            path = tmp_path / "doc1.json"
+            path.write_text(json.dumps({
+                "last_seen": "2025-01-20T00:00:00Z",
+                "last_read_version": 7,
+            }))
+            state = load_state("doc1")
+            assert state.tab_read_versions == {}
+            assert state.last_read_version == 7
 
     def test_edit_does_not_advance_read_baseline(self, tmp_path):
         """Partial mutations (find/replace) don't establish full-content
@@ -531,3 +591,41 @@ class TestCommentStatePatch:
             )
             state = load_state("doc1")
             assert state.last_comment_check == "2025-01-20T00:00:00Z"
+
+
+class TestMetadataOnlyTabHealing:
+    """Metadata-only bumps (mv/rename) carry per-tab baselines forward
+    when the post-op version is attributable to our own bump."""
+
+    def test_current_tab_entries_heal(self, tmp_path):
+        from gdoc.notify import ChangeInfo
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(
+                last_version=100,
+                tab_read_versions={"t.a": 100, "t.b": 90},
+            ))
+            info = ChangeInfo(current_version=100)
+            update_state_after_command(
+                "doc1", info, command="mv", quiet=False,
+                command_version=101, metadata_only_write=True,
+            )
+            st = load_state("doc1")
+            # Entry current at pre-flight heals; the stale one must not.
+            assert st.tab_read_versions == {"t.a": 101, "t.b": 90}
+
+    def test_unattributable_bump_leaves_tab_entries(self, tmp_path):
+        from gdoc.notify import ChangeInfo
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("doc1", DocState(
+                last_version=100, tab_read_versions={"t.a": 100},
+            ))
+            info = ChangeInfo(current_version=100)
+            # +2 jump: a concurrent edit slipped in; nothing heals.
+            update_state_after_command(
+                "doc1", info, command="mv", quiet=False,
+                command_version=102, metadata_only_write=True,
+            )
+            st = load_state("doc1")
+            assert st.tab_read_versions == {"t.a": 100}

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -199,3 +199,83 @@ class TestCmdStructure:
                 cmd_structure(args)
             assert e.value.exit_code == 3
         mock_get.assert_not_called()
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.docs.get_document_structure", return_value=_DOC)
+class TestStructureUrlTab:
+    def test_url_tab_narrows_output(self, mock_get, _update, capsys):
+        args = _make_args(
+            doc="https://docs.google.com/document/d/doc123/edit?tab=t2",
+        )
+        cmd_structure(args)
+        data = json.loads(capsys.readouterr().out)
+        assert data["tab"]["tabProperties"]["tabId"] == "t2"
+        assert "tabs" not in data
+
+    def test_flag_overrides_url_tab(self, mock_get, _update, capsys):
+        args = _make_args(
+            doc="https://docs.google.com/document/d/doc123/edit?tab=t2",
+            tab="Main",
+        )
+        cmd_structure(args)
+        data = json.loads(capsys.readouterr().out)
+        assert data["tab"]["tabProperties"]["tabId"] == "t1"
+
+    def test_t0_url_tab_ignored(self, mock_get, _update, capsys):
+        # Google auto-appends ?tab=t.0 — ambient noise, whole doc returned.
+        args = _make_args(
+            doc="https://docs.google.com/document/d/doc123/edit?tab=t.0",
+        )
+        cmd_structure(args)
+        assert json.loads(capsys.readouterr().out) == _DOC
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.docs.get_document_structure", return_value=_DOC)
+class TestStructureTabBaseline:
+    def test_multi_tab_read_stamps_tab_baseline(self, mock_get, mock_update):
+        args = _make_args(tab="Notes")
+        cmd_structure(args)
+        assert mock_update.call_args.kwargs["read_tab_id"] == "t2"
+
+    def test_whole_doc_read_keeps_global_baseline(self, mock_get, mock_update):
+        args = _make_args()
+        cmd_structure(args)
+        assert mock_update.call_args.kwargs["read_tab_id"] is None
+
+    def test_single_tab_read_is_whole_doc(self, mock_get, mock_update):
+        # One tab IS the whole document (same rule as `cat --tab`).
+        mock_get.return_value = {
+            "documentId": "doc123",
+            "tabs": [_tab("t1", "Main")],
+        }
+        args = _make_args(tab="Main")
+        cmd_structure(args)
+        assert mock_update.call_args.kwargs["read_tab_id"] is None
+
+
+@patch("gdoc.state.update_state_after_command")
+@patch("gdoc.api.docs.get_document_structure", return_value=_DOC)
+class TestStructureFieldsBaseline:
+    """F1: a --fields-masked response can't prove a full read, so it must
+    not advance any read baseline (global or per-tab)."""
+
+    def test_fields_read_is_partial(self, mock_get, mock_update):
+        args = _make_args(fields="tabs(tabProperties)")
+        cmd_structure(args)
+        kw = mock_update.call_args.kwargs
+        assert kw["command"] == "structure-partial"
+        assert kw.get("read_tab_id") is None
+
+    def test_fields_with_tab_stamps_nothing(self, mock_get, mock_update):
+        args = _make_args(tab="Notes", fields="tabs(tabProperties),revisionId")
+        cmd_structure(args)
+        kw = mock_update.call_args.kwargs
+        assert kw["command"] == "structure-partial"
+        assert kw.get("read_tab_id") is None
+
+    def test_unmasked_read_still_counts(self, mock_get, mock_update):
+        args = _make_args()
+        cmd_structure(args)
+        assert mock_update.call_args.kwargs["command"] == "structure"

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1390,6 +1390,42 @@ class TestCmdSuggest:
         assert call.args[1] == [{"startIndex": 5, "endIndex": 10}]
         assert call.kwargs["tab_id"] == "t.draft"
 
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_url_tab_targets_that_tab(
+        self, _pf, mock_doc, mock_sug, _ver, _state,
+    ):
+        # A doc URL's ?tab= drives suggest like --tab does.
+        mock_doc.return_value = _structure(tabs=[
+            ("t.first", "Tab 1", _body(_para(_run("nothing here\n", 1, 14)))),
+            ("t.draft", "Draft", _body(_para(_run("say hello\n", 1, 11)))),
+        ])
+        cmd_suggest(_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.draft",
+        ))
+        call = mock_sug.call_args
+        assert call.args[1] == [{"startIndex": 5, "endIndex": 10}]
+        assert call.kwargs["tab_id"] == "t.draft"
+
+    @patch("gdoc.api.docs._token_identity", return_value=("cid.apps", "rt1"))
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value=_VERSION)
+    @patch("gdoc.api.docs.suggest_replacement", return_value=_result())
+    @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    def test_url_t0_is_ambient_noise_targets_first_tab(
+        self, _pf, mock_doc, mock_sug, _ver, _state, _tid,
+    ):
+        # ?tab=t.0 is the editor's ambient default -> first tab, as with
+        # a bare URL.
+        cmd_suggest(_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.0",
+        ))
+        assert mock_sug.call_args.kwargs["tab_id"] == "t.first"
+
     @patch("gdoc.api.docs.suggest_replacement")
     @patch("gdoc.api.docs.get_document_structure", return_value=_structure())
     @patch("gdoc.notify.pre_flight", return_value=None)

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -208,6 +208,43 @@ class TestTocTab:
         with pytest.raises(GdocError, match="tab not found"):
             cmd_toc(_make_args(tab="nope"))
 
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.resolve_tab")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_url_tab_selects_tab(
+        self, _svc, mock_tabs, mock_resolve, mock_headings, _pf, _update, capsys,
+    ):
+        # A ?tab= in the URL selects that tab, exactly like --tab.
+        tab = {"id": "t.o50waw95wxfc", "title": "Notes", "body": {"content": []}}
+        mock_tabs.return_value = [tab]
+        mock_resolve.return_value = tab
+        mock_headings.return_value = _headings((1, "h.abc", "Title"))
+        rc = cmd_toc(_make_args(doc=f"{BASE_URL}?tab=t.o50waw95wxfc"))
+        assert rc == 0
+        mock_resolve.assert_called_once_with([tab], "t.o50waw95wxfc")
+        mock_headings.assert_called_once_with(DOC_ID, body=tab["body"])
+        out = capsys.readouterr().out
+        assert f"{BASE_URL}?tab=t.o50waw95wxfc#heading=h.abc" in out
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.docs.get_document_headings")
+    @patch("gdoc.api.docs.get_document_tabs")
+    @patch("gdoc.api.docs.get_docs_service")
+    def test_url_tab_t0_uses_whole_doc(
+        self, _svc, mock_tabs, mock_headings, _pf, _update, capsys,
+    ):
+        # ?tab=t.0 is ambient noise: fall through to the whole-doc path,
+        # never touching per-tab resolution.
+        mock_headings.return_value = _headings((1, "h.abc", "Title"))
+        rc = cmd_toc(_make_args(doc=f"{BASE_URL}?tab=t.0"))
+        assert rc == 0
+        mock_tabs.assert_not_called()
+        mock_headings.assert_called_once_with(DOC_ID, body=None)
+
 
 class TestTocAwareness:
     @patch("gdoc.state.update_state_after_command")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -117,6 +117,22 @@ class TestExtractDocRef:
         url = "https://docs.google.com/document/d/1aBcDeFg/edit?subtab=t.9"
         assert extract_doc_ref(url) == ("1aBcDeFg", None)
 
+    def test_html_escaped_separator_still_finds_tab(self):
+        # A URL copied out of rendered HTML keeps "&amp;" as the separator.
+        # Missing the tab there is not a no-op: the caller silently falls
+        # back to the whole-doc path and edits outside the intended tab.
+        url = (
+            "https://docs.google.com/document/d/1aBcDeFg/edit"
+            "?usp=sharing&amp;tab=t.xyz"
+        )
+        assert extract_doc_ref(url) == ("1aBcDeFg", "t.xyz")
+
+    def test_escaped_separator_does_not_relax_the_name_anchor(self):
+        # The &amp; alternative must not become a wildcard: a param whose
+        # name merely ends in "tab" is still rejected.
+        url = "https://docs.google.com/document/d/1aBcDeFg/edit?a=1&amp;subtab=t.9"
+        assert extract_doc_ref(url) == ("1aBcDeFg", None)
+
     def test_bare_id_has_no_tab(self):
         assert extract_doc_ref("1aBcDeFgHiJkLmNoPqRsTuVwXyZ") == (
             "1aBcDeFgHiJkLmNoPqRsTuVwXyZ",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,6 +10,7 @@ from gdoc.util import (
     build_doc_url,
     confirm_destructive,
     extract_doc_id,
+    extract_doc_ref,
 )
 
 
@@ -81,6 +82,54 @@ class TestExtractDocId:
     def test_folder_url_with_params(self):
         url = "https://drive.google.com/drive/folders/abc123?usp=sharing"
         assert extract_doc_id(url) == "abc123"
+
+
+class TestExtractDocRef:
+    def test_no_tab_param(self):
+        url = "https://docs.google.com/document/d/1aBcDeFg/edit"
+        assert extract_doc_ref(url) == ("1aBcDeFg", None)
+
+    def test_tab_t0(self):
+        url = "https://docs.google.com/document/d/1aBcDeFg/edit?tab=t.0"
+        assert extract_doc_ref(url) == ("1aBcDeFg", "t.0")
+
+    def test_tab_non_t0(self):
+        url = "https://docs.google.com/document/d/1aBcDeFg/edit?tab=t.abc123"
+        assert extract_doc_ref(url) == ("1aBcDeFg", "t.abc123")
+
+    def test_tab_with_fragment(self):
+        url = (
+            "https://docs.google.com/document/d/1aBcDeFg/edit"
+            "?tab=t.xyz#heading=h.abc"
+        )
+        assert extract_doc_ref(url) == ("1aBcDeFg", "t.xyz")
+
+    def test_tab_as_second_query_param(self):
+        url = (
+            "https://docs.google.com/document/d/1aBcDeFg/edit"
+            "?usp=sharing&tab=t.xyz"
+        )
+        assert extract_doc_ref(url) == ("1aBcDeFg", "t.xyz")
+
+    def test_tab_suffixed_param_name_does_not_match(self):
+        # The [?&] anchor means a param whose *name* ends in "tab"
+        # (e.g. subtab=) must NOT be read as the tab id.
+        url = "https://docs.google.com/document/d/1aBcDeFg/edit?subtab=t.9"
+        assert extract_doc_ref(url) == ("1aBcDeFg", None)
+
+    def test_bare_id_has_no_tab(self):
+        assert extract_doc_ref("1aBcDeFgHiJkLmNoPqRsTuVwXyZ") == (
+            "1aBcDeFgHiJkLmNoPqRsTuVwXyZ",
+            None,
+        )
+
+    def test_folder_url_has_no_tab(self):
+        url = "https://drive.google.com/drive/folders/abc123?usp=sharing"
+        assert extract_doc_ref(url) == ("abc123", None)
+
+    def test_invalid_url_raises(self):
+        with pytest.raises(ValueError, match="Cannot extract"):
+            extract_doc_ref("https://example.com/not-a-doc")
 
 
 class TestErrorClasses:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -13,6 +13,30 @@ from gdoc.state import DocState
 from gdoc.util import AuthError, GdocError
 
 
+def _doc_with_tabs(*tabs):
+    """Build a get_document_with_tabs() response for the given tabs.
+
+    Each arg is an ``(id, title)`` pair. cmd_write's per-tab branch fetches
+    this doc, flattens it, and resolves the requested tab against it before
+    the conflict check — so a tab-write test must supply a matching tab here.
+    """
+    return {
+        "revisionId": "rev1",
+        "tabs": [
+            {
+                "tabProperties": {"tabId": tid, "title": title, "index": i},
+                "documentTab": {"body": {"content": []}},
+            }
+            for i, (tid, title) in enumerate(tabs)
+        ],
+    }
+
+
+def _read_state(version=11):
+    """State proving a whole-doc read at `version` (0.20 provenance)."""
+    return DocState(last_read_version=version, global_read_covers_doc=True)
+
+
 def _make_args(**overrides):
     """Build a SimpleNamespace mimicking parsed write args.
 
@@ -50,6 +74,21 @@ def _stub_single_tab():
     the duration of the test.
     """
     with patch("gdoc.api.docs.count_document_tabs", return_value=1):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_dir(tmp_path_factory):
+    """Point per-doc state at a throwaway dir for the whole module.
+
+    The non-quiet `write --tab` conflict check now calls the real
+    `load_state(doc_id)` (for the per-tab baseline), so tests that don't
+    mock `gdoc.state` would otherwise read the developer's real
+    ~/.config/gdoc/state/<doc_id>.json and could flip on a stray file.
+    Isolating STATE_DIR keeps them hermetic; tests that patch
+    `gdoc.state.load_state` directly are unaffected.
+    """
+    with patch("gdoc.state.STATE_DIR", tmp_path_factory.mktemp("state")):
         yield
 
 
@@ -293,19 +332,27 @@ class TestWriteInSync:
         assert mock_state.call_args.kwargs["command_version"] == 12
         assert mock_state.call_args.kwargs["command"] == "write"
 
+    @patch("gdoc.api.docs.get_document_with_tabs")
     @patch("gdoc.api.drive.export_doc", return_value="content")
     @patch("gdoc.api.docs.insert_markdown_into_tab")
     @patch("gdoc.notify.pre_flight")
     def test_write_tab_conflict_not_rescued_by_content_match(
-        self, mock_pf, mock_insert, mock_export, tmp_path,
+        self, mock_pf, mock_insert, mock_export, mock_doc, tmp_path,
     ):
-        """Tab writes never compare content — a tab body isn't the full doc."""
+        """Tab writes never compare content — a tab body isn't the full doc,
+        so a version mismatch conflicts instead of an in-sync rescue."""
         f = tmp_path / "test.md"
         f.write_text("content")
+        mock_doc.return_value = _doc_with_tabs(("t.notes", "Notes"))
         mock_pf.return_value = ChangeInfo(current_version=12, last_read_version=5)
         args = _make_args(file=str(f), tab="Notes")
-        with pytest.raises(GdocError, match="doc changed since last read"):
-            cmd_write(args)
+        with patch("gdoc.state.load_state", return_value=_read_state(5)), \
+             patch("gdoc.api.drive.get_file_version",
+                   return_value={"version": 12}):
+            with pytest.raises(
+                GdocError, match="may have changed since last read",
+            ):
+                cmd_write(args)
         mock_export.assert_not_called()
         mock_insert.assert_not_called()
 
@@ -753,17 +800,22 @@ class TestWriteCollapseSafety:
 class TestWriteTabScoped:
     """--tab NAME writes only to that tab via Docs API."""
 
+    @patch("gdoc.api.docs.get_document_with_tabs")
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab")
     @patch("gdoc.notify.pre_flight")
     def test_forced_tab_write_does_not_claim_full_read(
-        self, mock_pf, mock_insert, _ver, mock_state, tmp_path,
+        self, mock_pf, mock_insert, _ver, mock_state, mock_doc, tmp_path,
     ):
         """A forced tab write bypasses the conflict check and touches one
-        tab — it must not advance the whole-doc read baseline."""
+        tab — it must not advance the whole-doc read baseline, and it stamps
+        the tab's own baseline instead."""
         f = tmp_path / "doc.md"
         f.write_text("body")
+        # Two tabs: a sole-tab write would legitimately count as a
+        # whole-doc write under the single-tab rule.
+        mock_doc.return_value = _doc_with_tabs(("t.a", "A"), ("t.b", "B"))
         mock_pf.return_value = ChangeInfo(
             current_version=10, last_read_version=5,
         )
@@ -774,16 +826,21 @@ class TestWriteTabScoped:
         rc = cmd_write(args)
         assert rc == 0
         assert mock_state.call_args.kwargs["full_doc_write"] is False
+        assert mock_state.call_args.kwargs["written_tab_id"] == "t.a"
 
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch("gdoc.api.docs.get_document_with_tabs")
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab")
     @patch("gdoc.notify.pre_flight")
     def test_tab_scoped_uses_docs_api(
-        self, mock_pf, mock_insert, _ver, _update, tmp_path,
+        self, mock_pf, mock_insert, _ver, _update, mock_doc, _state,
+        tmp_path,
     ):
         f = tmp_path / "doc.md"
         f.write_text("# New body\n")
+        mock_doc.return_value = _doc_with_tabs(("t.todo", "TODO for Mark"))
         mock_pf.return_value = ChangeInfo(
             current_version=10, last_read_version=10,
         )
@@ -795,10 +852,14 @@ class TestWriteTabScoped:
         args = _make_args(file=str(f), tab="TODO for Mark")
         rc = cmd_write(args)
         assert rc == 0
+        # The pre-fetched doc is threaded through so it isn't fetched twice.
         mock_insert.assert_called_once_with(
             "abc123", "TODO for Mark", "# New body\n", replace=True,
+            doc=mock_doc.return_value,
         )
 
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch("gdoc.api.docs.get_document_with_tabs")
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.drive.update_doc_content")
@@ -807,10 +868,11 @@ class TestWriteTabScoped:
     @patch("gdoc.notify.pre_flight")
     def test_tab_scoped_does_not_touch_drive(
         self, mock_pf, mock_insert, mock_tabs, mock_update_doc, _ver,
-        _update, tmp_path,
+        _update, mock_doc, _state, tmp_path,
     ):
         f = tmp_path / "doc.md"
         f.write_text("body")
+        mock_doc.return_value = _doc_with_tabs(("t.todo", "TODO"))
         mock_pf.return_value = ChangeInfo(
             current_version=10, last_read_version=10,
         )
@@ -824,17 +886,21 @@ class TestWriteTabScoped:
         # --tab writes must not invoke it.
         mock_tabs.assert_not_called()
 
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch("gdoc.api.docs.get_document_with_tabs")
     @patch("gdoc.state.update_state_after_command")
     @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
     @patch("gdoc.api.docs.insert_markdown_into_tab")
     @patch("gdoc.notify.pre_flight")
     def test_tab_scoped_strips_frontmatter(
-        self, mock_pf, mock_insert, _ver, _update, tmp_path,
+        self, mock_pf, mock_insert, _ver, _update, mock_doc, _state,
+        tmp_path,
     ):
         f = tmp_path / "doc.md"
         f.write_text(
             "---\ngdoc: abc123\n---\n# Real body\n",
         )
+        mock_doc.return_value = _doc_with_tabs(("t.a", "A"))
         mock_pf.return_value = ChangeInfo(
             current_version=10, last_read_version=10,
         )
@@ -846,3 +912,73 @@ class TestWriteTabScoped:
         uploaded = mock_insert.call_args.args[2]
         assert "---" not in uploaded
         assert uploaded.startswith("# Real body")
+
+
+class TestWriteUrlTab:
+    """A ?tab= in the document URL drives the per-tab write path."""
+
+    @patch("gdoc.state.load_state", return_value=_read_state())
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 11})
+    @patch("gdoc.api.drive.update_doc_content")
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.notify.pre_flight")
+    def test_url_tab_writes_single_tab(
+        self, mock_pf, mock_insert, mock_update_doc, _ver, mock_state,
+        mock_doc, _lstate, tmp_path,
+    ):
+        f = tmp_path / "doc.md"
+        f.write_text("# New body\n")
+        mock_doc.return_value = _doc_with_tabs(
+            ("t.second", "Second"), ("t.first", "First"),
+        )
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        mock_insert.return_value = {
+            "tab_id": "t.second", "tab_title": "Second", "insert_index": 1,
+        }
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+        )
+        rc = cmd_write(args)
+        assert rc == 0
+        mock_insert.assert_called_once_with(
+            "abc123", "t.second", "# New body\n", replace=True,
+            doc=mock_doc.return_value,
+        )
+        mock_update_doc.assert_not_called()
+        assert mock_state.call_args.kwargs["full_doc_write"] is False
+        assert mock_state.call_args.kwargs["written_tab_id"] == "t.second"
+
+    def test_url_tab_and_force_collapse_conflict(self, tmp_path):
+        args = _make_args(
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            force_collapse_tabs=True,
+            quiet=True,
+        )
+        with pytest.raises(GdocError, match="URL targets tab") as exc:
+            cmd_write(args)
+        assert exc.value.exit_code == 3
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.update_doc_content", return_value=42)
+    @patch("gdoc.notify.pre_flight")
+    def test_url_tab_t0_uses_whole_doc(
+        self, mock_pf, mock_update_doc, _update, tmp_path,
+    ):
+        """?tab=t.0 is ambient noise: whole-doc write, collapse guard intact."""
+        f = tmp_path / "doc.md"
+        f.write_text("content")
+        mock_pf.return_value = ChangeInfo(
+            current_version=10, last_read_version=10,
+        )
+        args = _make_args(
+            file=str(f),
+            doc="https://docs.google.com/document/d/abc123/edit?tab=t.0",
+        )
+        rc = cmd_write(args)
+        assert rc == 0
+        mock_update_doc.assert_called_once()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -11,30 +11,8 @@ from gdoc.cli import cmd_write
 from gdoc.notify import ChangeInfo
 from gdoc.state import DocState
 from gdoc.util import AuthError, GdocError
-
-
-def _doc_with_tabs(*tabs):
-    """Build a get_document_with_tabs() response for the given tabs.
-
-    Each arg is an ``(id, title)`` pair. cmd_write's per-tab branch fetches
-    this doc, flattens it, and resolves the requested tab against it before
-    the conflict check — so a tab-write test must supply a matching tab here.
-    """
-    return {
-        "revisionId": "rev1",
-        "tabs": [
-            {
-                "tabProperties": {"tabId": tid, "title": title, "index": i},
-                "documentTab": {"body": {"content": []}},
-            }
-            for i, (tid, title) in enumerate(tabs)
-        ],
-    }
-
-
-def _read_state(version=11):
-    """State proving a whole-doc read at `version` (0.20 provenance)."""
-    return DocState(last_read_version=version, global_read_covers_doc=True)
+from tests.conftest import doc_with_tabs as _doc_with_tabs
+from tests.conftest import whole_doc_read_state as _read_state
 
 
 def _make_args(**overrides):

--- a/tests/test_write_tab_baselines.py
+++ b/tests/test_write_tab_baselines.py
@@ -1,0 +1,531 @@
+"""Per-tab write-conflict baselines (0.14.0).
+
+The lenient effective-baseline rule: a `write --tab X` is allowed when
+max(whole-doc last_read_version, tab_read_versions[X]) equals the current doc
+version. These tests cover the two defects per-tab state fixes — the
+cross-tab false negative (read tab A, write tab B) and the same-tab false
+positive (write tab X twice) — plus the sibling-edit conservatism and the
+--force escape, at both the end-to-end (real state) and decision layers.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gdoc.cli import cmd_cat, cmd_write
+from gdoc.notify import ChangeInfo
+from gdoc.state import DocState, load_state, save_state
+from gdoc.util import GdocError
+
+DOC_MIME = "application/vnd.google-apps.document"
+
+
+def _tab_dict(tab_id, title):
+    return {
+        "id": tab_id, "title": title, "index": 0,
+        "nesting_level": 0, "body": {"content": []},
+    }
+
+
+def _doc_with_tabs(*pairs):
+    """A get_document_with_tabs() response for the given (id, title) pairs."""
+    return {
+        "revisionId": "rev1",
+        "tabs": [
+            {
+                "tabProperties": {"tabId": tid, "title": title, "index": i},
+                "documentTab": {"body": {"content": []}},
+            }
+            for i, (tid, title) in enumerate(pairs)
+        ],
+    }
+
+
+def _cat_args(doc, tab):
+    return SimpleNamespace(
+        command="cat", doc=doc, plain=False, comments=False, all=False,
+        tab=tab, all_tabs=False, no_images=False, json=False, verbose=False,
+        quiet=False, revision=None, range=None, max_bytes=0,
+    )
+
+
+def _write_args(doc, tab, file, **over):
+    d = dict(
+        command="write", doc=doc, file=file, force=False, json=False,
+        verbose=False, quiet=True, tab=tab, force_collapse_tabs=False,
+    )
+    d.update(over)
+    return SimpleNamespace(**d)
+
+
+def _run_cat_tab(doc, tab_title, tab_id, version):
+    """Run `gdoc cat --tab TITLE` non-quiet against a MULTI-tab doc; persists
+    state under the caller's STATE_DIR patch. Stamps tab_read_versions[tab_id]
+    = version. The mock carries a sibling tab on purpose: on a single-tab doc a
+    `--tab` read would instead advance the whole-doc baseline."""
+    change_info = ChangeInfo(current_version=version, mime_type=DOC_MIME)
+    with patch("gdoc.notify.pre_flight", return_value=change_info), \
+         patch("gdoc.api.docs.get_document_tabs",
+               return_value=[
+                   _tab_dict(tab_id, tab_title),
+                   _tab_dict("t.sibling", "Sibling"),
+               ]), \
+         patch("gdoc.api.docs.get_tab_text", return_value="body\n"), \
+         patch("gdoc.api.docs.get_docs_service"):
+        assert cmd_cat(_cat_args(doc, tab_title)) == 0
+
+
+class TestTabBaselineWorkflow:
+    """End-to-end read -> write cycles against real (tmp) state, so the tab id
+    cat stamps is exactly the key write checks."""
+
+    def test_write_same_tab_twice_both_succeed(self, tmp_path):
+        """False-positive fix: the writer's own output advances the tab
+        baseline, so a second write to the same tab isn't blocked."""
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            _run_cat_tab("abc123", "X", "t.x", 100)
+            st = load_state("abc123")
+            assert st.last_read_version is None  # tab read, not whole-doc
+            assert st.tab_read_versions == {"t.x": 100}
+
+            # Model the doc version advancing on each (mocked) write.
+            doc_version = [100]
+
+            def fake_ver(doc_id):
+                return {"version": doc_version[0]}
+
+            def fake_insert(*a, **k):
+                doc_version[0] += 1
+                return {"tab_id": "t.x", "tab_title": "X", "insert_index": 1}
+
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.x", "X"),
+                                                   ("t.y", "Y"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab",
+                       side_effect=fake_insert), \
+                 patch("gdoc.api.drive.get_file_version", side_effect=fake_ver):
+                assert cmd_write(_write_args("abc123", "X", str(f))) == 0
+                assert cmd_write(_write_args("abc123", "X", str(f))) == 0
+
+            st = load_state("abc123")
+            assert st.tab_read_versions["t.x"] == doc_version[0]
+            assert st.last_read_version is None  # never became a whole-doc read
+
+    def test_read_tab_a_then_write_tab_b_blocked(self, tmp_path):
+        """False-negative fix: reading tab A gives no baseline for tab B."""
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            _run_cat_tab("abc123", "A", "t.a", 100)
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.a", "A"), ("t.b", "B"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab") as mock_insert, \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 100}):
+                with pytest.raises(
+                    GdocError, match="no read baseline for tab 'B'",
+                ) as exc:
+                    cmd_write(_write_args("abc123", "B", str(f)))
+                assert exc.value.exit_code == 3
+                mock_insert.assert_not_called()
+
+    def test_plain_cat_then_write_tab_succeeds(self, tmp_path):
+        """Lenient rule: a whole-doc cat is a genuine read of every tab, so
+        its global baseline covers a subsequent tab write."""
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            change_info = ChangeInfo(current_version=100, mime_type=DOC_MIME)
+            with patch("gdoc.notify.pre_flight", return_value=change_info), \
+                 patch("gdoc.api.drive.export_doc", return_value="whole\n"):
+                assert cmd_cat(_cat_args("abc123", None)) == 0
+            assert load_state("abc123").last_read_version == 100
+
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.b", "B"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab",
+                       return_value={"tab_id": "t.b", "tab_title": "B",
+                                     "insert_index": 1}), \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 100}):
+                assert cmd_write(_write_args("abc123", "B", str(f))) == 0
+
+    def test_single_tab_cat_then_whole_doc_write_succeeds(self, tmp_path):
+        """R1 fix: on a single-tab doc, `cat --tab X` reads the whole document,
+        so it advances the whole-doc baseline and a following whole-document
+        `write DOC` is not blocked. (When tab reads stopped advancing the
+        global baseline, this briefly errored 'no read baseline'.)"""
+        f = tmp_path / "body.md"
+        f.write_text("# edited\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            # Single-tab cat --tab is a whole-doc read: advances last_read.
+            change_info = ChangeInfo(current_version=100, mime_type=DOC_MIME)
+            with patch("gdoc.notify.pre_flight", return_value=change_info), \
+                 patch("gdoc.api.docs.get_document_tabs",
+                       return_value=[_tab_dict("t.only", "Only")]), \
+                 patch("gdoc.api.docs.get_tab_text", return_value="body\n"), \
+                 patch("gdoc.api.docs.get_docs_service"):
+                assert cmd_cat(_cat_args("abc123", "Only")) == 0
+            st = load_state("abc123")
+            assert st.last_read_version == 100
+            assert st.tab_read_versions == {}  # not a per-tab stamp
+
+            # Whole-doc write at the same version passes on that baseline.
+            with patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 100}), \
+                 patch("gdoc.api.docs.count_document_tabs", return_value=1), \
+                 patch("gdoc.api.drive.update_doc_content", return_value=101):
+                assert cmd_write(_write_args("abc123", None, str(f))) == 0
+
+
+class TestTabBaselineDecision:
+    """Focused conflict decisions with an injected state, pinning the sibling
+    -edit conservatism, its message, and the --force escape."""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 101})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.state.load_state")
+    @patch("gdoc.notify.pre_flight")
+    def test_sibling_edit_blocks_tab_write(
+        self, mock_pf, mock_load, mock_doc, mock_insert, _ver, _upd, tmp_path,
+    ):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        # Tab X read at v100; the doc has since moved to v101 (a sibling edit).
+        mock_load.return_value = DocState(
+            last_read_version=None, tab_read_versions={"t.x": 100},
+        )
+        mock_pf.return_value = ChangeInfo(
+            current_version=101, last_read_version=None,
+        )
+        mock_doc.return_value = _doc_with_tabs(("t.x", "X"))
+        with pytest.raises(
+            GdocError, match=r"tab 'X' may have changed .*v100 -> v101",
+        ) as exc:
+            cmd_write(_write_args("abc123", "X", str(f), quiet=False))
+        assert exc.value.exit_code == 3
+        mock_insert.assert_not_called()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 100})
+    @patch("gdoc.api.docs.insert_markdown_into_tab",
+           return_value={"tab_id": "t.x", "tab_title": "X", "insert_index": 1})
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.state.load_state")
+    @patch("gdoc.notify.pre_flight")
+    def test_nonquiet_write_succeeds_on_own_tab_baseline(
+        self, mock_pf, mock_load, mock_doc, mock_insert, _ver, _upd, tmp_path,
+    ):
+        """Non-quiet flagship happy path: with no whole-doc baseline, tab X
+        read at v100 and the doc still at v100, `write --tab X` succeeds — the
+        per-tab entry alone satisfies the guard. The non-quiet branch sources
+        the global part from pre_flight (None here) and the per-tab part from
+        state, so this locks that split, which the quiet success tests don't."""
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        mock_load.return_value = DocState(
+            last_read_version=None, tab_read_versions={"t.x": 100},
+        )
+        mock_pf.return_value = ChangeInfo(
+            current_version=100, last_read_version=None,
+        )
+        mock_doc.return_value = _doc_with_tabs(("t.x", "X"))
+        rc = cmd_write(_write_args("abc123", "X", str(f), quiet=False))
+        assert rc == 0
+        mock_insert.assert_called_once()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 101})
+    @patch("gdoc.api.docs.insert_markdown_into_tab",
+           return_value={"tab_id": "t.x", "tab_title": "X", "insert_index": 1})
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.state.load_state")
+    @patch("gdoc.notify.pre_flight")
+    def test_force_bypasses_sibling_edit(
+        self, mock_pf, mock_load, mock_doc, mock_insert, _ver, _upd, tmp_path,
+    ):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        mock_load.return_value = DocState(
+            last_read_version=None, tab_read_versions={"t.x": 100},
+        )
+        mock_pf.return_value = ChangeInfo(
+            current_version=101, last_read_version=None,
+        )
+        mock_doc.return_value = _doc_with_tabs(("t.x", "X"))
+        rc = cmd_write(_write_args("abc123", "X", str(f), quiet=False, force=True))
+        assert rc == 0
+        mock_insert.assert_called_once()
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 101})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.state.load_state")
+    def test_quiet_sibling_edit_blocks_tab_write(
+        self, mock_load, mock_doc, mock_insert, _ver, _upd, tmp_path,
+    ):
+        """The --quiet path reads the same per-tab baseline from state."""
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        mock_load.return_value = DocState(
+            last_read_version=None, tab_read_versions={"t.x": 100},
+        )
+        mock_doc.return_value = _doc_with_tabs(("t.x", "X"))
+        with pytest.raises(
+            GdocError, match=r"tab 'X' may have changed .*v100 -> v101",
+        ) as exc:
+            cmd_write(_write_args("abc123", "X", str(f), quiet=True))
+        assert exc.value.exit_code == 3
+        mock_insert.assert_not_called()
+
+
+class TestTabBaselineUrlParity:
+    """A ?tab= URL drives the same per-tab conflict check as --tab."""
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.api.drive.get_file_version", return_value={"version": 100})
+    @patch("gdoc.api.docs.insert_markdown_into_tab")
+    @patch("gdoc.api.docs.get_document_with_tabs")
+    @patch("gdoc.state.load_state")
+    def test_url_tab_blocked_without_baseline(
+        self, mock_load, mock_doc, mock_insert, _ver, _upd, tmp_path,
+    ):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        mock_load.return_value = None  # no prior read of anything
+        mock_doc.return_value = _doc_with_tabs(("t.second", "Second"))
+        args = _write_args(
+            "https://docs.google.com/document/d/abc123/edit?tab=t.second",
+            None, str(f), quiet=True,
+        )
+        with pytest.raises(
+            GdocError, match="no read baseline for tab 't.second'",
+        ) as exc:
+            cmd_write(args)
+        assert exc.value.exit_code == 3
+        mock_insert.assert_not_called()
+        # With no baseline the write is rejected regardless of version, so
+        # the quiet path must not spend a get_file_version call to learn it.
+        _ver.assert_not_called()
+
+
+class TestLegacyBaselineProvenance:
+    """F18: a pre-0.20 state file's last_read_version is ambiguous (it may
+    record a tab-scoped read) and must not authorize a tab write."""
+
+    def test_legacy_global_baseline_is_not_trusted(self, tmp_path):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            # Simulates a pre-0.20 file: field filtered in as default False.
+            save_state("abc123", DocState(last_version=100,
+                                          last_read_version=100))
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.x", "X"),
+                                                   ("t.y", "Y"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab"), \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 100}):
+                with pytest.raises(GdocError, match="no read baseline"):
+                    cmd_write(_write_args("abc123", "X", str(f)))
+
+    def test_marked_global_baseline_is_trusted(self, tmp_path):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            save_state("abc123", DocState(
+                last_version=100, last_read_version=100,
+                global_read_covers_doc=True,
+            ))
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.x", "X"),
+                                                   ("t.y", "Y"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab",
+                       return_value={"tab_id": "t.x", "tab_title": "X",
+                                     "insert_index": 1}), \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 100}):
+                assert cmd_write(_write_args("abc123", "X", str(f))) == 0
+
+    def test_whole_doc_cat_sets_provenance_marker(self, tmp_path):
+        from gdoc.state import update_state_after_command
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=100), command="cat",
+                quiet=False,
+            )
+            st = load_state("abc123")
+            assert st.last_read_version == 100
+            assert st.global_read_covers_doc is True
+
+    def test_tab_read_does_not_set_marker(self, tmp_path):
+        from gdoc.state import update_state_after_command
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=100), command="cat",
+                quiet=False, read_tab_id="t.x",
+            )
+            st = load_state("abc123")
+            assert st.last_read_version is None
+            assert st.global_read_covers_doc is False
+
+
+class TestSoleTabWholeDocRule:
+    """F21: replacing a document's only tab IS a whole-doc write."""
+
+    def test_sole_tab_write_advances_global_baseline(self, tmp_path):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.x", "X"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab",
+                       return_value={"tab_id": "t.x", "tab_title": "X",
+                                     "insert_index": 1}), \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 101}):
+                args = _write_args("abc123", "X", str(f), force=True)
+                assert cmd_write(args) == 0
+            st = load_state("abc123")
+            # Whole-doc baseline advanced: a following whole-doc write
+            # won't conflict against our own mutation.
+            assert st.last_read_version == 101
+            assert st.global_read_covers_doc is True
+            assert st.tab_read_versions == {"t.x": 101}
+
+
+class TestBlankTabRejected:
+    """F20: a blank --tab must error, not silently read as no tab."""
+
+    def test_blank_flag_tab_errors(self):
+        from gdoc.cli import _effective_tab
+
+        with pytest.raises(GdocError, match="non-empty") as exc:
+            _effective_tab("t.second", "  ")
+        assert exc.value.exit_code == 3
+
+
+class TestInfoDoesNotAuthorizeTabWrites:
+    """`info` shows metadata only: it advances the whole-doc guard's
+    baseline (status quo) but must not stamp whole-doc content provenance,
+    which is what authorizes tab-scoped writes."""
+
+    def test_info_does_not_set_provenance_marker(self, tmp_path):
+        from gdoc.state import update_state_after_command
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=100), command="info",
+                quiet=False, command_version=100,
+            )
+            st = load_state("abc123")
+            assert st.last_read_version == 100  # whole-doc guard status quo
+            assert st.global_read_covers_doc is False
+
+    def test_info_then_tab_write_blocked(self, tmp_path):
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            from gdoc.state import update_state_after_command
+
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=100), command="info",
+                quiet=False, command_version=100,
+            )
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.x", "X"),
+                                                   ("t.y", "Y"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab") as mi, \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 100}):
+                with pytest.raises(GdocError, match="no read baseline"):
+                    cmd_write(_write_args("abc123", "X", str(f)))
+                mi.assert_not_called()
+
+
+    def test_info_after_edit_voids_stale_provenance(self, tmp_path):
+        """cat (marker True) -> unseen edit -> info: the marker must be
+        voided — the versions between the cat and the info were never
+        read, so leaving it True would launder the edit into the guard."""
+        from gdoc.state import update_state_after_command
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=5), command="cat",
+                quiet=False,
+            )
+            assert load_state("abc123").global_read_covers_doc is True
+
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=6), command="info",
+                quiet=False,
+            )
+            st = load_state("abc123")
+            assert st.last_read_version == 6
+            assert st.global_read_covers_doc is False
+
+    def test_info_at_same_version_preserves_provenance(self, tmp_path):
+        """An info that confirms nothing moved keeps the cat's provenance:
+        the authorization still traces to a genuine content read."""
+        from gdoc.state import update_state_after_command
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=5), command="cat",
+                quiet=False,
+            )
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=5), command="info",
+                quiet=False,
+            )
+            assert load_state("abc123").global_read_covers_doc is True
+
+    def test_quiet_info_after_edit_voids_stale_provenance(self, tmp_path):
+        from gdoc.state import update_state_after_command
+
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=5), command="cat",
+                quiet=False,
+            )
+            update_state_after_command(
+                "abc123", None, command="info", quiet=True,
+                command_version=6,
+            )
+            st = load_state("abc123")
+            assert st.last_read_version == 6
+            assert st.global_read_covers_doc is False
+
+    def test_cat_edit_info_write_tab_blocked_end_to_end(self, tmp_path):
+        """The full laundering sequence must fail closed: cat v5 ->
+        collaborator edit -> info v6 -> write --tab B is blocked."""
+        from gdoc.state import update_state_after_command
+
+        f = tmp_path / "body.md"
+        f.write_text("# new\n")
+        with patch("gdoc.state.STATE_DIR", tmp_path):
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=5), command="cat",
+                quiet=False,
+            )
+            update_state_after_command(
+                "abc123", ChangeInfo(current_version=6), command="info",
+                quiet=False,
+            )
+            with patch("gdoc.api.docs.get_document_with_tabs",
+                       return_value=_doc_with_tabs(("t.a", "A"),
+                                                   ("t.b", "B"))), \
+                 patch("gdoc.api.docs.insert_markdown_into_tab") as mi, \
+                 patch("gdoc.api.drive.get_file_version",
+                       return_value={"version": 6}):
+                with pytest.raises(GdocError, match="no read baseline"):
+                    cmd_write(_write_args("abc123", "B", str(f)))
+                mi.assert_not_called()

--- a/tests/test_write_tab_baselines.py
+++ b/tests/test_write_tab_baselines.py
@@ -1,4 +1,4 @@
-"""Per-tab write-conflict baselines (0.14.0).
+"""Per-tab write-conflict baselines (0.22.0).
 
 The lenient effective-baseline rule: a `write --tab X` is allowed when
 max(whole-doc last_read_version, tab_read_versions[X]) equals the current doc
@@ -17,6 +17,7 @@ from gdoc.cli import cmd_cat, cmd_write
 from gdoc.notify import ChangeInfo
 from gdoc.state import DocState, load_state, save_state
 from gdoc.util import GdocError
+from tests.conftest import doc_with_tabs as _doc_with_tabs
 
 DOC_MIME = "application/vnd.google-apps.document"
 
@@ -25,20 +26,6 @@ def _tab_dict(tab_id, title):
     return {
         "id": tab_id, "title": title, "index": 0,
         "nesting_level": 0, "body": {"content": []},
-    }
-
-
-def _doc_with_tabs(*pairs):
-    """A get_document_with_tabs() response for the given (id, title) pairs."""
-    return {
-        "revisionId": "rev1",
-        "tabs": [
-            {
-                "tabProperties": {"tabId": tid, "title": title, "index": i},
-                "documentTab": {"body": {"content": []}},
-            }
-            for i, (tid, title) in enumerate(pairs)
-        ],
     }
 
 
@@ -316,14 +303,14 @@ class TestTabBaselineUrlParity:
 
 
 class TestLegacyBaselineProvenance:
-    """F18: a pre-0.20 state file's last_read_version is ambiguous (it may
+    """F18: a pre-0.22 state file's last_read_version is ambiguous (it may
     record a tab-scoped read) and must not authorize a tab write."""
 
     def test_legacy_global_baseline_is_not_trusted(self, tmp_path):
         f = tmp_path / "body.md"
         f.write_text("# new\n")
         with patch("gdoc.state.STATE_DIR", tmp_path):
-            # Simulates a pre-0.20 file: field filtered in as default False.
+            # Simulates a pre-0.22 file: field filtered in as default False.
             save_state("abc123", DocState(last_version=100,
                                           last_read_version=100))
             with patch("gdoc.api.docs.get_document_with_tabs",

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
Lands two features as **0.20.0**, ported onto main after it advanced to 0.19.0:

## 1. Document URLs honor their `?tab=` deep link
Google's editor appends `?tab=<id>` when you open a tab, so a pasted tab URL now acts like `--tab <id>` for `cat`, `edit` (incl. `--cell`), `write`, `insert`, `toc`, `structure`, `insert-image`, and `suggest` (0.21.0's suggested-edit command, wired in via the 0.21.0 merge). Previously the tab was silently dropped. An explicit `--tab`/`--all-tabs` still overrides the URL, and the ambient `?tab=t.0` (auto-appended for the first tab) is treated as no selection. Whole-document commands (`pull`/`push`/`export`) print a stderr `NOTE:` when discarding a non-`t.0` URL tab.

## 2. Per-tab write-conflict baselines
The write guard now tracks a read baseline *per tab* (`tab_read_versions` in state), fixing two defects on multi-tab docs:
- **Cross-tab false negative** — `write --tab B` after only `cat --tab A` used to be satisfied by A's read and would replace tab B unseen. Now errors until B (or the whole doc) is read.
- **Same-tab false positive** — `write --tab X` twice in a row used to conflict against the version the first write itself produced. A tab write now advances that tab's own baseline.

A plain `cat`/`pull` still covers every tab; on a single-tab doc a `--tab` read counts as a whole-doc read. `structure --tab` follows the same per-tab rule.

## History
- Originally PRs #3/#4/#5 stacked against a main frozen at 0.12.0 (branch releases numbered 0.13.0/0.14.0). Main has since moved to 0.19.0 — reusing those version numbers for other features — so this branch merged main and renumbered to 0.22.0 (twice: upstream reused 0.20.0 and 0.21.0 while this PR was open). The merge reconciles the per-tab baselines with main's newer `_check_write_conflict` framework (`metadata_only_write`, baseline healing, `export`/`structure` as reads).
- Commands added on main since the fork (`structure`, `insert-image`, `export`) are wired into the URL-tab conventions in this PR.
- Supersedes #3 (landed upstream separately as 0.13.0 page mode) and #4 (its commits are contained in this branch).

1645 tests pass; ruff error count unchanged vs main.

🤖 Written by Claude Code on JP's instruction.


## Review risks for human judgment (from the swarm review)
0. **`suggest` targeting changed in the 0.21.0 merge** — `gdoc suggest '<url>?tab=t.7' ...` now writes the suggestion into that tab instead of the first tab. `suggest` landed upstream via an outside contributor's PR (#53, alejoacelas); consider whether this wants their sign-off.
1. **`?tab=t.0` on mutating commands** — tab ids survive reordering, so `t.0` isn't always the first-positioned tab; the ambient-noise rule still drops it on `edit`/`write`/`insert-image`, where the read-fidelity rationale doesn't apply. Docs + error hint shipped; honoring `t.0` on write paths is an open policy call.
2. **Post-write version race** — the tab-write baseline stamp uses a version fetched after the batchUpdate (sub-second window, documented in code; on a single-tab doc it reaches the whole-doc baseline). No clean fix without the Docs API returning the post-write version.
3. **`info` still advances the whole-doc guard's baseline** (pre-existing main semantics). Only the tab guard is provenance-protected as of this PR.



---
Previously reviewed end-to-end on the fork as [jpaddison3#5](https://github.com/jpaddison3/gdoc/pull/5) (multi-agent review, 3 fix iterations + a merge review; full disclosure in that PR's review thread). @alejoacelas — item 0 in the risks above touches `suggest`'s tab targeting from your #53; flagging for your eyes.

🤖 Written by Claude Code on JP's instruction.

https://claude.ai/code/session_01BwoPq3fNqCwJXAzz8DpZN7
