### PR TITLE
share: quiet by default, --notify opts into the notification email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `gdoc` are documented here. This project follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] — 2026-09-04
+
+### Changed
+- **`share DOC EMAIL` no longer sends Google's notification email by
+  default.** The permission call now passes `sendNotificationEmail=False`
+  explicitly (it was hardcoded `True`, and the Drive API's own default
+  for user grants is also on). The new `--notify` flag opts back in.
+  **Breaking**: workflows that relied on the recipient being emailed must
+  now pass `--notify`. Domain and `--anyone` shares are unchanged —
+  link-based, never emailed — and `--notify` combined with `--domain` or
+  `--anyone` is rejected before any API call (exit 3), the same guard
+  `--discoverable` uses in the other direction.
+
 ## [0.21.0] — 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ expired auth, still do).
 | Command | Description |
 |---------|-------------|
 | `auth` | Authenticate with Google (`--no-browser` for headless) |
-| `share DOC EMAIL` | Share a document (`--role reader\|writer\|commenter`) |
+| `share DOC EMAIL` | Share a document (`--role reader\|writer\|commenter`; quiet by default — `--notify` sends Google's notification email) |
 | `share DOC --domain D` / `--anyone` | Link-based sharing with a Workspace domain or anyone with the link (`--discoverable` to also surface in search) |
 | `mkdir TITLE` | Create a Drive folder (`--parent FOLDER`) |
 | `mv DOC FOLDER` | Move a file into a folder (alias: `move`) |

--- a/gdoc.md
+++ b/gdoc.md
@@ -37,7 +37,7 @@ gdoc resolve DOC_ID COMMENT_ID              # Resolve a comment
 gdoc reopen DOC_ID COMMENT_ID               # Reopen a resolved comment
 
 gdoc info DOC_ID                             # Title, owner, last modified, word count
-gdoc share DOC_ID EMAIL [--role reader|writer|commenter]
+gdoc share DOC_ID EMAIL [--role reader|writer|commenter] [--notify]  # No notification email unless --notify
 gdoc new "Document Title" [--folder FOLDER_ID]  # Create blank doc
 gdoc cp DOC_ID "Copy Title"                  # Duplicate a doc
 

--- a/gdoc/__init__.py
+++ b/gdoc/__init__.py
@@ -1,3 +1,3 @@
 """gdoc -- Token-efficient CLI for Google Docs & Drive."""
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/gdoc/api/drive.py
+++ b/gdoc/api/drive.py
@@ -537,12 +537,14 @@ def create_permission(
     domain: str | None = None,
     anyone: bool = False,
     discoverable: bool = False,
+    notify: bool = False,
 ) -> dict:
     """Share a document with a user, a whole domain, or anyone with the link.
 
     Exactly one of email / domain / anyone selects the grantee type; the
-    caller validates that. User shares send a notification email; domain
-    and anyone shares are link-based, with `discoverable` controlling
+    caller validates that. User shares are quiet by default — pass
+    `notify=True` to send Google's notification email. Domain and anyone
+    shares are link-based (never emailed), with `discoverable` controlling
     whether the file also appears in search results
     (`allowFileDiscovery` — never inferred, off by default).
 
@@ -553,6 +555,7 @@ def create_permission(
         domain: Workspace domain to share with (domain grant).
         anyone: Share with anyone who has the link.
         discoverable: Let the file surface in search (domain/anyone only).
+        notify: Send the notification email (user grants only).
 
     Returns:
         Permission resource dict from the API.
@@ -560,7 +563,9 @@ def create_permission(
     kwargs: dict = {}
     if email:
         body: dict = {"type": "user", "role": role, "emailAddress": email}
-        kwargs["sendNotificationEmail"] = True
+        # The API's own default is True for user grants, so quiet
+        # sharing needs an explicit False.
+        kwargs["sendNotificationEmail"] = notify
     elif domain:
         body = {
             "type": "domain",

--- a/gdoc/cli.py
+++ b/gdoc/cli.py
@@ -3452,6 +3452,7 @@ def cmd_share(args) -> int:
     anyone = getattr(args, "anyone", False)
     role = getattr(args, "role", "reader")
     discoverable = getattr(args, "discoverable", False)
+    notify = getattr(args, "notify", False)
     quiet = getattr(args, "quiet", False)
 
     targets = sum(1 for t in (email, domain, anyone) if t)
@@ -3465,6 +3466,11 @@ def cmd_share(args) -> int:
             "--discoverable applies only to --domain/--anyone shares",
             exit_code=3,
         )
+    if notify and not email:
+        raise GdocError(
+            "--notify applies only to EMAIL shares",
+            exit_code=3,
+        )
 
     # Pre-flight awareness check
     from gdoc.notify import pre_flight
@@ -3476,6 +3482,7 @@ def cmd_share(args) -> int:
     create_permission(
         doc_id, email=email, role=role,
         domain=domain, anyone=anyone, discoverable=discoverable,
+        notify=notify,
     )
 
     if email:
@@ -4467,6 +4474,11 @@ def build_parser() -> GdocArgumentParser:
         choices=["reader", "writer", "commenter"],
         default="reader",
         help="Permission role",
+    )
+    share_p.add_argument(
+        "--notify", action="store_true",
+        help="Send Google's notification email "
+        "(EMAIL shares only; off by default)",
     )
     share_p.add_argument(
         "--discoverable", action="store_true",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gdoc"
-version = "0.21.0"
+version = "0.22.0"
 description = "Token-efficient CLI for Google Docs & Drive"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_drive_mgmt.py
+++ b/tests/test_drive_mgmt.py
@@ -432,6 +432,7 @@ class TestCmdShareTargets:
         mock_perm.assert_called_once_with(
             "doc1", email=None, role="reader",
             domain="example.org", anyone=False, discoverable=False,
+            notify=False,
         )
         assert (
             "OK shared with example.org as reader"
@@ -499,6 +500,40 @@ class TestCmdShareTargets:
         assert "type\tdomain" in lines
         assert "role\treader" in lines
         assert "discoverable\ttrue" in lines
+
+    @patch("gdoc.state.update_state_after_command")
+    @patch("gdoc.notify.pre_flight", return_value=None)
+    @patch("gdoc.api.drive.create_permission", return_value={"id": "perm1"})
+    def test_user_share_notify(self, mock_perm, _pf, _update, capsys):
+        args = _make_args(
+            "share", doc="doc1", email="a@b.com", domain=None,
+            anyone=False, role="reader", discoverable=False, notify=True,
+        )
+        rc = cmd_share(args)
+        assert rc == 0
+        mock_perm.assert_called_once_with(
+            "doc1", email="a@b.com", role="reader",
+            domain=None, anyone=False, discoverable=False,
+            notify=True,
+        )
+
+    def test_notify_with_domain_rejected(self):
+        args = _make_args(
+            "share", doc="doc1", email=None, domain="example.org",
+            anyone=False, role="reader", notify=True,
+        )
+        with pytest.raises(GdocError, match="--notify") as exc_info:
+            cmd_share(args)
+        assert exc_info.value.exit_code == 3
+
+    def test_notify_with_anyone_rejected(self):
+        args = _make_args(
+            "share", doc="doc1", email=None, domain=None,
+            anyone=True, role="reader", notify=True,
+        )
+        with pytest.raises(GdocError, match="--notify") as exc_info:
+            cmd_share(args)
+        assert exc_info.value.exit_code == 3
 
     def test_no_target_rejected(self):
         args = _make_args(

--- a/tests/test_file_mgmt.py
+++ b/tests/test_file_mgmt.py
@@ -299,6 +299,7 @@ class TestCmdShare:
         mock_perm.assert_called_once_with(
             "abc123", email="alice@co.com", role="reader",
             domain=None, anyone=False, discoverable=False,
+            notify=False,
         )
 
     @patch("gdoc.state.update_state_after_command")
@@ -310,6 +311,7 @@ class TestCmdShare:
         mock_perm.assert_called_once_with(
             "abc123", email="alice@co.com", role="writer",
             domain=None, anyone=False, discoverable=False,
+            notify=False,
         )
 
     @patch("gdoc.state.update_state_after_command")
@@ -321,6 +323,7 @@ class TestCmdShare:
         mock_perm.assert_called_once_with(
             "abc123", email="alice@co.com", role="commenter",
             domain=None, anyone=False, discoverable=False,
+            notify=False,
         )
 
     @patch("gdoc.state.update_state_after_command")
@@ -552,13 +555,30 @@ class TestCreatePermissionAPI:
         }
 
     @patch("gdoc.api.drive.get_drive_service")
-    def test_permission_sends_notification(self, mock_get_service):
+    def test_permission_quiet_by_default(self, mock_get_service):
+        # The API's own default is True for user grants, so quiet
+        # sharing requires an explicit False — absence is not enough.
         mock_service = MagicMock()
         mock_get_service.return_value = mock_service
         mock_service.permissions().create().execute.return_value = {"id": "perm1"}
 
         from gdoc.api.drive import create_permission
         create_permission("doc1", "alice@co.com", "reader")
+
+        call_kwargs = mock_service.permissions().create.call_args
+        assert call_kwargs.kwargs.get(
+            "sendNotificationEmail",
+            call_kwargs[1].get("sendNotificationEmail"),
+        ) is False
+
+    @patch("gdoc.api.drive.get_drive_service")
+    def test_permission_notify_sends_notification(self, mock_get_service):
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+        mock_service.permissions().create().execute.return_value = {"id": "perm1"}
+
+        from gdoc.api.drive import create_permission
+        create_permission("doc1", "alice@co.com", "reader", notify=True)
 
         call_kwargs = mock_service.permissions().create.call_args
         assert call_kwargs.kwargs.get(

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "gdoc"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## What changed

`gdoc share DOC EMAIL` no longer sends Google's notification email by default. The new opt-in `--notify` flag sends it.

- `create_permission` (gdoc/api/drive.py) gains `notify: bool = False` and passes `sendNotificationEmail=notify` on user grants — explicitly, because the Drive API's own default for user grants is **on**, so omitting the kwarg would not make sharing quiet.
- `gdoc share` gains `--notify` (cli.py). It applies only to email shares; combined with `--domain`/`--anyone` (which are link-based and never email anyone) it is rejected before any API call with exit 3, mirroring the existing `--discoverable`-with-email guard.
- Docs updated: `create_permission` docstring, `share --help`, README command table, gdoc.md cheat sheet, CHANGELOG 0.22.0 entry; version bumped to 0.22.0 in pyproject.toml, `gdoc/__init__.py`, and uv.lock.

## Why

Sharing hardcoded `sendNotificationEmail=True` with no way to disable it, so every scripted share spammed the recipient's inbox. Quiet is the right default for an agent-driven CLI: the caller usually delivers the link through their own channel and can opt into Google's email when they want it.

## Behavior change

**This flips a default.** Any workflow that relied on the recipient getting Google's notification email must now pass `--notify`. Domain/anyone shares are unchanged. The MCP servers shell out to the CLI, so shares made through `share_document`/`gdoc_share` become quiet too; the new flag flows through the Python MCP's argparse-derived schema automatically.

## How it was tested

- `uv run pytest tests/ -q` — 1567 passed, 0 failed.
- New/updated tests: API layer asserts `sendNotificationEmail is False` by default and `is True` with `notify=True` (test_file_mgmt.py); CLI layer asserts `--notify` reaches `create_permission` and that `--notify` with `--domain`/`--anyone` exits 3 (test_drive_mgmt.py); existing exact-args assertions extended with `notify=False`.
- `uv run ruff check gdoc/ tests/` — 196 findings, identical count on main (pre-existing debt; none added).
- Smoke-checked `gdoc share --help` renders the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)